### PR TITLE
Route the remaining embed passes through the background worker

### DIFF
--- a/crates/service/src/daemon.rs
+++ b/crates/service/src/daemon.rs
@@ -200,9 +200,10 @@ pub async fn run_serve(
     // domain registered after this daemon started, so it starts watching that
     // root without a restart. See `Engine::domain_root`'s fresh-config fallback.
     let (watch_tx, watch_rx) = tokio::sync::mpsc::unbounded_channel::<WatchEvent>();
-    // A channel the embed worker (spawned below) listens on: connecting an
-    // origin schedules its embedding pass here instead of running it inline,
-    // so the connect request returns without waiting on the model.
+    // A channel the embed worker (spawned below) listens on: every engine
+    // operation that touches embeddings schedules its pass here instead of
+    // running it inline, so the triggering request returns without waiting
+    // on the model.
     let (embed_tx, embed_rx) = tokio::sync::mpsc::unbounded_channel();
     // The provider is built in the background (see below); text search and the
     // socket never wait on the model download. The engine holds the file config
@@ -432,8 +433,12 @@ async fn handle_conn(mut stream: IpcStream, shared: Arc<Shared>) {
 }
 
 /// Watch every domain root, debounce bursts by ~300ms and sync the touched
-/// domains, then embed. The store's on-disk stamp already matches any file a
-/// mutating tool just wrote, so those files are classified unchanged here.
+/// domains, then schedule an embedding pass on the worker (falling back to an
+/// inline pass only if the worker channel is unwired or its receiver already
+/// dropped, which in practice only a shutdown race produces). The store's
+/// on-disk stamp already matches
+/// any file a mutating tool just wrote, so those files are classified
+/// unchanged here.
 ///
 /// `new_roots` carries domains discovered after startup (see
 /// `Engine::domain_root`'s fresh-config fallback): a `domain add` while this
@@ -531,7 +536,9 @@ async fn run_watcher(
                                         if let Err(err) = engine.sync(Some(name.as_str())).await {
                                             tracing::warn!("catch-up sync of new domain '{name}' failed: {err}");
                                         }
-                                        if let Err(err) = engine.embed_pending().await {
+                                        if !engine.request_embed()
+                                            && let Err(err) = engine.embed_pending().await
+                                        {
                                             tracing::warn!("catch-up embed of new domain '{name}' failed: {err}");
                                         }
                                     }
@@ -574,6 +581,7 @@ async fn run_watcher(
                     }
                 }
                 if !dirty.is_empty()
+                    && !engine.request_embed()
                     && let Err(err) = engine.embed_pending().await
                 {
                     tracing::warn!("watch embed failed: {err}");

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -2932,7 +2932,9 @@ impl Engine {
         }
 
         let sync = self.sync(Some(&domain_name)).await?;
-        if let Err(e) = self.embed_pending().await {
+        if !self.request_embed()
+            && let Err(e) = self.embed_pending().await
+        {
             tracing::warn!("embedding after creating '{domain_name}' failed: {e}");
         }
 
@@ -3367,7 +3369,9 @@ impl Engine {
             .inspect_err(|e| self.drop_github_credential_on_auth(e))?;
 
         self.sync(Some(name)).await?;
-        if let Err(e) = self.embed_pending().await {
+        if !self.request_embed()
+            && let Err(e) = self.embed_pending().await
+        {
             tracing::warn!("embedding after updating '{name}' failed: {e}");
         }
 
@@ -3421,7 +3425,9 @@ impl Engine {
         }
 
         self.sync(Some(name)).await?;
-        if let Err(e) = self.embed_pending().await {
+        if !self.request_embed()
+            && let Err(e) = self.embed_pending().await
+        {
             tracing::warn!("embedding after bootstrapping '{name}' failed: {e}");
         }
 
@@ -3855,7 +3861,9 @@ impl Engine {
         let report = ops::discard(&root, &state_dir, proposal_number)?;
 
         self.sync(Some(domain)).await?;
-        if let Err(e) = self.embed_pending().await {
+        if !self.request_embed()
+            && let Err(e) = self.embed_pending().await
+        {
             tracing::warn!(
                 "embedding after discarding proposal #{proposal_number} for '{domain}' failed: {e}"
             );
@@ -3896,7 +3904,9 @@ impl Engine {
         let report = ops::resolve(&root, &state_dir, path, resolution)?;
 
         self.sync(Some(domain)).await?;
-        if let Err(e) = self.embed_pending().await {
+        if !self.request_embed()
+            && let Err(e) = self.embed_pending().await
+        {
             tracing::warn!("embedding after resolving a conflict for '{domain}' failed: {e}");
         }
 

--- a/crates/service/tests/origin.rs
+++ b/crates/service/tests/origin.rs
@@ -1,7 +1,9 @@
 //! Engine-level tests for GitHub origin collaboration: `origin_add`,
 //! `origin_update`, `origin_status`, `origin_share`, `origin_discard` and
 //! `origin_resolve`, plus the gating matrix (the `github.enabled` refusal
-//! and the read-only mode's asymmetric refusal).
+//! and the read-only mode's asymmetric refusal). The embed-worker
+//! scheduling checks also live here, beside the harness they share; they
+//! include the non-origin `domain_add_local` one.
 //!
 //! Every test injects `support::MockProvider` via `Engine::with_origin_provider`
 //! and points origin state at a tempdir via `Engine::with_origins_dir`, so
@@ -870,6 +872,52 @@ async fn origin_update_applies_an_upstream_edit_and_the_index_reflects_it() {
 }
 
 #[tokio::test]
+async fn origin_update_schedules_embedding_on_the_worker_channel() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mock = Arc::new(MockProvider::new());
+    let c1 = mock.add_commit(commit_files(&[
+        ("MANIFEST.md", manifest()),
+        ("notes/alpha.md", engram("Alpha", "alpha", "version one")),
+    ]));
+    mock.set_branch("main", &c1);
+
+    let config_path = tmp.path().join("config.yaml");
+    let origins_dir = tmp.path().join("origins");
+    let root = tmp.path().join("brand-knowledge");
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let eng = engine_with(&config_path, &origins_dir, mock.clone(), true, false)
+        .await
+        .with_embed_channel(tx);
+    eng.origin_add(
+        "acme/brand-knowledge",
+        Some("brand"),
+        None,
+        None,
+        Some(root.to_str().unwrap()),
+    )
+    .await
+    .unwrap();
+    // Drain the connect's own scheduled embed so the assertion below sees
+    // only the update's pass.
+    while rx.try_recv().is_ok() {}
+
+    let c2 = mock.add_commit(commit_files(&[
+        ("MANIFEST.md", manifest()),
+        (
+            "notes/alpha.md",
+            engram("Alpha", "alpha", "version two, revised upstream"),
+        ),
+    ]));
+    mock.set_branch("main", &c2);
+
+    eng.origin_update(Some("brand")).await.unwrap();
+    assert!(
+        rx.try_recv().is_ok(),
+        "origin_update must schedule a background embed instead of embedding inline"
+    );
+}
+
+#[tokio::test]
 async fn origin_update_named_domain_with_no_origin_errors() {
     let tmp = tempfile::tempdir().unwrap();
     let mock = Arc::new(MockProvider::new());
@@ -1544,6 +1592,64 @@ async fn origin_discard_restores_files_and_syncs_the_index() {
     assert_eq!(hits["total"], 1, "{hits}");
 }
 
+#[tokio::test]
+async fn origin_discard_schedules_embedding_on_the_worker_channel() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mock = Arc::new(MockProvider::new());
+    let commit = mock.add_commit(commit_files(&[
+        ("MANIFEST.md", manifest()),
+        ("notes/keep.md", engram("Keep", "keep", "base content")),
+    ]));
+    mock.set_branch("main", &commit);
+
+    let config_path = tmp.path().join("config.yaml");
+    let origins_dir = tmp.path().join("origins");
+    let root = tmp.path().join("brand-knowledge");
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let eng = engine_with(&config_path, &origins_dir, mock.clone(), true, false)
+        .await
+        .with_embed_channel(tx);
+    eng.origin_add(
+        "acme/brand-knowledge",
+        Some("brand"),
+        None,
+        None,
+        Some(root.to_str().unwrap()),
+    )
+    .await
+    .unwrap();
+    // Drain the connect's own scheduled embed so the assertion below sees
+    // only the discard's pass.
+    while rx.try_recv().is_ok() {}
+
+    // A previously opened, now declined proposal touching keep.md, without
+    // going through a real `origin_share` call.
+    let proposed = engram("Keep", "keep", "shared v2 content");
+    std::fs::write(root.join("notes/keep.md"), &proposed).unwrap();
+    let state_dir = origins_dir.join("brand");
+    let mut state = OriginState::load(&state_dir).unwrap().unwrap();
+    state.proposals.push(Proposal {
+        number: 5,
+        url: "https://github.test/pulls/5".to_string(),
+        branch: "crystalline/share-brand-000101000000".to_string(),
+        title: "Refine 1 engram in brand".to_string(),
+        created_at: chrono::Utc::now(),
+        status: ProposalStatus::Declined,
+        files: vec![ProposedFile {
+            path: "notes/keep.md".to_string(),
+            change: ProposedChange::Modified,
+            sha256: Some(sha256_hex(&proposed)),
+        }],
+    });
+    state.save(&state_dir).unwrap();
+
+    eng.origin_discard("brand", 5).await.unwrap();
+    assert!(
+        rx.try_recv().is_ok(),
+        "origin_discard must schedule a background embed instead of embedding inline"
+    );
+}
+
 // --- origin_resolve --------------------------------------------------------------
 
 #[tokio::test]
@@ -1648,5 +1754,40 @@ async fn origin_resolve_unknown_path_errors_without_writing() {
             EngineError::Remote(RemoteError::ConflictNotFound { .. })
         ),
         "{err}"
+    );
+}
+
+// --- domain_add_local --------------------------------------------------------
+
+#[tokio::test]
+async fn domain_add_local_schedules_embedding_on_the_worker_channel() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mock = Arc::new(MockProvider::new());
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let eng = engine_with(
+        &tmp.path().join("config.yaml"),
+        &tmp.path().join("origins"),
+        mock,
+        false,
+        false,
+    )
+    .await
+    .with_embed_channel(tx);
+
+    let folder = tmp.path().join("local-notes");
+    std::fs::create_dir_all(folder.join("notes")).unwrap();
+    std::fs::write(folder.join("MANIFEST.md"), manifest()).unwrap();
+    std::fs::write(
+        folder.join("notes/alpha.md"),
+        engram("Alpha", "alpha", "alpha body"),
+    )
+    .unwrap();
+
+    eng.domain_add_local(Some("local-notes"), Some(folder.to_str().unwrap()))
+        .await
+        .unwrap();
+    assert!(
+        rx.try_recv().is_ok(),
+        "domain_add_local must schedule a background embed instead of embedding inline"
     );
 }


### PR DESCRIPTION
## Summary

Follow-up to #2. That PR moved the connect path's embedding onto a background worker but converted only origin_add; this converts the seven remaining fire-and-forget embed sites to the same schedule-or-inline idiom, so no MCP or ctl request and no watcher loop ever stalls on inline embedding: domain_add_local, origin_update, env-origin bootstrap, origin_discard, origin_resolve and both daemon watcher arms.

Deliberately unchanged: the ctl embed command (a synchronous pass that reports its count is its purpose) and the two startup background embeds. Warn messages, response shapes and the worker wiring are untouched; without a worker every site falls back to the old inline pass.

## Testing

- Three new engine-level scheduling tests (domain_add_local, origin_update, origin_discard) written RED first, plus the existing origin_add one - all gate the channel behavior directly
- cargo test --workspace green (54 suites), clippy -D warnings, fmt and style-lint clean