### PR TITLE
Make daemon mode work on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,6 +1230,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "walkdir",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +964,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1116,7 +1132,7 @@ dependencies = [
  "crystalline-service",
  "insta",
  "predicates",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1159,7 +1175,7 @@ dependencies = [
  "hf-hub",
  "indexmap",
  "pgvector",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1185,7 +1201,7 @@ dependencies = [
  "diffy",
  "flate2",
  "keyring",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -1340,6 +1356,16 @@ name = "datasketches"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -1520,6 +1546,15 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "endi"
@@ -1753,6 +1788,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2144,6 +2194,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,7 +2287,9 @@ dependencies = [
  "indicatif",
  "libc",
  "log",
+ "native-tls",
  "rand 0.9.4",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2341,6 +2412,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2368,6 +2440,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2385,9 +2473,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3102,6 +3192,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3290,10 +3397,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -3384,6 +3528,15 @@ name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3903,6 +4056,49 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -4119,7 +4315,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -4259,7 +4455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4831,6 +5027,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tantivy"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5210,6 +5427,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -5777,8 +6004,10 @@ checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
+ "der",
  "flate2",
  "log",
+ "native-tls",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
@@ -5787,6 +6016,7 @@ dependencies = [
  "socks",
  "ureq-proto",
  "utf8-zero",
+ "webpki-root-certs",
  "webpki-roots",
 ]
 
@@ -5856,6 +6086,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -5959,6 +6195,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -6106,6 +6355,17 @@ dependencies = [
  "regex",
  "windows-sys 0.61.2",
  "zeroize",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,10 @@ turso = "0.6.1"
 candle-core = "0.11.0"
 candle-nn = "0.11.0"
 candle-transformers = "0.11.0"
-# Blocking downloader over ureq, whose bundled rustls avoids any system OpenSSL
-# so the static release binaries stay self-contained. The local provider loads
-# and runs off the async runtime.
+# Blocking downloader over ureq. The base build bundles rustls so static Linux
+# binaries stay self-contained; crates/index adds the native-tls feature on
+# Windows and macOS targets so the download validates against the OS trust
+# store (corporate TLS-interception CAs live there, not in webpki roots).
 hf-hub = { version = "0.5.0", default-features = false, features = ["ureq"] }
 # Pure-Rust regex backend (fancy-regex) instead of the onig C library, and no
 # esaxx C++ trainer or progress bar; keeps musl static builds clean. Only the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ schemars = "1.2.1"
 futures = "0.3.32"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.23"
+windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_System_Threading"] }
 
 # GitHub collaboration (crates/remote): plain-text three-way merge, the
 # GitHub-issued token in the OS keychain and repository tarball extraction.

--- a/crates/cli/src/doctor.rs
+++ b/crates/cli/src/doctor.rs
@@ -1201,6 +1201,9 @@ pub fn render_human(report: &DoctorReport) -> String {
     if !s.lock_stale && !s.socket_orphaned {
         let _ = writeln!(out, "  ok");
     }
+    if let Ok(log_path) = config::daemon_log_path() {
+        let _ = writeln!(out, "  daemon log: {}", log_path.display());
+    }
 
     if let Some(e) = &report.environment {
         let _ = writeln!(out, "environment:");

--- a/crates/cli/src/doctor.rs
+++ b/crates/cli/src/doctor.rs
@@ -667,12 +667,18 @@ fn is_hidden(name: &str) -> bool {
 }
 
 fn check_service(fix: bool) -> Result<ServiceDoctor> {
-    let lock_path = config::service_lock_path()
+    // The record's primary home is `service.json`; a still-present pre-split
+    // daemon's record sitting in the lock file itself counts as present too
+    // (see `instance::read_lock_info`'s legacy fallback), so an upgraded
+    // doctor still flags and cleans up an old-format leftover.
+    let info_path = config::service_info_path()
+        .map_err(|e| anyhow!("could not resolve the service record path: {e}"))?;
+    let legacy_path = config::service_lock_path()
         .map_err(|e| anyhow!("could not resolve the service lock path: {e}"))?;
     let sock_path = config::service_sock_path()
         .map_err(|e| anyhow!("could not resolve the service socket path: {e}"))?;
 
-    let lock_present = lock_path.is_file();
+    let lock_present = info_path.is_file() || legacy_path.is_file();
     let info = instance::read_lock_info();
     let pid = info.as_ref().map(|i| i.pid);
     let alive = info
@@ -695,7 +701,9 @@ fn check_service(fix: bool) -> Result<ServiceDoctor> {
 
     if fix {
         if s.lock_stale {
-            s.lock_removed = std::fs::remove_file(&lock_path).is_ok();
+            let info_removed = std::fs::remove_file(&info_path).is_ok();
+            let legacy_removed = std::fs::remove_file(&legacy_path).is_ok();
+            s.lock_removed = info_removed || legacy_removed;
         }
         if s.socket_orphaned {
             s.socket_removed = std::fs::remove_file(&sock_path).is_ok();

--- a/crates/cli/tests/service.rs
+++ b/crates/cli/tests/service.rs
@@ -52,6 +52,9 @@ impl Env {
     fn lock_path(&self) -> PathBuf {
         self.state_dir().join("service.lock")
     }
+    fn info_path(&self) -> PathBuf {
+        self.state_dir().join("service.json")
+    }
     fn sock_path(&self) -> PathBuf {
         self.state_dir().join("service.sock")
     }
@@ -119,8 +122,11 @@ impl Env {
         }
     }
 
+    /// The pid from the owner record. Reads `service.json`, never the lock
+    /// file itself: the record moved there so a reader never has to touch a
+    /// handle another process holds an exclusive lock on.
     fn lock_pid(&self) -> Option<u64> {
-        let text = std::fs::read_to_string(self.lock_path()).ok()?;
+        let text = std::fs::read_to_string(self.info_path()).ok()?;
         let v: Value = serde_json::from_str(&text).ok()?;
         v.get("pid").and_then(Value::as_u64)
     }

--- a/crates/cli/tests/service_windows.rs
+++ b/crates/cli/tests/service_windows.rs
@@ -1,0 +1,305 @@
+//! Windows integration tests for the daemon: the record split, the named-pipe
+//! attach and the second-instance refusal, driven against the real
+//! `crystalline` binary. The unix twin lives in service.rs; this file is
+//! windows-only because it exercises the named pipe and Windows env isolation
+//! (USERPROFILE, APPDATA, LOCALAPPDATA, which etcetera's Windows strategy
+//! reads). It compiles to an empty test binary on every other platform, so the
+//! coverage rides the windows-latest CI leg without touching local runs.
+#![cfg(windows)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::mpsc::{Receiver, RecvTimeoutError};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use serde_json::{Value, json};
+
+fn bin() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("crystalline")
+}
+
+/// An isolated home for one test: USERPROFILE, APPDATA and LOCALAPPDATA all
+/// point below one scratch directory, so the state dir (and with it the lock,
+/// the record and the derived pipe name) never collides with another test or
+/// the developer's real install. On Windows etcetera resolves both the config
+/// dir and the state dir to `APPDATA\crystalline`, so config.yaml and
+/// service.json share the `roaming/crystalline` directory here.
+struct Env {
+    dir: PathBuf,
+}
+
+impl Env {
+    fn new(tag: &str) -> Env {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("cq-{tag}-{nanos}"));
+        std::fs::create_dir_all(dir.join("roaming")).unwrap();
+        std::fs::create_dir_all(dir.join("local")).unwrap();
+        // An unresolvable embeddings provider keeps the daemon text-only so a
+        // CI run never attempts the model download. The daemon warns and
+        // continues; the record is published before the provider build anyway,
+        // so the round trip below never waits on embeddings.
+        let config_dir = dir.join("roaming/crystalline");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("config.yaml"),
+            "embeddings:\n  provider: disabled-for-tests\n  model: none\n",
+        )
+        .unwrap();
+        Env { dir }
+    }
+
+    fn apply(&self, cmd: &mut Command) {
+        cmd.env("USERPROFILE", &self.dir)
+            .env("APPDATA", self.dir.join("roaming"))
+            .env("LOCALAPPDATA", self.dir.join("local"));
+    }
+
+    fn state_dir(&self) -> PathBuf {
+        self.dir.join("roaming/crystalline")
+    }
+
+    fn info_path(&self) -> PathBuf {
+        self.state_dir().join("service.json")
+    }
+}
+
+impl Drop for Env {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// Kill-on-drop so a failing assertion never leaks a daemon into the runner.
+/// Killing the process releases its exclusive lock: Windows drops the region
+/// lock when the owning process dies, so the next test's fresh home is clean.
+struct Reap(Child);
+
+impl Drop for Reap {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Spawn a foreground `serve --daemon` bound to this env, returning the kill
+/// guard. `--daemon` only silences the banner; the process serves in the
+/// foreground of this child and acquires ownership itself, so its pid is the
+/// pid the record names.
+fn spawn_daemon(env: &Env) -> Reap {
+    let mut serve = Command::new(bin());
+    env.apply(&mut serve);
+    serve
+        .args(["serve", "--daemon"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    Reap(serve.spawn().unwrap())
+}
+
+/// Poll `service.json` for up to 60s and return the parsed record. The daemon
+/// writes it only after the pipe is bound, so a readable record means the pipe
+/// is ready to attach. On the pre-split code this never appears on Windows: the
+/// mandatory lock made the record unwritable and unreadable through any other
+/// handle.
+fn wait_for_record(env: &Env) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        if let Ok(text) = std::fs::read_to_string(env.info_path())
+            && let Ok(v) = serde_json::from_str::<Value>(&text)
+        {
+            return v;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "no readable service.json within 60s"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// A `crystalline mcp` child driven with newline-delimited JSON-RPC over its
+/// stdio, mirroring service.rs's `Mcp` helper (same initialize params, the same
+/// id counter and json! request shapes). It attaches over the named pipe with
+/// no `--config`: for `mcp` an explicit config is forwarded only to a daemon
+/// this call would spawn, so omitting it keeps parity with the `serve`
+/// invocation above and still attaches to the running daemon.
+///
+/// Reads are bounded, unlike service.rs's plain blocking `read_line`: a
+/// background thread pumps every stdout line into a channel and `read` waits on
+/// it with a deadline, so a wedged pipe handshake fails the test within seconds
+/// instead of hanging the windows-latest job. A CI hang is worse than a
+/// failure, and this leg is the first to run the pipe path.
+struct Bridge {
+    // Held only to keep the child alive and kill it on drop; never read.
+    _proc: Reap,
+    stdin: ChildStdin,
+    rx: Receiver<String>,
+    id: i64,
+}
+
+impl Bridge {
+    fn attach(env: &Env) -> Bridge {
+        let mut cmd = Command::new(bin());
+        env.apply(&mut cmd);
+        cmd.arg("mcp")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        let mut child = cmd.spawn().unwrap();
+        let stdin = child.stdin.take().unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let (tx, rx) = std::sync::mpsc::channel();
+        // Detached reader: it ends on its own when the child's stdout closes
+        // (the Reap guard kills the child on drop), so nothing needs to join it.
+        std::thread::spawn(move || {
+            for line in BufReader::new(stdout).lines() {
+                let Ok(line) = line else { break };
+                if tx.send(line).is_err() {
+                    break;
+                }
+            }
+        });
+        Bridge {
+            _proc: Reap(child),
+            stdin,
+            rx,
+            id: 0,
+        }
+    }
+
+    fn send(&mut self, value: &Value) {
+        self.stdin.write_all(value.to_string().as_bytes()).unwrap();
+        self.stdin.write_all(b"\n").unwrap();
+        self.stdin.flush().unwrap();
+    }
+
+    /// The next non-empty JSON-RPC line, or a panic if none arrives before the
+    /// deadline so the test fails fast rather than hanging CI.
+    fn read(&mut self) -> Value {
+        loop {
+            match self.rx.recv_timeout(Duration::from_secs(30)) {
+                Ok(line) => {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    return serde_json::from_str(trimmed).unwrap();
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    panic!("no response from the mcp bridge within 30s")
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    panic!("the mcp bridge closed its stdout before answering")
+                }
+            }
+        }
+    }
+
+    /// Drive the handshake and return the initialize response.
+    fn initialize(&mut self) -> Value {
+        self.id += 1;
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": self.id,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": { "name": "it", "version": "0" }
+            }
+        }));
+        let resp = self.read();
+        self.send(&json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }));
+        resp
+    }
+
+    /// Send `tools/list` and return the raw response value.
+    fn list_tools(&mut self) -> Value {
+        self.id += 1;
+        self.send(&json!({
+            "jsonrpc": "2.0", "id": self.id, "method": "tools/list", "params": {}
+        }));
+        self.read()
+    }
+}
+
+/// The record appears while the daemon holds the exclusive lock, names the
+/// daemon's real pid and its per-state-dir pipe, and an `mcp` bridge attaches
+/// over that pipe end to end. On the pre-split code this fails in the first
+/// poll: the mandatory lock made the record unreadable on Windows.
+#[test]
+fn daemon_publishes_a_readable_record_and_serves_mcp_over_the_pipe() {
+    let env = Env::new("win-daemon");
+    let daemon = spawn_daemon(&env);
+
+    let record = wait_for_record(&env);
+    assert_eq!(
+        record["pid"].as_u64().unwrap() as u32,
+        daemon.0.id(),
+        "the record names the live daemon pid: {record}"
+    );
+    let pipe = record["socket_path"].as_str().unwrap();
+    assert!(
+        pipe.starts_with(r"\\.\pipe\crystalline-"),
+        "per-state-dir pipe name, got {pipe}"
+    );
+
+    let mut bridge = Bridge::attach(&env);
+    let init = bridge.initialize();
+    assert!(
+        init.get("result").is_some() && init.pointer("/result/serverInfo").is_some(),
+        "initialize returns a server result over the pipe: {init}"
+    );
+
+    let tools = bridge.list_tools();
+    let names: Vec<String> = tools
+        .pointer("/result/tools")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| t["name"].as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        names.iter().any(|n| n == "search_engrams"),
+        "tools/list served over the pipe includes search_engrams: {tools}"
+    );
+
+    drop(bridge);
+    drop(daemon);
+}
+
+/// A second serve must fail fast and name the live owner's real pid: before the
+/// split it could not even read who owned the lock, so it reported pid 0.
+#[test]
+fn a_second_serve_fails_fast_naming_the_owner() {
+    let env = Env::new("win-second");
+    let daemon = spawn_daemon(&env);
+    let record = wait_for_record(&env);
+    let owner_pid = record["pid"].as_u64().unwrap();
+
+    let mut second = Command::new(bin());
+    env.apply(&mut second);
+    let out = second
+        .args(["serve"])
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert!(
+        !out.status.success(),
+        "the second serve exits nonzero while the owner holds the lock"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("another Crystalline instance owns the index")
+            && stderr.contains(&owner_pid.to_string()),
+        "the refusal names the live owner (pid {owner_pid}): {stderr}"
+    );
+
+    drop(daemon);
+}

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -552,6 +552,14 @@ pub fn service_sock_path() -> Result<PathBuf, ConfigError> {
     Ok(state_dir()?.join("service.sock"))
 }
 
+/// The spawned daemon's stderr log, `<state_dir>/daemon.log`. A daemon spawned
+/// by the MCP bridge is fully detached, so without this file a startup failure
+/// is invisible; the log made the difference between a one-log field diagnosis
+/// and a blind one.
+pub fn daemon_log_path() -> Result<PathBuf, ConfigError> {
+    Ok(state_dir()?.join("daemon.log"))
+}
+
 /// The directory holding every origin's on-disk state, `<state_dir>/origins`.
 pub fn origins_state_dir() -> Result<PathBuf, ConfigError> {
     Ok(state_dir()?.join("origins"))

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -530,9 +530,21 @@ pub fn index_db_path() -> Result<PathBuf, ConfigError> {
     Ok(state_dir()?.join("index.db"))
 }
 
-/// The single-instance lock path, `<state_dir>/service.lock`.
+/// The single-instance lock path, `<state_dir>/service.lock`. Lock only: the
+/// owner holds an exclusive OS lock on this file for its lifetime and the
+/// contents are meaningless. The owner's record lives at [`service_info_path`],
+/// never in this file, because Windows region locks are mandatory: reading or
+/// writing a locked file through any other handle fails there.
 pub fn service_lock_path() -> Result<PathBuf, ConfigError> {
     Ok(state_dir()?.join("service.lock"))
+}
+
+/// The daemon record path, `<state_dir>/service.json`: the owner's pid, socket
+/// and version, written once the socket is bound and removed on shutdown. Kept
+/// apart from `service.lock` so reading the record never touches the locked
+/// file (see [`service_lock_path`]).
+pub fn service_info_path() -> Result<PathBuf, ConfigError> {
+    Ok(state_dir()?.join("service.json"))
 }
 
 /// The service socket path, `<state_dir>/service.sock`.

--- a/crates/core/tests/config.rs
+++ b/crates/core/tests/config.rs
@@ -116,6 +116,11 @@ fn default_paths_are_namespaced() {
             .ends_with("crystalline/service.lock")
     );
     assert!(
+        config::service_info_path()
+            .unwrap()
+            .ends_with("crystalline/service.json")
+    );
+    assert!(
         config::models_dir()
             .unwrap()
             .ends_with("crystalline/models")

--- a/crates/index/Cargo.toml
+++ b/crates/index/Cargo.toml
@@ -57,6 +57,15 @@ hf-hub = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 pgvector = { workspace = true, optional = true }
 
+# On Windows and macOS the model download must trust the OS certificate store
+# (corporate TLS-intercepting proxies install their CA there; the bundled
+# webpki roots reject it with UnknownIssuer). hf-hub's native-tls feature
+# flips its ureq agent to schannel / Security.framework on these targets.
+# Linux keeps the bundled rustls roots so musl static builds stay
+# self-contained.
+[target.'cfg(any(windows, target_os = "macos"))'.dependencies]
+hf-hub = { workspace = true, optional = true, features = ["native-tls"] }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true }

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -56,6 +56,9 @@ futures = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 serde_yaml_ng = { workspace = true }

--- a/crates/service/src/instance.rs
+++ b/crates/service/src/instance.rs
@@ -358,13 +358,17 @@ pub async fn ensure_daemon(
         }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
-    anyhow::bail!("spawned a daemon but it did not become ready within 15s")
+    anyhow::bail!(
+        "spawned a daemon but it did not become ready within 15s (see daemon.log in the state directory)"
+    )
 }
 
 /// Open the daemon stderr log for appending, starting the file over once it
-/// outgrows 1 MiB so it never grows unbounded. `None` (and a null stderr)
-/// when the state dir or the file cannot be prepared: logging must never be
-/// the reason a daemon fails to spawn.
+/// outgrows 1 MiB. The cap is checked at spawn time and the reset is
+/// best-effort (a live holder can defeat the removal on Windows), so it bounds
+/// growth across spawns, not within one daemon's lifetime. `None` (and a null
+/// stderr) when the state dir or the file cannot be prepared: logging must
+/// never be the reason a daemon fails to spawn.
 fn daemon_log_sink() -> Option<std::process::Stdio> {
     let path = config::daemon_log_path().ok()?;
     if let Some(dir) = path.parent() {

--- a/crates/service/src/instance.rs
+++ b/crates/service/src/instance.rs
@@ -113,7 +113,7 @@ impl Ownership {
     pub fn socket_display(&self) -> String {
         #[cfg(windows)]
         {
-            PIPE_NAME.to_string()
+            format!(r"\\.\pipe\{}", pipe_name(&self.socket_path))
         }
         #[cfg(not(windows))]
         {
@@ -134,17 +134,29 @@ impl Drop for Ownership {
     }
 }
 
-/// The Windows named pipe name.
+/// The Windows pipe name for a given socket path: `crystalline-` plus the
+/// FNV-1a hash of the lowercased path. Hashing keeps the name short and free
+/// of separator characters; deriving it from the state-directory-scoped
+/// socket path isolates users and test homes from each other, where a fixed
+/// name would collide machine-wide. FNV-1a is fixed here (not DefaultHasher)
+/// so every release derives the same name and can attach across upgrades.
 #[cfg(windows)]
-const PIPE_NAME: &str = r"\\.\pipe\crystalline";
+fn pipe_name(sock_path: &Path) -> String {
+    let lowered = sock_path.to_string_lossy().to_lowercase();
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in lowered.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("crystalline-{hash:016x}")
+}
 
 /// Build the platform socket name: a filesystem path on unix, a namespaced pipe
 /// on Windows.
 fn socket_name(sock_path: &Path) -> io::Result<Name<'_>> {
     #[cfg(windows)]
     {
-        let _ = sock_path;
-        "crystalline".to_ns_name::<GenericNamespaced>()
+        pipe_name(sock_path).to_ns_name::<GenericNamespaced>()
     }
     #[cfg(not(windows))]
     {
@@ -349,6 +361,29 @@ pub async fn ensure_daemon(
     anyhow::bail!("spawned a daemon but it did not become ready within 15s")
 }
 
+/// Open the daemon stderr log for appending, starting the file over once it
+/// outgrows 1 MiB so it never grows unbounded. `None` (and a null stderr)
+/// when the state dir or the file cannot be prepared: logging must never be
+/// the reason a daemon fails to spawn.
+fn daemon_log_sink() -> Option<std::process::Stdio> {
+    let path = config::daemon_log_path().ok()?;
+    if let Some(dir) = path.parent() {
+        std::fs::create_dir_all(dir).ok()?;
+    }
+    if std::fs::metadata(&path)
+        .map(|m| m.len() > 1024 * 1024)
+        .unwrap_or(false)
+    {
+        let _ = std::fs::remove_file(&path);
+    }
+    let file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .ok()?;
+    Some(file.into())
+}
+
 /// Spawn `current_exe serve --daemon` fully detached, forwarding `--read-only`
 /// when this instance was asked to serve read-only.
 fn spawn_daemon(
@@ -370,7 +405,7 @@ fn spawn_daemon(
     }
     cmd.stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null());
+        .stderr(daemon_log_sink().unwrap_or_else(std::process::Stdio::null));
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
@@ -388,8 +423,29 @@ fn spawn_daemon(
             });
         }
     }
-    cmd.spawn()?;
-    Ok(())
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        use windows_sys::Win32::System::Threading::{
+            CREATE_BREAKAWAY_FROM_JOB, CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW,
+        };
+        // No console window for the detached daemon, its own process group,
+        // and a breakaway from the parent's job object so it outlives a
+        // harness that kills its job on exit. A job that forbids breakaway
+        // fails the spawn outright, so retry inside the job: starting at all
+        // beats outliving the parent.
+        cmd.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP | CREATE_BREAKAWAY_FROM_JOB);
+        if cmd.spawn().is_err() {
+            cmd.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP);
+            cmd.spawn()?;
+        }
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        cmd.spawn()?;
+        Ok(())
+    }
 }
 
 /// Acquire ownership of the index by taking the advisory lock, with stale
@@ -500,6 +556,26 @@ pub fn process_alive(pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn pipe_names_are_stable_and_scoped_to_the_socket_path() {
+        let a = pipe_name(Path::new(
+            r"C:\Users\a\AppData\Roaming\crystalline\service.sock",
+        ));
+        let b = pipe_name(Path::new(
+            r"C:\Users\b\AppData\Roaming\crystalline\service.sock",
+        ));
+        assert_ne!(a, b, "different homes get different pipes");
+        assert_eq!(
+            a,
+            pipe_name(Path::new(
+                r"c:\users\A\appdata\roaming\crystalline\service.sock"
+            )),
+            "windows paths are case-insensitive, the pipe name must be too"
+        );
+        assert!(a.starts_with("crystalline-") && a.len() == "crystalline-".len() + 16);
+    }
 
     #[test]
     fn attach_policy_displaces_only_a_strictly_older_daemon() {
@@ -817,6 +893,25 @@ mod tests {
         drop(home);
     }
 
+    /// An oversized daemon log starts over rather than growing unbounded.
+    /// Deliberately ungated - a detached daemon's stderr sink matters on every
+    /// platform, and `ScratchHome` keeps this sync-safe under the same env
+    /// lock the other tests here take.
+    #[tokio::test]
+    async fn daemon_log_sink_caps_the_file_size() {
+        let home = ScratchHome::new("daemon-log");
+        let path = config::daemon_log_path().unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, vec![b'x'; 2 * 1024 * 1024]).unwrap();
+        let sink = daemon_log_sink().expect("the sink opens");
+        drop(sink);
+        assert!(
+            std::fs::metadata(&path).unwrap().len() < 1024 * 1024,
+            "an oversized log starts over"
+        );
+        drop(home);
+    }
+
     /// A pre-split daemon wrote its record into service.lock itself; with no
     /// live owner the fallback still surfaces it so displacement works across
     /// the upgrade.
@@ -840,7 +935,9 @@ mod tests {
     }
 
     /// Acquiring ownership empties legacy bytes out of the lock file, so a
-    /// stale pre-split record can never shadow the live service.json.
+    /// stale pre-split record can never shadow the live service.json. On
+    /// Windows the mandatory lock alone already hides the legacy bytes from
+    /// any other handle, so this emptying assertion is meaningful on unix.
     #[tokio::test]
     async fn acquire_ownership_empties_a_stale_legacy_record() {
         let home = ScratchHome::new("legacy-emptied");

--- a/crates/service/src/instance.rs
+++ b/crates/service/src/instance.rs
@@ -1,9 +1,13 @@
 //! Single-instance mechanics: the advisory lock and the local socket.
 //!
-//! Exactly one process owns the derived index. Ownership is an `fs4` advisory
-//! exclusive lock held on `service.lock` for the owner's lifetime; the socket
-//! (a Unix domain socket, or the named pipe `\\.\pipe\crystalline` on Windows)
-//! is how everyone else reaches it. See `research/single-instance-ipc.md`.
+//! Exactly one process owns the derived index. Ownership is an `fs4` exclusive
+//! lock held on `service.lock` for the owner's lifetime; the record describing
+//! the owner (pid, socket, version) lives in the separate `service.json`,
+//! because Windows region locks are mandatory - reads and writes through any
+//! other handle fail - so the locked file itself must never carry data. The
+//! socket (a Unix domain socket, or a per-state-directory named pipe on
+//! Windows) is how everyone else reaches the owner. See
+//! `research/single-instance-ipc.md`.
 //!
 //! Attaching is version aware: the lock record carries the owner's version,
 //! and a client built from a newer version displaces an older daemon with a
@@ -30,7 +34,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crystalline_core::config;
 
-/// The lock file record, written after the socket is bound.
+/// The owner record, written to service.json after the socket is bound.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LockInfo {
     /// The owning process id.
@@ -73,6 +77,7 @@ impl Connection {
 pub struct Ownership {
     lock_file: File,
     lock_path: PathBuf,
+    info_path: PathBuf,
     socket_path: PathBuf,
 }
 
@@ -88,7 +93,9 @@ impl Ownership {
         ListenerOptions::new().name(name).create_tokio()
     }
 
-    /// Publish the lock record now that the socket is bound.
+    /// Publish the owner record now that the socket is bound. Written beside
+    /// the lock file, never into it (mandatory locks on Windows), and renamed
+    /// into place so a reader never sees a partial record.
     pub fn publish(&self) -> io::Result<()> {
         let info = LockInfo {
             pid: std::process::id(),
@@ -97,7 +104,9 @@ impl Ownership {
             started_at: chrono::Utc::now().to_rfc3339(),
         };
         let json = serde_json::to_string(&info).unwrap_or_default();
-        std::fs::write(&self.lock_path, json.as_bytes())
+        let tmp = self.info_path.with_extension("json.tmp");
+        std::fs::write(&tmp, json.as_bytes())?;
+        std::fs::rename(&tmp, &self.info_path)
     }
 
     /// The socket path (unix) or pipe name (Windows) as a display string.
@@ -115,6 +124,7 @@ impl Ownership {
 
 impl Drop for Ownership {
     fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.info_path);
         let _ = FileExt::unlock(&self.lock_file);
         #[cfg(unix)]
         {
@@ -142,10 +152,19 @@ fn socket_name(sock_path: &Path) -> io::Result<Name<'_>> {
     }
 }
 
-/// Read the current lock record, if any is present and parseable.
+/// Read the current owner record, if any is present and parseable. Reads
+/// `service.json`; falls back to parsing a legacy record out of `service.lock`
+/// itself, which pre-record-split daemons wrote, so an upgraded client can
+/// still see (and displace) a daemon from before the split.
 pub fn read_lock_info() -> Option<LockInfo> {
-    let path = config::service_lock_path().ok()?;
-    let text = std::fs::read_to_string(path).ok()?;
+    if let Ok(path) = config::service_info_path()
+        && let Ok(text) = std::fs::read_to_string(path)
+        && let Ok(info) = serde_json::from_str(&text)
+    {
+        return Some(info);
+    }
+    let legacy = config::service_lock_path().ok()?;
+    let text = std::fs::read_to_string(legacy).ok()?;
     serde_json::from_str(&text).ok()
 }
 
@@ -380,6 +399,7 @@ pub fn acquire_ownership() -> anyhow::Result<Ownership> {
     let dir = config::state_dir()?;
     std::fs::create_dir_all(&dir)?;
     let lock_path = config::service_lock_path()?;
+    let info_path = config::service_info_path()?;
     let socket_path = config::service_sock_path()?;
 
     let file = OpenOptions::new()
@@ -406,9 +426,15 @@ pub fn acquire_ownership() -> anyhow::Result<Ownership> {
         );
     }
 
+    // The lock is held. Empty any legacy record bytes (pre-split daemons wrote
+    // the record into the lock file itself) through this same handle, the only
+    // handle that may touch a mandatorily locked file on Windows.
+    let _ = file.set_len(0);
+
     Ok(Ownership {
         lock_file: file,
         lock_path,
+        info_path,
         socket_path,
     })
 }
@@ -428,8 +454,8 @@ pub async fn read_mode_line(stream: &mut IpcStream) -> io::Result<String> {
     Ok(String::from_utf8_lossy(&buf).trim().to_string())
 }
 
-/// Best-effort process liveness. On unix a signal-0 probe; elsewhere the lock
-/// and socket reachability govern, so assume alive.
+/// Best-effort process liveness. On unix a signal-0 probe, on Windows an
+/// OpenProcess exit-code query; elsewhere assume alive.
 pub fn process_alive(pid: u32) -> bool {
     #[cfg(unix)]
     {
@@ -443,7 +469,28 @@ pub fn process_alive(pid: u32) -> bool {
         // EPERM means the process exists but is not ours to signal.
         io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Foundation::{CloseHandle, ERROR_ACCESS_DENIED, STILL_ACTIVE};
+        use windows_sys::Win32::System::Threading::{
+            GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        };
+        if pid == 0 {
+            return false;
+        }
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid) };
+        if handle.is_null() {
+            // Access denied means the process exists but is not ours to query.
+            return std::io::Error::last_os_error().raw_os_error()
+                == Some(ERROR_ACCESS_DENIED as i32);
+        }
+        let mut code: u32 = 0;
+        let alive =
+            unsafe { GetExitCodeProcess(handle, &mut code) } != 0 && code == STILL_ACTIVE as u32;
+        unsafe { CloseHandle(handle) };
+        alive
+    }
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = pid;
         true
@@ -576,31 +623,27 @@ mod tests {
     // scratch socket instead, the same substitution `displace_*` above makes
     // for the daemon process itself.
 
-    /// Guards `HOME`/`XDG_*_HOME` for the two tests below: `try_attach_reporting`
-    /// resolves the real `crystalline_core::config::state_dir()` through
-    /// these, and cargo runs test functions from this file on multiple
-    /// threads, so both tests take this lock for their duration to avoid
-    /// observing each other's env var state. The same pattern
-    /// `crates/core/tests/config.rs` uses for `CRYSTALLINE_MODELS_DIR`.
-    /// `cfg(unix)` like the two tests that use it, so the Windows build does
-    /// not carry it as dead code.
-    #[cfg(unix)]
+    /// Guards `HOME`/`XDG_*_HOME` (and, on Windows, `USERPROFILE`/`APPDATA`/
+    /// `LOCALAPPDATA`) for the tests below: each resolves the real
+    /// `crystalline_core::config::state_dir()` through these, and cargo runs
+    /// test functions from this file on multiple threads, so every test takes
+    /// this lock for its duration to avoid observing another's env var state.
+    /// The same pattern `crates/core/tests/config.rs` uses for
+    /// `CRYSTALLINE_MODELS_DIR`.
     static STATE_DIR_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-    /// Points `HOME`/`XDG_*_HOME` at a fresh scratch directory for the
-    /// duration of one test, restoring whatever the surrounding environment
-    /// had on drop. A short `/tmp/cq-...` path rather than
+    /// Points `HOME`/`XDG_*_HOME` (and the Windows equivalents) at a fresh
+    /// scratch directory for the duration of one test, restoring whatever the
+    /// surrounding environment had on drop. A short base path rather than
     /// `tempfile::tempdir()`'s deeper one: the socket bound under it must stay
     /// within the ~104 byte unix socket path limit on macOS, the same reason
     /// the CLI integration tests' `Env` helper uses a short base.
-    #[cfg(unix)]
     struct ScratchHome {
         dir: PathBuf,
         previous: Vec<(&'static str, Option<String>)>,
         _guard: std::sync::MutexGuard<'static, ()>,
     }
 
-    #[cfg(unix)]
     impl ScratchHome {
         fn new(tag: &str) -> ScratchHome {
             let guard = STATE_DIR_ENV_LOCK.lock().unwrap();
@@ -608,7 +651,14 @@ mod tests {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_nanos();
-            let dir = PathBuf::from("/tmp").join(format!("cq-{tag}-{nanos}"));
+            // `/tmp` keeps the unix socket path short; `temp_dir()` is the
+            // Windows equivalent (there is no unix socket path limit to
+            // respect there, but `/tmp` does not exist on Windows).
+            #[cfg(unix)]
+            let base = PathBuf::from("/tmp");
+            #[cfg(windows)]
+            let base = std::env::temp_dir();
+            let dir = base.join(format!("cq-{tag}-{nanos}"));
             std::fs::create_dir_all(dir.join("config")).unwrap();
             std::fs::create_dir_all(dir.join("state")).unwrap();
             std::fs::create_dir_all(dir.join("cache")).unwrap();
@@ -617,6 +667,9 @@ mod tests {
                 "XDG_CONFIG_HOME",
                 "XDG_STATE_HOME",
                 "XDG_CACHE_HOME",
+                "USERPROFILE",
+                "APPDATA",
+                "LOCALAPPDATA",
             ];
             let previous = vars.iter().map(|v| (*v, std::env::var(v).ok())).collect();
             unsafe {
@@ -624,6 +677,9 @@ mod tests {
                 std::env::set_var("XDG_CONFIG_HOME", dir.join("config"));
                 std::env::set_var("XDG_STATE_HOME", dir.join("state"));
                 std::env::set_var("XDG_CACHE_HOME", dir.join("cache"));
+                std::env::set_var("USERPROFILE", &dir);
+                std::env::set_var("APPDATA", dir.join("config"));
+                std::env::set_var("LOCALAPPDATA", dir.join("cache"));
             }
             // `state_dir()` itself never creates its directory (only
             // `acquire_ownership` does, which these tests bypass), so the
@@ -637,7 +693,6 @@ mod tests {
         }
     }
 
-    #[cfg(unix)]
     impl Drop for ScratchHome {
         fn drop(&mut self) {
             for (var, value) in &self.previous {
@@ -672,14 +727,14 @@ mod tests {
             .unwrap();
         let pid = child.id();
 
-        let lock_path = config::service_lock_path().unwrap();
+        let info_path = config::service_info_path().unwrap();
         let info = LockInfo {
             pid,
             socket_path: sock.display().to_string(),
             version: "0.0.1".to_string(),
             started_at: chrono::Utc::now().to_rfc3339(),
         };
-        std::fs::write(&lock_path, serde_json::to_string(&info).unwrap()).unwrap();
+        std::fs::write(&info_path, serde_json::to_string(&info).unwrap()).unwrap();
 
         let server = tokio::spawn(async move {
             let mut stream = listener.accept().await.unwrap();
@@ -719,14 +774,14 @@ mod tests {
         let name = socket_name(&sock).unwrap();
         let listener = ListenerOptions::new().name(name).create_tokio().unwrap();
 
-        let lock_path = config::service_lock_path().unwrap();
+        let info_path = config::service_info_path().unwrap();
         let info = LockInfo {
             pid: std::process::id(),
             socket_path: sock.display().to_string(),
             version: crystalline_core::VERSION.to_string(),
             started_at: chrono::Utc::now().to_rfc3339(),
         };
-        std::fs::write(&lock_path, serde_json::to_string(&info).unwrap()).unwrap();
+        std::fs::write(&info_path, serde_json::to_string(&info).unwrap()).unwrap();
 
         let server = tokio::spawn(async move {
             let _ = listener.accept().await;
@@ -742,5 +797,77 @@ mod tests {
         drop(conn);
         server.await.unwrap();
         drop(home);
+    }
+
+    /// The record round trip that was impossible while the record lived inside
+    /// the locked file: publish writes and read_lock_info reads WHILE the
+    /// exclusive lock is held. Deliberately ungated - on Windows CI this is
+    /// the regression test for the mandatory-lock bug that broke daemon mode.
+    #[tokio::test]
+    async fn ownership_record_round_trips_while_the_lock_is_held() {
+        let home = ScratchHome::new("record-round-trip");
+        let ownership = acquire_ownership().unwrap();
+        ownership.publish().unwrap();
+        let info = read_lock_info().expect("the record is readable while the lock is held");
+        assert_eq!(info.pid, std::process::id());
+        assert_eq!(info.version, crystalline_core::VERSION);
+        assert_eq!(info.socket_path, ownership.socket_display());
+        drop(ownership);
+        assert!(read_lock_info().is_none(), "drop removes the record");
+        drop(home);
+    }
+
+    /// A pre-split daemon wrote its record into service.lock itself; with no
+    /// live owner the fallback still surfaces it so displacement works across
+    /// the upgrade.
+    #[tokio::test]
+    async fn read_lock_info_falls_back_to_a_legacy_record() {
+        let home = ScratchHome::new("legacy-record");
+        let legacy = LockInfo {
+            pid: std::process::id(),
+            socket_path: "legacy".to_string(),
+            version: "0.8.2".to_string(),
+            started_at: chrono::Utc::now().to_rfc3339(),
+        };
+        std::fs::write(
+            config::service_lock_path().unwrap(),
+            serde_json::to_string(&legacy).unwrap(),
+        )
+        .unwrap();
+        let info = read_lock_info().expect("the legacy record is readable");
+        assert_eq!(info.version, "0.8.2");
+        drop(home);
+    }
+
+    /// Acquiring ownership empties legacy bytes out of the lock file, so a
+    /// stale pre-split record can never shadow the live service.json.
+    #[tokio::test]
+    async fn acquire_ownership_empties_a_stale_legacy_record() {
+        let home = ScratchHome::new("legacy-emptied");
+        let stale = r#"{"pid":1,"socket_path":"gone","version":"0.0.1","started_at":""}"#;
+        std::fs::write(config::service_lock_path().unwrap(), stale).unwrap();
+        let ownership = acquire_ownership().unwrap();
+        assert!(
+            read_lock_info().is_none(),
+            "no service.json and the legacy bytes are gone"
+        );
+        drop(ownership);
+        drop(home);
+    }
+
+    /// process_alive tracks a real child on every platform.
+    #[test]
+    fn process_alive_tracks_a_real_child() {
+        assert!(process_alive(std::process::id()));
+        #[cfg(windows)]
+        let mut child = std::process::Command::new("cmd")
+            .args(["/C", "exit 0"])
+            .spawn()
+            .unwrap();
+        #[cfg(unix)]
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = child.id();
+        child.wait().unwrap();
+        assert!(!process_alive(pid), "a reaped child is not alive");
     }
 }


### PR DESCRIPTION
Windows LockFileEx region locks are mandatory, so the old design (owner record stored inside the locked service.lock) could neither publish the record nor let clients read it - every spawned daemon died at publish and every start burned the 15s readiness budget before falling back embedded. Diagnosis from a corporate Windows amd64 field report on 2026-07-14.

- Split the owner record into service.json beside the lock-only service.lock, with a legacy fallback for upgrades in place
- Real process_alive on Windows (OpenProcess/GetExitCodeProcess) instead of a hardcoded true
- Pipe name derived per state directory (FNV-1a of the socket path) instead of one machine-global name
- Windows spawn flags (no console window, own process group, job breakaway with in-job retry) and a capped daemon.log stderr sink for detached startup failures
- hf-hub native-tls on Windows and macOS targets so model downloads trust the OS certificate store behind TLS-intercepting proxies; Linux keeps bundled rustls
- New windows-only integration suite driving serve, record publication, an mcp attach over the pipe and the second-instance refusal

The windows-latest leg of this PR is the first time the daemon path runs on Windows at all.