### PR TITLE
Serve a degraded status server when crystalline mcp cannot start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "crystalline"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "crystalline-core"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "crystalline-index"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "async-trait",
  "candle-core",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "crystalline-remote"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "async-trait",
  "axum",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "crystalline-service"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,6 +1146,7 @@ dependencies = [
  "crystalline-index",
  "crystalline-remote",
  "crystalline-service",
+ "fs4 1.1.0",
  "insta",
  "predicates",
  "reqwest 0.13.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.5"
+version = "0.8.6"
 authors = ["Jordi Boehme <jordi@boehme-lopez.de>"]
 edition = "2024"
 license = "AGPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -312,14 +312,14 @@ github:
 `crystalline verify` statically checks one or more domains against the full rule catalog - malformed frontmatter, broken links, missing MANIFEST sections, schema drift - with no database, service or network connection involved. Its usual home is CI/CD on the GitHub repositories that hold a team's knowledge: every proposal is verified before the team merges it, so nothing malformed ever lands on the branch everyone pulls from. The bundled GitHub Action wires that up:
 
 ```yaml
-- uses: jordiboehme/crystalline/action@v0.8.5
+- uses: jordiboehme/crystalline/action@v0.8.6
   with:
     paths: knowledge/       # space-separated domain roots, default '.'
     strict: 'false'         # promote Warning rules to Error
-    version: v0.8.5         # crystalline binary tag to download, or 'latest'
+    version: v0.8.6         # crystalline binary tag to download, or 'latest'
 ```
 
-The action ref (`@v0.8.5`) pins the action's own code; `version` pins the crystalline binary it downloads, so pinning both gives a fully reproducible check. The binary is checksum-verified, then the action runs `crystalline verify`, annotates the run and, on a pull request, posts a single summary comment kept up to date in place.
+The action ref (`@v0.8.6`) pins the action's own code; `version` pins the crystalline binary it downloads, so pinning both gives a fully reproducible check. The binary is checksum-verified, then the action runs `crystalline verify`, annotates the run and, on a pull request, posts a single summary comment kept up to date in place.
 
 Two more commands keep a knowledge base trustworthy:
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -80,3 +80,7 @@ serde_json = { workspace = true }
 insta = { workspace = true }
 reqwest = { workspace = true, features = ["blocking"] }
 sha2 = { workspace = true }
+# The degraded-stub binary test holds an exclusive index lock in the test
+# process (the fs4 lock a rival daemon would hold) so the spawned `mcp` child
+# fails to acquire it and serves the stub.
+fs4 = { workspace = true }

--- a/crates/cli/tests/mcp_stub.rs
+++ b/crates/cli/tests/mcp_stub.rs
@@ -1,0 +1,348 @@
+//! Binary integration tests for the degraded status server: the real
+//! `crystalline` binary serving the stub over stdio when it cannot start.
+//!
+//! Each test holds an exclusive `fs4` lock on `service.lock` in the test
+//! process itself - the very lock a rival daemon would hold - so the spawned
+//! `crystalline mcp` child fails to acquire the index and falls through to the
+//! degraded stub. A `service.json` owner record (pid = this alive test process)
+//! drives the case selection: a strictly newer version reads as an upgrade
+//! skew, this binary's own version as a plain conflict, an unreadable record as
+//! generic. Unix-only: an exclusive advisory lock across two processes and a
+//! short `/tmp` HOME are the mechanism.
+#![cfg(unix)]
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use fs4::FileExt;
+use serde_json::{Value, json};
+
+fn bin() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("crystalline")
+}
+
+/// An isolated, short-path environment holding the index lock for one test.
+struct Env {
+    dir: PathBuf,
+    /// The exclusively locked `service.lock` handle, held for the test's whole
+    /// life so the spawned child can never acquire the index.
+    _lock: File,
+}
+
+impl Env {
+    /// Create the isolated dirs, then take and hold the exclusive index lock.
+    fn locked(tag: &str) -> Env {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        // A short base keeps any derived path well under the macOS limits and
+        // matches the daemon integration tests' `Env`.
+        let dir = PathBuf::from("/tmp").join(format!("cq-{tag}-{nanos}"));
+        std::fs::create_dir_all(dir.join("config")).unwrap();
+        std::fs::create_dir_all(dir.join("cache")).unwrap();
+        let state = dir.join("state/crystalline");
+        std::fs::create_dir_all(&state).unwrap();
+
+        let lock = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(state.join("service.lock"))
+            .unwrap();
+        FileExt::try_lock(&lock).expect("the test holds the index lock");
+        Env { dir, _lock: lock }
+    }
+
+    fn apply(&self, cmd: &mut Command) {
+        cmd.env("HOME", &self.dir)
+            .env("XDG_CONFIG_HOME", self.dir.join("config"))
+            .env("XDG_STATE_HOME", self.dir.join("state"))
+            .env("XDG_CACHE_HOME", self.dir.join("cache"));
+    }
+
+    fn info_path(&self) -> PathBuf {
+        self.dir.join("state/crystalline/service.json")
+    }
+
+    /// Write an owner record naming this alive test process, so the child's
+    /// case selection sees a live daemon at `version`.
+    fn write_record(&self, version: &str) {
+        let record = json!({
+            "pid": std::process::id(),
+            "socket_path": "/nonexistent",
+            "version": version,
+            "started_at": "2026-07-16T00:00:00Z",
+        });
+        std::fs::write(self.info_path(), record.to_string()).unwrap();
+    }
+}
+
+impl Drop for Env {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// A `crystalline mcp` child driven with raw newline-delimited JSON-RPC.
+struct Mcp {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    out: BufReader<ChildStdout>,
+    id: i64,
+}
+
+impl Mcp {
+    /// Spawn `crystalline mcp` (with `--embedded` unless `daemon_path` asks for
+    /// the daemon-first path) under `env` with the mcpb channel marker set.
+    fn spawn(env: &Env, embedded: bool, channel: Option<&str>) -> Mcp {
+        let mut cmd = Command::new(bin());
+        env.apply(&mut cmd);
+        cmd.arg("mcp");
+        if embedded {
+            cmd.arg("--embedded");
+        }
+        if let Some(channel) = channel {
+            cmd.env("CRYSTALLINE_CHANNEL", channel);
+        }
+        let mut child = cmd
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take().unwrap();
+        let out = BufReader::new(child.stdout.take().unwrap());
+        Mcp {
+            child,
+            stdin: Some(stdin),
+            out,
+            id: 0,
+        }
+    }
+
+    fn send(&mut self, value: &Value) {
+        let stdin = self.stdin.as_mut().expect("stdin open");
+        stdin.write_all(value.to_string().as_bytes()).unwrap();
+        stdin.write_all(b"\n").unwrap();
+        stdin.flush().unwrap();
+    }
+
+    fn read(&mut self) -> Value {
+        loop {
+            let mut line = String::new();
+            let n = self.out.read_line(&mut line).unwrap();
+            assert!(n > 0, "unexpected EOF from mcp child");
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            return serde_json::from_str(trimmed).unwrap();
+        }
+    }
+
+    /// Drive `initialize`, send the initialized notification and return the
+    /// initialize response.
+    fn initialize(&mut self) -> Value {
+        self.id += 1;
+        self.send(&json!({
+            "jsonrpc": "2.0",
+            "id": self.id,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": { "name": "it", "version": "0" }
+            }
+        }));
+        let resp = self.read();
+        self.send(&json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }));
+        resp
+    }
+
+    /// Send `tools/list` and return the tool names.
+    fn list_tools(&mut self) -> Vec<String> {
+        self.id += 1;
+        self.send(&json!({
+            "jsonrpc": "2.0", "id": self.id, "method": "tools/list", "params": {}
+        }));
+        self.read()
+            .pointer("/result/tools")
+            .and_then(Value::as_array)
+            .map(|tools| {
+                tools
+                    .iter()
+                    .filter_map(|t| t["name"].as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Call `tool` and return the parsed JSON payload from its text block.
+    fn call(&mut self, tool: &str) -> Value {
+        self.id += 1;
+        self.send(&json!({
+            "jsonrpc": "2.0", "id": self.id, "method": "tools/call",
+            "params": { "name": tool, "arguments": {} }
+        }));
+        let resp = self.read();
+        let text = resp
+            .pointer("/result/content/0/text")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        serde_json::from_str(text).unwrap_or(Value::Null)
+    }
+
+    /// Close stdin and wait for the child to exit, returning its exit code.
+    fn close_and_wait(&mut self) -> i32 {
+        self.stdin = None;
+        let start = Instant::now();
+        loop {
+            if let Some(status) = self.child.try_wait().unwrap() {
+                return status.code().unwrap_or(-1);
+            }
+            if start.elapsed() > Duration::from_secs(10) {
+                panic!("mcp child did not exit after stdin close");
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+impl Drop for Mcp {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// A strictly newer daemon owns the index and the mcpb channel is set: the
+/// stub serves the extension-upgrade copy, exposes only `status` and its
+/// payload names the newer daemon, then a clean exit on stdin close.
+#[test]
+fn embedded_newer_daemon_on_mcpb_channel_serves_the_upgrade_stub() {
+    let env = Env::locked("stub-mcpb");
+    env.write_record("99.0.0");
+
+    let mut mcp = Mcp::spawn(&env, true, Some("mcpb"));
+    let init = mcp.initialize();
+    assert_eq!(
+        init.pointer("/result/serverInfo/name")
+            .and_then(Value::as_str),
+        Some("crystalline"),
+        "a RESULT, not an error: {init}"
+    );
+    let instructions = init
+        .pointer("/result/instructions")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        instructions.contains("https://github.com/jordiboehme/crystalline/releases"),
+        "instructions carry the releases URL:\n{instructions}"
+    );
+
+    assert_eq!(
+        mcp.list_tools(),
+        vec!["status".to_string()],
+        "only the status tool"
+    );
+
+    let payload = mcp.call("status");
+    assert_eq!(payload["available"], json!(false));
+    assert_eq!(payload["daemon_version"], json!("99.0.0"));
+    assert_eq!(payload["channel"], json!("mcpb"));
+
+    assert_eq!(mcp.close_and_wait(), 0, "a degraded session ends cleanly");
+}
+
+/// A live record at this binary's own version is a plain conflict: the copy
+/// names the pid and offers no update hint.
+#[test]
+fn embedded_same_version_record_serves_the_conflict_stub() {
+    let env = Env::locked("stub-conflict");
+    env.write_record(env!("CARGO_PKG_VERSION"));
+
+    let mut mcp = Mcp::spawn(&env, true, Some("mcpb"));
+    let init = mcp.initialize();
+    let instructions = init
+        .pointer("/result/instructions")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        instructions.contains("owns this machine's knowledge index"),
+        "plain conflict copy:\n{instructions}"
+    );
+    assert!(
+        !instructions.contains("install it over the current")
+            && !instructions.contains("update this Crystalline installation"),
+        "an equal-version record is never an upgrade skew:\n{instructions}"
+    );
+
+    let payload = mcp.call("status");
+    assert_eq!(payload["available"], json!(false));
+    assert_eq!(payload["daemon_version"], json!(env!("CARGO_PKG_VERSION")));
+
+    assert_eq!(mcp.close_and_wait(), 0);
+}
+
+/// No readable owner record (the lock is held but `service.json` is absent):
+/// the generic copy surfaces the raw startup reason and points at daemon.log.
+#[test]
+fn embedded_no_record_serves_the_generic_stub() {
+    let env = Env::locked("stub-generic");
+    // Deliberately no service.json: read_lock_info finds nothing to explain the
+    // failure, so the stub degrades to the generic reason-carrying copy.
+
+    let mut mcp = Mcp::spawn(&env, true, Some("mcpb"));
+    let init = mcp.initialize();
+    let instructions = init
+        .pointer("/result/instructions")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        instructions.contains("cannot run an embedded MCP server"),
+        "generic copy carries the reason:\n{instructions}"
+    );
+    assert!(
+        instructions.contains("daemon.log"),
+        "generic copy points at daemon.log:\n{instructions}"
+    );
+
+    let payload = mcp.call("status");
+    assert_eq!(payload["available"], json!(false));
+    assert!(
+        !payload.as_object().unwrap().contains_key("daemon_version"),
+        "no live record: {payload}"
+    );
+
+    assert_eq!(mcp.close_and_wait(), 0);
+}
+
+/// The field incident itself: `crystalline mcp` WITHOUT `--embedded` against a
+/// held lock. It first spends the daemon spawn-and-readiness budget (~15s)
+/// before falling through to the embedded path and serving the stub, so this
+/// is ignored by default to keep the suite fast. Run it explicitly with:
+/// `cargo nextest run -p crystalline --run-ignored all -E 'binary(mcp_stub)'`
+/// (nextest's `test()` predicate matches test names, so the mcp_stub file is
+/// selected by `binary()`).
+#[test]
+#[ignore = "burns the ~15s daemon spawn budget before the stub serves"]
+fn daemon_path_falls_through_to_the_stub_after_the_spawn_budget() {
+    let env = Env::locked("stub-daemon");
+    env.write_record("99.0.0");
+
+    let mut mcp = Mcp::spawn(&env, false, Some("mcpb"));
+    let init = mcp.initialize();
+    assert_eq!(
+        init.pointer("/result/serverInfo/name")
+            .and_then(Value::as_str),
+        Some("crystalline"),
+        "the stub serves after the daemon path gives up: {init}"
+    );
+    assert_eq!(mcp.list_tools(), vec!["status".to_string()]);
+    assert_eq!(mcp.close_and_wait(), 0);
+}

--- a/crates/service/src/client.rs
+++ b/crates/service/src/client.rs
@@ -220,19 +220,34 @@ pub async fn run_mcp(
 
     // Embedded path: the explicit flag, or a daemon that could not be reached.
     // A terminal startup failure (lock held, config or store error) happens
-    // before rmcp answers anything, so reply to the held `initialize` with a
-    // JSON-RPC error rather than closing stdio, which the negotiation window
-    // reads as an unrecoverable network error. The process still exits non-zero
-    // (stderr carries the chain for the Desktop log).
-    match run_embedded_stdio(primed, db, config_path, read_only).await {
-        Ok(()) => Ok(()),
+    // before rmcp answers anything. Rather than closing stdio - which the
+    // negotiation window reads as an unrecoverable network error - serve a
+    // degraded status server: `initialize` succeeds with per-case instructions
+    // and a `status` tool explaining the failure and its fix, so the model can
+    // relay it instead of the session going dark. Every fallible step lives in
+    // `build_embedded`, ahead of the primed reader, so on failure the reader is
+    // still intact for the stub. Only if the stub itself fails to serve do we
+    // fall back to the old `-32000` reply and a non-zero exit (stderr carries
+    // the chain for the Desktop log).
+    match build_embedded(db, config_path, read_only).await {
+        Ok(stack) => run_embedded_stdio(stack, primed).await,
         Err(e) => {
-            if let Some(reply) = initialize_error_reply(&init_line, &format!("{e:#}")) {
-                let _ = stdout.write_all(reply.as_bytes()).await;
-                let _ = stdout.write_all(b"\n").await;
-                let _ = stdout.flush().await;
+            tracing::error!(
+                "crystalline mcp cannot start ({e:#}); serving a degraded status server"
+            );
+            let status = crate::stub::StubStatus::gather(format!("{e:#}"));
+            match serve_degraded_stub(status, primed).await {
+                Ok(()) => Ok(()),
+                Err(stub_err) => {
+                    tracing::warn!("degraded status server failed ({stub_err:#})");
+                    if let Some(reply) = initialize_error_reply(&init_line, &format!("{e:#}")) {
+                        let _ = stdout.write_all(reply.as_bytes()).await;
+                        let _ = stdout.write_all(b"\n").await;
+                        let _ = stdout.flush().await;
+                    }
+                    Err(e)
+                }
             }
-            Err(e)
         }
     }
 }
@@ -508,22 +523,27 @@ where
     }
 }
 
-/// The full in-process stack over stdio. Takes the lock; refuses if held. The
-/// effective mode is the explicit flag or `service.read_only`. `reader` is the
-/// primed stdin [`run_mcp`] already fronted with the drained `initialize`, so
-/// this path never touches the pre-init probe itself; it hands the reader
-/// straight to `rmcp::serve_server`. A startup error returned here reaches
-/// `run_mcp` before rmcp ever answers, which is where the terminal-failure
-/// `initialize` reply is written.
-async fn run_embedded_stdio<R>(
-    reader: R,
+/// The built-and-ready in-process stack: the tool server plus the index
+/// ownership it holds for the session. Every fallible startup step already ran
+/// in [`build_embedded`], so [`run_embedded_stdio`] only has to serve and can
+/// take the primed reader with no risk of failing after it is consumed.
+struct EmbeddedStack {
+    server: McpServer,
+    ownership: crate::instance::Ownership,
+}
+
+/// Build the full in-process stack: take the index lock (refused if held),
+/// load the config and overlay, open the store, construct the engine, launch
+/// the background sync and embed workers and prime the routing cache. Every
+/// step that can fail lives here, ahead of the reader ever being touched, so a
+/// terminal failure leaves [`run_mcp`]'s primed `initialize` reader intact for
+/// the degraded stub to serve. The effective read-only mode is the explicit
+/// flag or `service.read_only`.
+async fn build_embedded(
     db: Option<&Path>,
     config_path: Option<&Path>,
     read_only: bool,
-) -> anyhow::Result<()>
-where
-    R: AsyncRead + Unpin + Send + 'static,
-{
+) -> anyhow::Result<EmbeddedStack> {
     let ownership = acquire_ownership()
         .map_err(|e| anyhow::anyhow!("cannot run an embedded MCP server: {e}"))?;
     let loaded = overlay::load(config_path)?;
@@ -562,11 +582,44 @@ where
     // renders complete instructions, never racing the background sync above.
     engine.refresh_routing_cache().await;
 
-    let server = McpServer::new(engine);
+    Ok(EmbeddedStack {
+        server: McpServer::new(engine),
+        ownership,
+    })
+}
+
+/// Serve the built stack over stdio until the client closes stdin. `reader` is
+/// the primed stdin [`run_mcp`] already fronted with the drained `initialize`,
+/// so this path never touches the pre-init probe itself; it hands the reader
+/// straight to `rmcp::serve_server`. This runs only after [`build_embedded`]
+/// succeeded, so nothing here consumes the reader on a startup failure.
+async fn run_embedded_stdio<R>(stack: EmbeddedStack, reader: R) -> anyhow::Result<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
     let stdout = tokio::io::stdout();
-    let running = rmcp::serve_server(server, (reader, stdout)).await?;
+    let running = rmcp::serve_server(stack.server, (reader, stdout)).await?;
     let _ = running.waiting().await;
-    drop(ownership);
+    drop(stack.ownership);
+    Ok(())
+}
+
+/// Serve the degraded status server over stdio: a stand-in that answers
+/// `initialize` with explanatory instructions and a single `status` tool when
+/// the embedded stack could not start (see [`crate::stub`]). It holds no lock
+/// and opens no store, so serving it cannot itself fail for the reasons that
+/// forced the degradation; it ends when the client closes stdin, exactly like
+/// [`run_embedded_stdio`].
+async fn serve_degraded_stub<R>(status: crate::stub::StubStatus, reader: R) -> anyhow::Result<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    let running = rmcp::serve_server(
+        crate::stub::DegradedServer::new(status),
+        (reader, tokio::io::stdout()),
+    )
+    .await?;
+    let _ = running.waiting().await;
     Ok(())
 }
 

--- a/crates/service/src/instance.rs
+++ b/crates/service/src/instance.rs
@@ -263,6 +263,17 @@ pub fn attach_policy(daemon_version: &str, own_version: &str) -> AttachPolicy {
     }
 }
 
+/// Whether `candidate` is a strictly newer release than `baseline`. Same
+/// triple parsing as [`attach_policy`]; an unparseable version on either side
+/// is never newer, so an odd record can only ever read as a conflict, never as
+/// an upgrade skew.
+pub(crate) fn strictly_newer(candidate: &str, baseline: &str) -> bool {
+    match (version_triple(candidate), version_triple(baseline)) {
+        (Some(candidate), Some(baseline)) => candidate > baseline,
+        _ => false,
+    }
+}
+
 /// Parse a version string's numeric `major.minor.patch` triple, ignoring any
 /// pre-release or build suffix.
 fn version_triple(version: &str) -> Option<(u64, u64, u64)> {
@@ -598,6 +609,21 @@ mod tests {
         assert_eq!(attach_policy("", "0.5.2"), AttachPolicy::Attach);
         assert_eq!(attach_policy("dev", "0.5.2"), AttachPolicy::Attach);
         assert_eq!(attach_policy("0.5.1", "junk"), AttachPolicy::Attach);
+    }
+
+    #[test]
+    fn strictly_newer_is_true_only_for_a_higher_triple() {
+        assert!(strictly_newer("0.9.0", "0.8.2"), "a higher triple is newer");
+        assert!(!strictly_newer("0.8.2", "0.8.2"), "equal is not newer");
+        assert!(!strictly_newer("0.8.1", "0.8.2"), "older is not newer");
+        assert!(
+            !strictly_newer("garbage", "0.8.2"),
+            "an unparseable candidate is never newer"
+        );
+        assert!(
+            !strictly_newer("0.9.0", "junk"),
+            "an unparseable baseline is never newer"
+        );
     }
 
     #[test]

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -20,6 +20,7 @@ pub mod overlay;
 pub mod params;
 mod poller;
 pub mod settings;
+pub mod stub;
 
 pub use client::{
     configure, ctl_if_running, ctl_required, domain_export, domain_import, origin_add,
@@ -32,3 +33,4 @@ pub use harness_cli::{CliRun, SystemMcpRunner, run_harness_cli};
 pub use mcp::McpServer;
 pub use origin::parse_origin_spec;
 pub use overlay::{EnvDomain, EnvOverlay, LoadedConfig};
+pub use stub::{DegradedServer, StubStatus};

--- a/crates/service/src/mcp.rs
+++ b/crates/service/src/mcp.rs
@@ -62,8 +62,8 @@ use std::sync::Arc;
 
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
-    CallToolResult, ContentBlock, ErrorData, ListToolsResult, PaginatedRequestParams,
-    ProgressNotificationParam, ServerCapabilities, ServerInfo, Tool,
+    CallToolResult, ContentBlock, ErrorData, Implementation, ListToolsResult,
+    PaginatedRequestParams, ProgressNotificationParam, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
 use rmcp::{Peer, RoleServer, ServerHandler, tool, tool_handler, tool_router};
@@ -748,9 +748,13 @@ impl ServerHandler for McpServer {
     /// and follows the engine's read-only mode, read-write and read-only intros
     /// alike. The daemon and the embedded stdio stack refresh the
     /// virtual-domain routing cache just before this runs, so the sync render
-    /// reads a current cache and never blocks on the store.
+    /// reads a current cache and never blocks on the store. `server_info` is
+    /// also set explicitly: `ServerInfo::default()` leaves
+    /// `Implementation::from_build_env()`, which would report the rmcp crate's
+    /// own name and version to harness logs rather than crystalline's.
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::default();
+        info.server_info = Implementation::new("crystalline", crystalline_core::VERSION);
         info.instructions = Some(self.engine.routing_text());
         info.capabilities = ServerCapabilities::builder()
             .enable_tools()

--- a/crates/service/src/overlay.rs
+++ b/crates/service/src/overlay.rs
@@ -83,6 +83,12 @@ const RESERVED_VARS: &[&str] = &[
     "CRYSTALLINE_HEARTBEAT_SECS",
     "CRYSTALLINE_STALE_SECS",
     "CRYSTALLINE_TEST_POSTGRES_URL",
+    // The install-channel marker (see [`crate::stub::CHANNEL_ENV`]): the mcpb
+    // manifest sets it so the degraded status server can tell the Desktop
+    // extension apart from a plain install. It is read straight from the
+    // environment in `crate::stub`, never through the settings registry, so
+    // reserve it here or every mcpb session logs a spurious warning.
+    crate::stub::CHANNEL_ENV,
 ];
 
 /// An error parsing the environment overlay. The message names the offending
@@ -686,6 +692,7 @@ mod tests {
             ("CRYSTALLINE_HEARTBEAT_SECS", "5"),
             ("CRYSTALLINE_STALE_SECS", "15"),
             ("CRYSTALLINE_TEST_POSTGRES_URL", "postgres://db/test"),
+            (crate::stub::CHANNEL_ENV, "mcpb"),
         ])
         .unwrap();
         assert!(

--- a/crates/service/src/stub.rs
+++ b/crates/service/src/stub.rs
@@ -1,0 +1,450 @@
+//! The degraded status server: what `crystalline mcp` serves over stdio when
+//! the embedded stack cannot start at all (the index lock is held by another
+//! instance, the config will not load, the store will not open).
+//!
+//! A terminal startup failure used to end the process with a `-32000`
+//! `initialize` reply, which Claude Desktop renders as "Server disconnected"
+//! with no hint about what went wrong or how to fix it. Instead this module
+//! serves a minimal, always-startable MCP server: `initialize` succeeds with
+//! per-case `instructions`, and a single `status` tool reports the failure,
+//! this binary's version, the daemon that owns the index and the fix, so the
+//! model can relay it to the user rather than the whole session going dark.
+//!
+//! The most common cause is an upgrade skew: the Claude Desktop extension
+//! bundles its own `crystalline` binary, and a daemon installed another way
+//! (a newer brew, say) owns the index at a version the bundled binary is too
+//! old to displace. That case gets extension-specific copy pointing at the
+//! releases page; a plain second instance gets conflict copy; anything else
+//! gets the raw startup error and a pointer at `daemon.log`.
+
+use std::sync::Arc;
+
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, ContentBlock, ErrorData, Implementation, JsonObject,
+    ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool, ToolAnnotations,
+};
+use rmcp::service::RequestContext;
+use rmcp::{RoleServer, ServerHandler};
+use serde_json::Value;
+
+/// The install-channel marker env var. The mcpb manifest sets it to "mcpb".
+pub const CHANNEL_ENV: &str = "CRYSTALLINE_CHANNEL";
+/// The Claude Desktop extension channel value.
+pub const MCPB_CHANNEL: &str = "mcpb";
+
+/// The description of the single `status` tool, agent-facing product copy: it
+/// tells the model to relay the fix to the user rather than keeping it.
+const STATUS_TOOL_DESCRIPTION: &str = "Report why Crystalline is degraded this session: the startup failure, this binary's version, the daemon that owns the knowledge index and how to fix it. Relay the fix to the user.";
+
+/// Everything the degraded server knows about why it is degraded, gathered once
+/// at startup. The optional fields are present only when a live daemon record
+/// explains the failure; absent (not null) otherwise, which drives both the
+/// case selection and the tool payload shape.
+#[derive(Debug, Clone)]
+pub struct StubStatus {
+    /// The startup error chain, `format!("{e:#}")` of the failure that forced
+    /// the degraded server.
+    pub reason: String,
+    /// This binary's version, `crystalline_core::VERSION`.
+    pub binary_version: String,
+    /// The owning daemon's version, kept only when its pid is alive.
+    pub daemon_version: Option<String>,
+    /// The owning daemon's pid, kept only when it is alive.
+    pub daemon_pid: Option<u32>,
+    /// The install channel from `CRYSTALLINE_CHANNEL`, when set.
+    pub channel: Option<String>,
+}
+
+/// Which explanatory copy the degraded server renders, chosen once from the
+/// gathered status. Private: the exact copy per case is the public contract,
+/// not the discriminant.
+enum StubCase {
+    /// A strictly newer daemon owns the index and this is the Desktop
+    /// extension: point the user at the releases page and an over-install.
+    OutdatedMcpb,
+    /// A strictly newer daemon owns the index and this is a plain install:
+    /// tell the user to update this installation.
+    OutdatedBinary,
+    /// A live instance owns the index but is not the newer-daemon skew (equal,
+    /// older or unparseable version): a plain conflict naming its pid.
+    Conflict,
+    /// No live record explains the failure: surface the raw startup error and
+    /// point at daemon.log.
+    Other,
+}
+
+impl StubStatus {
+    /// Gather the degraded status from the environment: the owning daemon
+    /// record (kept only when its pid is still alive, so a dead pid never
+    /// masquerades as a conflict) and the install channel. `reason` is the
+    /// startup error chain that forced the degraded server.
+    pub fn gather(reason: String) -> StubStatus {
+        let live = crate::instance::read_lock_info()
+            .filter(|info| crate::instance::process_alive(info.pid));
+        StubStatus {
+            reason,
+            binary_version: crystalline_core::VERSION.to_string(),
+            daemon_version: live.as_ref().map(|info| info.version.clone()),
+            daemon_pid: live.as_ref().map(|info| info.pid),
+            channel: std::env::var(CHANNEL_ENV).ok(),
+        }
+    }
+
+    /// Which case's copy to render. A live daemon record strictly newer than
+    /// this binary is the upgrade skew (extension vs plain install by channel);
+    /// any other live record is a plain conflict; no live record is generic.
+    fn case(&self) -> StubCase {
+        match &self.daemon_version {
+            Some(daemon) if crate::instance::strictly_newer(daemon, &self.binary_version) => {
+                if self.channel.as_deref() == Some(MCPB_CHANNEL) {
+                    StubCase::OutdatedMcpb
+                } else {
+                    StubCase::OutdatedBinary
+                }
+            }
+            Some(_) => StubCase::Conflict,
+            None => StubCase::Other,
+        }
+    }
+
+    /// The `instructions` string handed to the connecting agent, per case. The
+    /// model reads this at initialize and relays the fix to the user. The
+    /// per-case optional fields are exactly the ones the case selection
+    /// guarantees present, so a missing one degrades to an empty substitution
+    /// rather than surfacing a placeholder.
+    pub fn instructions(&self) -> String {
+        let bin = &self.binary_version;
+        let daemon = self.daemon_version.as_deref().unwrap_or_default();
+        let pid = self.daemon_pid.unwrap_or_default();
+        let reason = &self.reason;
+        match self.case() {
+            StubCase::OutdatedMcpb => format!(
+                "Crystalline is running in degraded mode: this Crystalline extension (v{bin}) is older than the Crystalline daemon (v{daemon}) that owns this machine's knowledge, so no knowledge tools are available this session. Ask the user to download the latest Crystalline extension from https://github.com/jordiboehme/crystalline/releases and install it over the current one, then start a new conversation. Call the status tool for the full details to relay."
+            ),
+            StubCase::OutdatedBinary => format!(
+                "Crystalline is running in degraded mode: this crystalline binary (v{bin}) is older than the Crystalline daemon (v{daemon}) that owns this machine's knowledge, so no knowledge tools are available this session. Ask the user to update this Crystalline installation to v{daemon} or newer, then reconnect. Call the status tool for the full details to relay."
+            ),
+            StubCase::Conflict => format!(
+                "Crystalline is running in degraded mode: another Crystalline instance (pid {pid}) owns this machine's knowledge index and it could not be reached, so no knowledge tools are available this session. Ask the user to check or restart that instance, then reconnect. Call the status tool for the full details to relay."
+            ),
+            StubCase::Other => format!(
+                "Crystalline is running in degraded mode: it failed to start ({reason}), so no knowledge tools are available this session. Ask the user to check daemon.log in the Crystalline state directory. Call the status tool for the full details to relay."
+            ),
+        }
+    }
+
+    /// The one-line fix, per case, carried in the tool payload and appended to
+    /// the error a stale tool call gets.
+    pub fn fix(&self) -> String {
+        let daemon = self.daemon_version.as_deref().unwrap_or_default();
+        let pid = self.daemon_pid.unwrap_or_default();
+        match self.case() {
+            StubCase::OutdatedMcpb =>
+                "Download the latest Crystalline extension (.mcpb) from https://github.com/jordiboehme/crystalline/releases and install it over the current extension, then start a new conversation.".to_string(),
+            StubCase::OutdatedBinary => format!(
+                "Update this Crystalline installation to v{daemon} or newer, then reconnect."
+            ),
+            StubCase::Conflict => format!(
+                "Check or restart the Crystalline instance with pid {pid}, then reconnect."
+            ),
+            StubCase::Other =>
+                "Check daemon.log in the Crystalline state directory for the startup error, then reconnect.".to_string(),
+        }
+    }
+
+    /// The `status` tool's JSON body: `available` is always false, `reason`,
+    /// `binary_version` and `fix` are always present, and the daemon fields and
+    /// channel are present only when known (absent, never null, otherwise).
+    pub fn tool_payload(&self) -> Value {
+        let mut map = serde_json::Map::new();
+        map.insert("available".to_string(), Value::Bool(false));
+        map.insert("reason".to_string(), Value::String(self.reason.clone()));
+        map.insert(
+            "binary_version".to_string(),
+            Value::String(self.binary_version.clone()),
+        );
+        if let Some(version) = &self.daemon_version {
+            map.insert("daemon_version".to_string(), Value::String(version.clone()));
+        }
+        if let Some(pid) = self.daemon_pid {
+            map.insert("daemon_pid".to_string(), Value::Number(pid.into()));
+        }
+        if let Some(channel) = &self.channel {
+            map.insert("channel".to_string(), Value::String(channel.clone()));
+        }
+        map.insert("fix".to_string(), Value::String(self.fix()));
+        Value::Object(map)
+    }
+}
+
+/// The degraded MCP server: an [`Arc`] status shared across the rmcp handler's
+/// cloned copies. Every fallible startup step already ran before this exists,
+/// so serving it cannot fail; `initialize`, ping and protocol negotiation come
+/// free from rmcp's [`ServerHandler`] defaults.
+#[derive(Clone)]
+pub struct DegradedServer {
+    status: Arc<StubStatus>,
+}
+
+impl DegradedServer {
+    /// Build a degraded server around the gathered status.
+    pub fn new(status: StubStatus) -> DegradedServer {
+        DegradedServer {
+            status: Arc::new(status),
+        }
+    }
+
+    /// The single `status` tool: an empty-object input schema (it takes no
+    /// arguments) and read-only, closed-world annotations, so a client can
+    /// batch it and skip a confirmation prompt.
+    fn status_tool() -> Tool {
+        let input_schema: JsonObject = match serde_json::json!({ "type": "object", "properties": {} })
+        {
+            Value::Object(map) => map,
+            _ => unreachable!("an object literal is an object"),
+        };
+        Tool::new("status", STATUS_TOOL_DESCRIPTION, input_schema)
+            .with_title("Crystalline status")
+            .annotate(
+                ToolAnnotations::with_title("Crystalline status")
+                    .read_only(true)
+                    .open_world(false),
+            )
+    }
+}
+
+impl ServerHandler for DegradedServer {
+    /// The degraded handshake: identify as `crystalline` at this binary's
+    /// version and hand the connecting agent the per-case degraded copy as its
+    /// `instructions`, advertising only the tools capability.
+    fn get_info(&self) -> ServerInfo {
+        let mut info = ServerInfo::default();
+        info.server_info = Implementation::new("crystalline", crystalline_core::VERSION);
+        info.instructions = Some(self.status.instructions());
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info
+    }
+
+    /// The degraded surface is exactly the one `status` tool.
+    async fn list_tools(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        Ok(ListToolsResult {
+            tools: vec![Self::status_tool()],
+            meta: None,
+            next_cursor: None,
+        })
+    }
+
+    /// Resolve `status` by name; every other name is unknown here.
+    fn get_tool(&self, name: &str) -> Option<Tool> {
+        (name == "status").then(Self::status_tool)
+    }
+
+    /// `status` returns the compact JSON payload as a single text block, the
+    /// same single-text-block convention the healthy server uses. Any other
+    /// tool name - a client replaying a stale tool list from a healthy session
+    /// will call `search_engrams` and the like - gets a tool-level error (not a
+    /// protocol `Err`, which clients render opaquely) carrying the instructions
+    /// and the fix, so the model learns why the call failed and what to relay.
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if request.name == "status" {
+            let text = serde_json::to_string(&self.status.tool_payload())
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+            Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
+        } else {
+            let text = format!("{}\n\n{}", self.status.instructions(), self.status.fix());
+            Ok(CallToolResult::error(vec![ContentBlock::text(text)]))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a status directly (no lock, no env): unit tests never touch the
+    /// process environment, which is global and would race nextest's
+    /// concurrent tests; the channel is the struct field instead.
+    fn status(
+        daemon_version: Option<&str>,
+        daemon_pid: Option<u32>,
+        channel: Option<&str>,
+    ) -> StubStatus {
+        StubStatus {
+            reason: "cannot run an embedded MCP server: another Crystalline instance owns the index (pid 4242)".to_string(),
+            binary_version: "0.8.2".to_string(),
+            daemon_version: daemon_version.map(str::to_string),
+            daemon_pid,
+            channel: channel.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn newer_daemon_on_the_mcpb_channel_points_at_the_releases_page() {
+        let s = status(Some("0.9.0"), Some(4242), Some(MCPB_CHANNEL));
+        let instructions = s.instructions();
+        assert!(
+            instructions.contains("https://github.com/jordiboehme/crystalline/releases"),
+            "instructions carry the releases URL:\n{instructions}"
+        );
+        assert!(
+            instructions.contains("install it over the current"),
+            "instructions tell the user to over-install:\n{instructions}"
+        );
+        let fix = s.fix();
+        assert!(
+            fix.contains("https://github.com/jordiboehme/crystalline/releases"),
+            "fix carries the releases URL:\n{fix}"
+        );
+        assert!(
+            fix.contains("install it over the current"),
+            "fix tells the user to over-install:\n{fix}"
+        );
+    }
+
+    #[test]
+    fn newer_daemon_without_a_channel_tells_the_user_to_update_this_installation() {
+        let s = status(Some("0.9.0"), Some(4242), None);
+        let instructions = s.instructions();
+        assert!(
+            instructions.contains("update this Crystalline installation to v0.9.0 or newer"),
+            "instructions name the target version:\n{instructions}"
+        );
+        assert!(
+            s.fix()
+                .contains("Update this Crystalline installation to v0.9.0 or newer"),
+            "fix names the target version:\n{}",
+            s.fix()
+        );
+    }
+
+    #[test]
+    fn an_equal_version_live_record_is_a_plain_conflict() {
+        let s = status(Some("0.8.2"), Some(4242), None);
+        let instructions = s.instructions();
+        assert!(
+            instructions.contains("owns this machine's knowledge index"),
+            "conflict copy:\n{instructions}"
+        );
+        assert!(
+            instructions.contains("pid 4242"),
+            "names the pid:\n{instructions}"
+        );
+        assert!(
+            !instructions.contains("update this Crystalline installation"),
+            "no binary-update hint:\n{instructions}"
+        );
+        assert!(
+            !instructions.contains("install it over the current"),
+            "no over-install hint:\n{instructions}"
+        );
+        assert!(
+            s.fix().contains("pid 4242"),
+            "fix names the pid:\n{}",
+            s.fix()
+        );
+    }
+
+    #[test]
+    fn an_unparseable_record_version_is_a_plain_conflict() {
+        let s = status(Some("garbage"), Some(4242), Some(MCPB_CHANNEL));
+        let instructions = s.instructions();
+        assert!(
+            instructions.contains("owns this machine's knowledge index"),
+            "conflict copy despite the mcpb channel:\n{instructions}"
+        );
+        assert!(
+            instructions.contains("pid 4242"),
+            "names the pid:\n{instructions}"
+        );
+        assert!(
+            !instructions.contains("install it over the current"),
+            "an unparseable version is never the newer-daemon skew:\n{instructions}"
+        );
+    }
+
+    #[test]
+    fn no_live_record_carries_the_raw_reason() {
+        let s = status(None, None, None);
+        let instructions = s.instructions();
+        assert!(
+            instructions.contains(&s.reason),
+            "generic copy carries the reason:\n{instructions}"
+        );
+        assert!(
+            instructions.contains("daemon.log"),
+            "generic copy points at daemon.log:\n{instructions}"
+        );
+        assert!(
+            s.fix().contains("daemon.log"),
+            "generic fix points at daemon.log:\n{}",
+            s.fix()
+        );
+    }
+
+    #[test]
+    fn tool_payload_omits_unknown_keys_and_keeps_known_ones() {
+        let s = status(Some("0.9.0"), Some(4242), Some("mcpb"));
+        let payload = s.tool_payload();
+        assert_eq!(payload["available"], serde_json::json!(false));
+        assert_eq!(payload["reason"], serde_json::json!(s.reason));
+        assert_eq!(payload["binary_version"], serde_json::json!("0.8.2"));
+        assert_eq!(payload["daemon_version"], serde_json::json!("0.9.0"));
+        assert_eq!(payload["daemon_pid"], serde_json::json!(4242));
+        assert_eq!(payload["channel"], serde_json::json!("mcpb"));
+        assert_eq!(payload["fix"], serde_json::json!(s.fix()));
+
+        let bare = status(None, None, None).tool_payload();
+        let obj = bare.as_object().unwrap();
+        assert_eq!(obj["available"], serde_json::json!(false));
+        assert!(
+            !obj.contains_key("daemon_version"),
+            "absent, not null: {bare}"
+        );
+        assert!(!obj.contains_key("daemon_pid"), "absent, not null: {bare}");
+        assert!(!obj.contains_key("channel"), "absent, not null: {bare}");
+        assert!(obj.contains_key("fix"), "fix is always present: {bare}");
+    }
+
+    #[test]
+    fn the_status_tool_declares_an_empty_schema_and_a_read_only_annotation() {
+        let tool = DegradedServer::status_tool();
+        assert_eq!(tool.name, "status");
+        let schema = tool.input_schema.as_ref();
+        assert_eq!(schema.get("type"), Some(&serde_json::json!("object")));
+        assert!(
+            schema
+                .get("properties")
+                .and_then(Value::as_object)
+                .is_some_and(|p| p.is_empty()),
+            "empty properties: {schema:?}"
+        );
+        let annotations = tool.annotations.as_ref().expect("annotations present");
+        assert_eq!(annotations.read_only_hint, Some(true));
+        assert_eq!(annotations.open_world_hint, Some(false));
+    }
+
+    #[test]
+    fn no_produced_string_carries_an_em_or_en_dash() {
+        let cases = [
+            status(Some("0.9.0"), Some(4242), Some(MCPB_CHANNEL)),
+            status(Some("0.9.0"), Some(4242), None),
+            status(Some("0.8.2"), Some(4242), None),
+            status(Some("garbage"), Some(4242), None),
+            status(None, None, None),
+        ];
+        for s in &cases {
+            for text in [s.instructions(), s.fix(), s.tool_payload().to_string()] {
+                assert!(!text.contains('\u{2014}'), "em dash in:\n{text}");
+                assert!(!text.contains('\u{2013}'), "en dash in:\n{text}");
+            }
+        }
+    }
+}

--- a/crates/service/tests/mcp_instructions.rs
+++ b/crates/service/tests/mcp_instructions.rs
@@ -135,6 +135,10 @@ async fn instructions_carry_a_routing_line_per_file_domain() {
     let (client, _server) = h.connect().await;
     let text = instructions(&client);
 
+    let peer_info = client.peer().peer_info().unwrap();
+    assert_eq!(peer_info.server_info.name, "crystalline");
+    assert_eq!(peer_info.server_info.version, crystalline_core::VERSION);
+
     assert!(
         text.starts_with("CRYSTALLINE KNOWLEDGE ROUTING"),
         "header first:\n{text}"

--- a/crates/service/tests/stub.rs
+++ b/crates/service/tests/stub.rs
@@ -1,0 +1,137 @@
+//! In-process rmcp duplex tests for the degraded status server.
+//!
+//! A `tokio::io::duplex` pair connects a real rmcp client to a
+//! [`DegradedServer`] in the same process, driving the actual JSON-RPC
+//! initialize handshake, `tools/list` and `tools/call`. `StubStatus`'s fields
+//! are public, so the status is built directly with no lock, socket or
+//! environment involved; the same duplex pattern as `tests/mcp_instructions.rs`.
+
+use crystalline_service::{DegradedServer, StubStatus};
+use rmcp::model::CallToolRequestParams;
+use rmcp::service::RunningService;
+use rmcp::{RoleClient, RoleServer};
+use serde_json::Value;
+
+/// A newer-daemon-on-mcpb status: the upgrade-skew case whose copy points at
+/// the releases page, so a single fixture exercises the interesting path.
+fn mcpb_skew_status() -> StubStatus {
+    StubStatus {
+        reason: "cannot run an embedded MCP server: another Crystalline instance owns the index (pid 4242)".to_string(),
+        binary_version: crystalline_core::VERSION.to_string(),
+        daemon_version: Some("99.0.0".to_string()),
+        daemon_pid: Some(4242),
+        channel: Some("mcpb".to_string()),
+    }
+}
+
+/// Open one rmcp connection to a degraded server carrying `status`. The server
+/// handshake blocks until the client sends `initialize`, so the two run
+/// concurrently, exactly as in the healthy-server harness.
+async fn connect(
+    status: StubStatus,
+) -> (
+    RunningService<RoleClient, ()>,
+    RunningService<RoleServer, DegradedServer>,
+) {
+    let (client_io, server_io) = tokio::io::duplex(1 << 16);
+    let server_task =
+        tokio::spawn(
+            async move { rmcp::serve_server(DegradedServer::new(status), server_io).await },
+        );
+    let client = rmcp::serve_client((), client_io).await.unwrap();
+    let server = server_task.await.unwrap().unwrap();
+    (client, server)
+}
+
+/// The text of a tool result's first content block.
+fn first_text(result: &rmcp::model::CallToolResult) -> String {
+    let v = serde_json::to_value(result).unwrap();
+    v.pointer("/content/0/text")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initialize_succeeds_and_identifies_as_crystalline_with_degraded_copy() {
+    let (client, _server) = connect(mcpb_skew_status()).await;
+    let info = client
+        .peer()
+        .peer_info()
+        .expect("the server sent its handshake");
+    assert_eq!(
+        info.server_info.name, "crystalline",
+        "identifies as crystalline"
+    );
+    assert_eq!(
+        info.server_info.version,
+        crystalline_core::VERSION,
+        "at this binary's version"
+    );
+    let instructions = info
+        .instructions
+        .clone()
+        .expect("degraded instructions present");
+    assert!(
+        instructions.contains("degraded mode"),
+        "instructions announce degraded mode:\n{instructions}"
+    );
+    assert!(
+        instructions.contains("https://github.com/jordiboehme/crystalline/releases"),
+        "the mcpb skew points at the releases page:\n{instructions}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn tools_list_exposes_exactly_the_status_tool() {
+    let (client, _server) = connect(mcpb_skew_status()).await;
+    let tools = client.peer().list_all_tools().await.unwrap();
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+    assert_eq!(
+        names,
+        ["status"],
+        "exactly one tool named status: {names:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn calling_status_returns_the_json_payload() {
+    let (client, _server) = connect(mcpb_skew_status()).await;
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("status"))
+        .await
+        .unwrap();
+    let payload: Value = serde_json::from_str(&first_text(&result)).expect("payload is JSON");
+    assert_eq!(payload["available"], serde_json::json!(false));
+    assert_eq!(payload["daemon_version"], serde_json::json!("99.0.0"));
+    assert_eq!(payload["daemon_pid"], serde_json::json!(4242));
+    assert_eq!(payload["channel"], serde_json::json!("mcpb"));
+    assert!(
+        payload["fix"].as_str().is_some_and(|f| !f.is_empty()),
+        "fix present: {payload}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_stale_real_tool_call_is_a_tool_error_carrying_the_fix() {
+    let (client, _server) = connect(mcpb_skew_status()).await;
+    // A client replaying a cached tool list from a healthy session calls a real
+    // tool by name; it must learn why it failed, not get an opaque protocol
+    // error, so the call succeeds at the protocol level with is_error set.
+    let result = client
+        .peer()
+        .call_tool(CallToolRequestParams::new("search_engrams"))
+        .await
+        .expect("a stale tool call is a tool-level error, not a protocol error");
+    assert_eq!(
+        result.is_error,
+        Some(true),
+        "the result is flagged an error"
+    );
+    let text = first_text(&result);
+    assert!(
+        text.contains("install it over the current extension"),
+        "the error carries the fix to relay:\n{text}"
+    );
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,6 +34,8 @@ flowchart LR
     D --> I[Index]
 ```
 
+Sometimes the bundled binary can neither reach the daemon nor take the index lock, typically because the extension is older than a Crystalline installed another way (a Homebrew install after a `brew upgrade`, say). The session still connects instead of failing: the server comes up degraded with a single `status` tool and instructions that tell the model (and through it the user) to download the latest extension from the GitHub releases page and install it over the current one. Claude Desktop has no in-app update mechanism for an extension, so installing the downloaded `.mcpb` over the existing one is the update path.
+
 ## Team server
 
 For a team, run the GHCR image (see [Run in a container](#run-in-a-container)) via `examples/docker/compose.yaml`: the daemon listens on `--http 0.0.0.0:7411` and every agent on the network reaches it over streamable HTTP instead of stdio. Knowledge is bind-mounted from the host so it stays exactly the same markdown files, a `/data` volume holds the disposable index, and the slim `latest` image downloads the model into that same volume once (pick `with-model` instead to skip the download). Agents that reach the daemon by a hostname rather than `localhost` need that host in `CRYSTALLINE_SERVICE_ALLOWED_HOSTS` (the transport validates the `Host` header; see [Configure through environment variables](#configure-through-environment-variables)). See [Run in a container](#run-in-a-container) for the compose file and image tags.
@@ -193,6 +195,7 @@ An immutable image with no `config.yaml` to mount or edit configures purely thro
 | `CRYSTALLINE_DOMAIN_<NAME>_ORIGIN` | `owner/repo[/subpath][@branch]` | bootstraps the domain on first start |
 | `CRYSTALLINE_GITHUB_TOKEN` | this machine's GitHub token | read-only; `connect github` refuses while set |
 | `CRYSTALLINE_MODELS_DIR` | the model cache path | pre-existing, unchanged |
+| `CRYSTALLINE_CHANNEL` | install channel marker | set to `mcpb` by the Claude Desktop extension manifest so degraded-startup copy tells the user to update the extension rather than the binary; not meant to be set by hand |
 
 `<NAME>` in a domain variable is lowercased with underscores turned into hyphens for the domain name itself (`CRYSTALLINE_DOMAIN_TEAM_KNOWLEDGE` becomes the domain `team-knowledge`). Precedence, highest first: a command-line flag, then an environment variable, then `config.yaml`, then the built-in default; an environment value is never written back to the config file.
 

--- a/packaging/mcpb/README.md
+++ b/packaging/mcpb/README.md
@@ -1,6 +1,6 @@
 # MCP Bundle packaging
 
-This folder holds `generate-manifest.sh`, which writes the `manifest.json` for a Crystalline MCP Bundle (`.mcpb`) given a platform, a version and an output directory, and stages the bundle icon (`icon.png`, copied from `assets/crystalline.png`) next to it. It does not build anything itself; it only describes an already-built `crystalline` binary to Claude Desktop and other MCPB hosts.
+This folder holds `generate-manifest.sh`, which writes the `manifest.json` for a Crystalline MCP Bundle (`.mcpb`) given a platform, a version and an output directory, and stages the bundle icon (`icon.png`, copied from `assets/crystalline.png`) next to it. It does not build anything itself; it only describes an already-built `crystalline` binary to Claude Desktop and other MCPB hosts. The generated manifest sets `CRYSTALLINE_CHANNEL=mcpb` in `server.mcp_config.env`, so the binary can tell it runs as the Claude Desktop extension and tailor degraded-startup copy (and future update hints) to that channel.
 
 The `mcpb` job in `.github/workflows/release.yml` calls this script once per platform, stages the release binary next to the generated manifest, then runs `@anthropic-ai/mcpb validate` and `@anthropic-ai/mcpb pack` to produce the six `.mcpb` files attached to each release.
 

--- a/packaging/mcpb/generate-manifest.sh
+++ b/packaging/mcpb/generate-manifest.sh
@@ -110,7 +110,9 @@ cat >"$manifest_path" <<JSON
     "mcp_config": {
       "command": "$command_path",
       "args": ["mcp"],
-      "env": {}
+      "env": {
+        "CRYSTALLINE_CHANNEL": "mcpb"
+      }
     }
   },
   "compatibility": {


### PR DESCRIPTION
## What

When \`crystalline mcp\` hits a terminal embedded-startup failure (the index lock held by another instance, a config or store error), it used to answer \`initialize\` with a \`-32000\` error and exit. Claude Desktop renders that as "Server disconnected" with no hint - the exact failure mode a bundled extension binary hits after the daemon was upgraded through another channel (e.g. \`brew upgrade\`).

Now the session connects instead of dying: a minimal degraded MCP server answers \`initialize\` with per-case instructions and exposes a single \`status\` tool reporting the failure, this binary's version, the daemon that owns the index and how to fix it, so the model can relay the fix to the user.

- Case selection: a strictly newer live daemon is upgrade skew (mcpb channel gets "download the latest extension from the releases page and install it over the current one", other installs get a plain update hint), any other live record is a conflict naming the pid, no readable record surfaces the raw reason.
- The mcpb manifest now sets \`CRYSTALLINE_CHANNEL=mcpb\` so the binary knows it runs as the Claude Desktop extension; the var is reserved in the env overlay.
- \`McpServer::get_info\` now reports \`crystalline\`/its real version instead of rmcp's own name and version in harness logs.
- The embedded path is split so every fallible startup step runs before the primed initialize reader is consumed; the old \`-32000\` reply survives only as a last resort if the stub itself fails to serve.
- Docs: deployment guide env table row and a degraded-mode paragraph in the Claude Desktop extension section, plus a note in the mcpb packaging README.

## Testing

- 16 new tests: stub copy/case unit tests, \`strictly_newer\` truth table, in-process rmcp duplex tests and real-binary integration tests holding a cross-process lock (plus one ignored 15s test mirroring the field incident)
- Full gates green: nextest 1061/1061, doctests, clippy \`-D warnings\`, fmt, style-lint
- Manual end-to-end: fake newer-daemon record + mcpb channel serves the degraded stub with releases-URL copy and exits 0; real daemon relay regression unchanged (routing instructions, full toolset, no stub)