### PR TITLE
Cut build and test times with profile tuning and nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Install Rust toolchain
         run: rustup show
 
+      - uses: taiki-e/install-action@nextest
+
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: cargo fmt --check
@@ -39,8 +41,11 @@ jobs:
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-      - name: cargo test
-        run: cargo test --workspace
+      - name: cargo nextest run
+        run: cargo nextest run --workspace
+
+      - name: cargo test --doc
+        run: cargo test --workspace --doc
 
   postgres-parity:
     name: postgres-parity

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,8 @@ Dependency direction: core <- index <- service <- cli.
 ## Commands
 
 - Build: `cargo build --release`
-- Test: `cargo test --workspace`
+- Test (fast path): `cargo nextest run --workspace` (install: `brew install cargo-nextest`), plus doctests via `cargo test --workspace --doc`
+- Test (canonical fallback): `cargo test --workspace`
 - Lint: `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all --check`
 - Style check: `bash scripts/style-lint.sh`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,11 @@ base64 = "0.22.1"
 insta = { version = "1.48.0", features = ["yaml"] }
 assert_cmd = "2.2.2"
 tempfile = "3.27.0"
+
+# Dev and test builds carry line tables only: panics and backtraces keep
+# file:line, links across the 45 integration-test binaries stay fast and the
+# target directory stays a fraction of full-DWARF size. Interactive debugger
+# variable inspection is the one thing this costs; release builds are
+# untouched.
+[profile.dev]
+debug = "line-tables-only"


### PR DESCRIPTION
cargo test --workspace was slow enough to fight both humans and agent tooling. Two low-risk levers, measured before and after on a warm tree:

- Dev and test builds now carry line tables only (backtraces keep file:line, release builds untouched). A one-line core touch rebuilt and relinked the workspace test binaries in 1m23 before, 15s after; target/debug shrank from 326 GB to 5.3 GB
- CI runs the test suites through cargo-nextest (per-test process isolation, better scheduling across the 45 test binaries) plus a separate doctest step; locally the full 1045-test suite finishes in under a minute

No test semantics changed - config and runner only.