### PR TITLE
Performance, reliability and UX improvements from the codebase audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "crystalline"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "crystalline-core"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "crystalline-index"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "async-trait",
  "candle-core",
@@ -1208,7 +1208,7 @@ dependencies = [
 
 [[package]]
 name = "crystalline-remote"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "crystalline-service"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,3 +101,7 @@ tempfile = "3.27.0"
 # untouched.
 [profile.dev]
 debug = "line-tables-only"
+
+[profile.release]
+lto = "thin"
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.6"
+version = "0.8.7"
 authors = ["Jordi Boehme <jordi@boehme-lopez.de>"]
 edition = "2024"
 license = "AGPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -312,14 +312,14 @@ github:
 `crystalline verify` statically checks one or more domains against the full rule catalog - malformed frontmatter, broken links, missing MANIFEST sections, schema drift - with no database, service or network connection involved. Its usual home is CI/CD on the GitHub repositories that hold a team's knowledge: every proposal is verified before the team merges it, so nothing malformed ever lands on the branch everyone pulls from. The bundled GitHub Action wires that up:
 
 ```yaml
-- uses: jordiboehme/crystalline/action@v0.8.6
+- uses: jordiboehme/crystalline/action@v0.8.7
   with:
     paths: knowledge/       # space-separated domain roots, default '.'
     strict: 'false'         # promote Warning rules to Error
-    version: v0.8.6         # crystalline binary tag to download, or 'latest'
+    version: v0.8.7         # crystalline binary tag to download, or 'latest'
 ```
 
-The action ref (`@v0.8.6`) pins the action's own code; `version` pins the crystalline binary it downloads, so pinning both gives a fully reproducible check. The binary is checksum-verified, then the action runs `crystalline verify`, annotates the run and, on a pull request, posts a single summary comment kept up to date in place.
+The action ref (`@v0.8.7`) pins the action's own code; `version` pins the crystalline binary it downloads, so pinning both gives a fully reproducible check. The binary is checksum-verified, then the action runs `crystalline verify`, annotates the run and, on a pull request, posts a single summary comment kept up to date in place.
 
 Two more commands keep a knowledge base trustworthy:
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ github:
 
 The action ref (`@v0.8.7`) pins the action's own code; `version` pins the crystalline binary it downloads, so pinning both gives a fully reproducible check. The binary is checksum-verified, then the action runs `crystalline verify`, annotates the run and, on a pull request, posts a single summary comment kept up to date in place.
 
-Two more commands keep a knowledge base trustworthy:
+Two more commands keep your knowledge trustworthy:
 
 - **`crystalline import <src> --domain <name>`** brings an existing markdown-plus-frontmatter knowledge base under Crystalline: normalizes legacy `type` values, backfills `status` and temporal metadata, drops sentinel far-future dates in favor of leaving the field open-ended, and adds a missing `timestamp` - all as a pure file transformation, with `--dry-run` to preview first.
 - **`crystalline doctor`** diagnoses the index, registered domains and service state (orphan index rows, encoding issues, stale service locks) and repairs what it safely can with `--fix`. Once team domains are turned on it also reports whether this machine is connected to GitHub and whether each team domain's local origin state is intact. When a domain ships provisioned artifacts, it reports every declaring domain's decision and shipped counts and every installed harness's drift, locally edited and orphaned counts against what was last reconciled - that part, like the GitHub checks, is always report-only, `--fix` never reconciles a harness.
@@ -336,7 +336,7 @@ Crystalline runs the same way in every scenario: a daemon in the middle keeps on
 | [Claude Desktop extension](docs/deployment.md#claude-desktop-extension) | One-click `.mcpb` install, no terminal involved; the agent creates domains at runtime |
 | [Team server](docs/deployment.md#team-server) | One container on the network, every agent connects over HTTP |
 | [Linux server with systemd](docs/deployment.md#linux-server-with-systemd) | The .deb ships a unit, disabled by default; enable it once and agents connect over HTTP |
-| [Published read-only knowledge base](docs/deployment.md#published-read-only-knowledge-base) | Knowledge curated in a git repository, served read-only to agents |
+| [Published read-only domains](docs/deployment.md#published-read-only-domains) | Knowledge curated in a git repository, served read-only to agents |
 | [Air-gapped or egress-restricted](docs/deployment.md#air-gapped-or-egress-restricted) | The `with-model` image or a pre-fetched model directory; nothing at runtime needs the network |
 | [Shared database collaboration](docs/deployment.md#shared-database-collaboration) | Several instances share one PostgreSQL index, so every capture is visible to all |
 | [Team knowledge on GitHub](docs/deployment.md#team-knowledge-on-github) | A domain tracks a GitHub repository; sharing goes through reviewed proposals |
@@ -347,10 +347,10 @@ Most domains are folders of files. A virtual domain is the other option: its eng
 
 ```sh
 # Register a database-backed domain and scaffold its MANIFEST into the index.
-crystalline domain add notes --virtual
+crystalline domain add decisions --virtual
 
 # It works with the same tools as any domain.
-crystalline write notes "First note" --content "captured straight into the database"
+crystalline write decisions "First decision" --content "captured straight into the database"
 crystalline search "captured"
 ```
 

--- a/crates/cli/src/cmd.rs
+++ b/crates/cli/src/cmd.rs
@@ -111,6 +111,44 @@ pub(crate) fn resolve_domain_path(entry: &DomainEntry) -> Option<PathBuf> {
     entry.file_path().filter(|_| !entry.is_virtual())
 }
 
+// --- relative time -------------------------------------------------------------
+
+/// Bucket a duration in seconds into a compact human string: `42s`, `12m`,
+/// `3h` or `4d`. The single-unit sibling of `main.rs`'s `format_uptime`
+/// (which keeps its own `3h07m` minute precision for a live daemon's "up"
+/// line); this is the coarser granularity a "how long ago" reading wants.
+fn humanize_duration(secs: u64) -> String {
+    if secs >= 86_400 {
+        format!("{}d", secs / 86_400)
+    } else if secs >= 3_600 {
+        format!("{}h", secs / 3_600)
+    } else if secs >= 60 {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{secs}s")
+    }
+}
+
+/// Render an ISO-8601 timestamp as `<duration> ago` for human output
+/// (`5m ago`, `2h ago`, `3d ago`). Used for `status`'s last-sync column, the
+/// domain list's host heartbeat and `origin status`'s last-checked line - every
+/// place a raw timestamp reads worse to a person than how long ago it was.
+/// Falls back to the value unchanged when it does not parse as a timestamp,
+/// or names a future instant (clock skew, a deliberately future value, where
+/// "ago" would mislead), so a caller can pass any string straight through
+/// without an `Option` dance. `--json` output always keeps the raw ISO
+/// string; this is for human rendering only.
+pub(crate) fn relative_time(value: &str) -> String {
+    let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(value) else {
+        return value.to_string();
+    };
+    let secs = (chrono::Utc::now() - parsed.with_timezone(&chrono::Utc)).num_seconds();
+    if secs < 0 {
+        return value.to_string();
+    }
+    format!("{} ago", humanize_duration(secs as u64))
+}
+
 // --- domain init -------------------------------------------------------------
 
 /// Scaffold a MANIFEST.md at a domain root if one is absent. Never touches the
@@ -166,9 +204,17 @@ pub fn domain_init(path: &Path, name: Option<&str>, json: bool) -> Result<()> {
 /// Returns the canonicalized domain root; indexing is a separate step (see
 /// [`sync_domain_direct`]) so the daemon-dispatch decision stays in `main.rs`,
 /// alongside `sync` and `reindex`'s own dispatch.
+///
+/// An absent `path` defaults to `<domains_root>/<name>` through
+/// [`crystalline_service::default_domain_folder`], the same placement rule
+/// the MCP `add_domain` tool's local-domain path uses (`Engine::domain_add_local`),
+/// so both entry points agree on where an unrooted domain ends up. The
+/// default path still needs a pre-scaffolded `MANIFEST.md`, exactly like an
+/// explicit path does - `domain add` never auto-creates one, `domain init`
+/// does.
 pub(crate) fn domain_add_register(
     name: &str,
-    path: &Path,
+    path: Option<&Path>,
     config_override: Option<&Path>,
 ) -> Result<PathBuf> {
     // Mutate the file truth and save it back to the resolved path; the
@@ -182,15 +228,20 @@ pub(crate) fn domain_add_register(
         );
     }
 
-    let manifest = path.join("MANIFEST.md");
+    let root = match path {
+        Some(p) => p.to_path_buf(),
+        None => crystalline_service::default_domain_folder(&loaded.effective.domains_root(), name),
+    };
+
+    let manifest = root.join("MANIFEST.md");
     if !manifest.exists() {
         bail!(
             "no MANIFEST.md at {}. Run: crystalline domain init {}",
-            path.display(),
-            path.display()
+            root.display(),
+            root.display()
         );
     }
-    let abs = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let abs = std::fs::canonicalize(&root).unwrap_or_else(|_| root.clone());
 
     let mut cfg = loaded.file;
     cfg.domains
@@ -741,9 +792,17 @@ pub async fn domain_list(
         if loaded.overlay.env_domain(name).is_some() {
             location.push_str(" (env)");
         }
-        // In a shared database a file domain names the instance that hosts it.
+        // In a shared database a file domain names the instance that hosts
+        // it, along with how recently it last heartbeat.
         let host = host_for(name)
-            .map(|(id, _)| format!("\thosted by {id}"))
+            .map(|(id, hb)| {
+                let heartbeat = hb.as_deref().map(relative_time).unwrap_or_default();
+                if heartbeat.is_empty() {
+                    format!("\thosted by {id}")
+                } else {
+                    format!("\thosted by {id} (heartbeat {heartbeat})")
+                }
+            })
             .unwrap_or_default();
         match count_for(name) {
             Some(n) => println!("{name}\t{location}\t{n} engrams{host}"),
@@ -775,6 +834,12 @@ pub async fn sync(
         let Some(path) = resolve_domain_path(&entry) else {
             continue;
         };
+        // A large domain's walk-hash-parse pass can take a while with no
+        // other output in between; say which domain is in flight before it
+        // starts, the same way `embed_pass` announces each batch.
+        if !json {
+            eprintln!("syncing {name}...");
+        }
         let report = sync_domain_with(&*store, &name, &path, &params)
             .await
             .map_err(|e| anyhow!("sync of '{name}' failed: {e}"))?;
@@ -939,12 +1004,19 @@ pub fn render_status(data: &serde_json::Value, daemon_note: &str) {
         .unwrap_or_default();
 
     if !data.get("indexed").and_then(Value::as_bool).unwrap_or(true) {
-        println!(
-            "No index at {} yet. Run: crystalline sync",
-            data["db_path"].as_str().unwrap_or("(unknown)")
-        );
-        for name in registered {
-            println!("{name}\t(not indexed yet)");
+        if registered.is_empty() {
+            // Nothing registered at all: pointing at `sync` here would send a
+            // first-time user in a circle, since sync has nothing to sync
+            // yet either.
+            println!("No domains registered yet. Run: crystalline domain add <name> <path>");
+        } else {
+            println!(
+                "No index at {} yet. Run: crystalline sync",
+                data["db_path"].as_str().unwrap_or("(unknown)")
+            );
+            for name in registered {
+                println!("{name}\t(not indexed yet)");
+            }
         }
         return;
     }
@@ -1001,6 +1073,7 @@ pub fn render_status(data: &serde_json::Value, daemon_note: &str) {
     for d in &domains {
         let name = d["name"].as_str().unwrap_or("");
         indexed_names.insert(name.to_string());
+        let last_sync = d["last_sync"].as_str().map(relative_time);
         println!(
             "{}\t{} engrams, {} observations, {} relations ({} unresolved)\tlast sync {}",
             name,
@@ -1008,7 +1081,7 @@ pub fn render_status(data: &serde_json::Value, daemon_note: &str) {
             d["observations"].as_u64().unwrap_or(0),
             d["relations"].as_u64().unwrap_or(0),
             d["unresolved_relations"].as_u64().unwrap_or(0),
-            d["last_sync"].as_str().unwrap_or("never")
+            last_sync.as_deref().unwrap_or("never")
         );
     }
     // Registered domains the index holds no row for yet.
@@ -1519,5 +1592,43 @@ fn print_report(r: &crystalline_index::SyncReport) {
     );
     for (path, err) in &r.failed {
         println!("  failed: {path}: {err}");
+    }
+}
+
+#[cfg(test)]
+mod relative_time_tests {
+    use super::{humanize_duration, relative_time};
+
+    #[test]
+    fn humanize_duration_buckets_at_each_unit_boundary() {
+        assert_eq!(humanize_duration(0), "0s");
+        assert_eq!(humanize_duration(59), "59s");
+        assert_eq!(humanize_duration(60), "1m");
+        assert_eq!(humanize_duration(3_599), "59m");
+        assert_eq!(humanize_duration(3_600), "1h");
+        assert_eq!(humanize_duration(86_399), "23h");
+        assert_eq!(humanize_duration(86_400), "1d");
+        assert_eq!(humanize_duration(172_800), "2d");
+    }
+
+    #[test]
+    fn relative_time_renders_past_instants_as_a_duration_ago() {
+        let five_minutes_ago = (chrono::Utc::now() - chrono::Duration::minutes(5)).to_rfc3339();
+        assert_eq!(relative_time(&five_minutes_ago), "5m ago");
+
+        let three_days_ago = (chrono::Utc::now() - chrono::Duration::days(3)).to_rfc3339();
+        assert_eq!(relative_time(&three_days_ago), "3d ago");
+    }
+
+    #[test]
+    fn relative_time_falls_back_to_the_original_value_when_unparsable_or_future() {
+        assert_eq!(relative_time("never"), "never");
+        assert_eq!(relative_time(""), "");
+
+        // A future instant (clock skew, a deliberately future value) must
+        // never be rendered as "ago" - that would actively mislead.
+        let five_minutes_from_now =
+            (chrono::Utc::now() + chrono::Duration::minutes(5)).to_rfc3339();
+        assert_eq!(relative_time(&five_minutes_from_now), five_minutes_from_now);
     }
 }

--- a/crates/cli/src/cmd.rs
+++ b/crates/cli/src/cmd.rs
@@ -1366,6 +1366,15 @@ const HEALTHCHECK_DEADLINE: std::time::Duration = std::time::Duration::from_secs
 /// connection refused, a timeout, a non-200 status or a malformed response -
 /// comes back as a single-line `Err` naming the address it failed against,
 /// so the process exits nonzero through the normal error path.
+///
+/// B14 exemption: unlike the other data verbs, this default output is not given
+/// a human rendering and does not honor `--json`. The line printed here is the
+/// daemon's own `/health` HTTP body echoed verbatim, not a locally composed set
+/// of checks, and it is a machine-consumed contract: the container `HEALTHCHECK`
+/// captures it into `docker inspect`, and `tests/service.rs` asserts the default
+/// output contains `"status":"ok"`. Reshaping it would break those consumers for
+/// no gain (the body is already the canonical machine JSON), so the behavior is
+/// left as-is deliberately.
 pub(crate) fn healthcheck(addr: &str) -> Result<()> {
     use std::io::{Read, Write};
     use std::net::{TcpStream, ToSocketAddrs};

--- a/crates/cli/src/cmd.rs
+++ b/crates/cli/src/cmd.rs
@@ -1157,32 +1157,41 @@ pub fn import(
 }
 
 fn print_import_report(r: &crystalline_core::import::ImportReport, dry_run: bool) {
+    use std::io::Write as _;
+
+    let stdout = std::io::stdout();
+    let mut out = std::io::BufWriter::new(stdout.lock());
     if dry_run {
-        println!("Dry run: no files were written.");
+        writeln!(out, "Dry run: no files were written.").unwrap();
     }
-    println!(
+    writeln!(
+        out,
         "{} converted, {} copied, {} skipped",
         r.files_converted, r.files_copied, r.files_skipped
-    );
-    println!(
+    )
+    .unwrap();
+    writeln!(
+        out,
         "type mapped: {}, temporal backfilled: {}, sentinels dropped: {}, prefixes stripped: {}, collisions: {}",
         r.type_mapped,
         r.temporal_backfilled,
         r.sentinels_dropped,
         r.prefixes_stripped,
         r.collisions
-    );
+    )
+    .unwrap();
     for w in &r.warnings {
-        println!("  warning: {w}");
+        writeln!(out, "  warning: {w}").unwrap();
     }
     for f in &r.files {
         if !f.changes.is_empty() {
-            println!("  {}", f.path);
+            writeln!(out, "  {}", f.path).unwrap();
             for c in &f.changes {
-                println!("    {c}");
+                writeln!(out, "    {c}").unwrap();
             }
         }
     }
+    out.flush().unwrap();
 }
 
 // --- connect github ------------------------------------------------------------

--- a/crates/cli/src/install.rs
+++ b/crates/cli/src/install.rs
@@ -1244,6 +1244,20 @@ pub fn run_install(opts: InstallOptions, json: bool) -> anyhow::Result<()> {
     {
         notices.push(notice);
     }
+    // A fresh install with nothing registered yet leaves an agent with
+    // nowhere to capture what it learns; point at both ways to fix that
+    // (the CLI now that install is done, or the MCP tool itself at runtime).
+    // A config load failure here is not install's problem to report twice
+    // over - it is silently skipped rather than turning an otherwise
+    // successful install into a failure.
+    if let Ok(loaded) = crystalline_service::overlay::load(None)
+        && loaded.effective.domains.is_empty()
+    {
+        notices.push(
+            "No domains registered yet. Create one with: crystalline domain add <name> <path> - or let an agent create one at runtime with the add_domain tool."
+                .to_string(),
+        );
+    }
     if opts.harness == HarnessKind::Codex {
         if !opts.skip_mcp && opts.project {
             notices.push(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -23,15 +23,26 @@ mod render;
 
 /// Local-first knowledge management for humans and AI agents.
 #[derive(Parser, Debug)]
-#[command(name = "crystalline", version, about, long_about = None)]
+#[command(
+    name = "crystalline",
+    version,
+    about,
+    long_about = None,
+    after_help = "Quickstart:
+  crystalline install claude-code
+  crystalline domain add engineering ~/knowledge/engineering
+  crystalline sync
+  crystalline write engineering \"Retry queue gotcha\" --content \"...\"
+  crystalline search \"retry queue\""
+)]
 struct Cli {
     /// Emit machine-readable JSON instead of human-readable text. Shorthand
     /// for `--format json` on subcommands that support it.
     #[arg(long, global = true)]
     json: bool,
 
-    /// Override the index database path. Defaults to the state-directory
-    /// `index.db`. Essential for tests and for pointing at a scratch index.
+    /// Override the index database path. Defaults to the state directory's
+    /// `index.db`. Useful for a scratch or alternate index.
     #[arg(long, global = true)]
     db: Option<PathBuf>,
 
@@ -389,6 +400,10 @@ enum Command {
         identifier: String,
         /// The engram's domain.
         domain: String,
+        /// Skip the confirmation prompt. Implied when stdin is not a live
+        /// terminal or `--json` is set, so a script never hangs on it.
+        #[arg(long)]
+        force: bool,
         /// Load the global config from this file instead of the default path.
         #[arg(long)]
         config: Option<PathBuf>,
@@ -595,10 +610,11 @@ enum DomainCommand {
     Add {
         /// The domain name used everywhere it is referenced.
         name: String,
-        /// The domain root directory. Omitted for a virtual domain. With
-        /// `--origin`, this is where the team domain lives on this machine
-        /// (existing files are kept); defaults to
-        /// ~/Documents/Crystalline/<name> when omitted.
+        /// The domain root directory. Omitted for a virtual domain. For a
+        /// file domain, defaults to <domains_root>/<name>
+        /// (~/Documents/Crystalline/<name> unless configured) when omitted;
+        /// with `--origin` this is where the team domain lives on this
+        /// machine, and existing files there are kept.
         path: Option<PathBuf>,
         /// Register a virtual domain: engrams live in the database, not on disk.
         /// Incompatible with a path argument.
@@ -1002,11 +1018,18 @@ fn main() -> anyhow::Result<()> {
             | Command::Read { .. }
             | Command::Edit { .. }
             | Command::Move { .. }
-            | Command::Delete { .. }
             | Command::Search { .. }
             | Command::Context { .. }
             | Command::Recent { .. }),
         ) => on_runtime(move || run_data(cmd, cli.db, cli.json)),
+        Some(Command::Delete {
+            identifier,
+            domain,
+            force,
+            config,
+        }) => {
+            on_runtime(move || delete_dispatch(identifier, domain, force, config, cli.db, cli.json))
+        }
         Some(Command::Hook { event }) => match event {
             HookEvent::Stop => {
                 hook::run_stop();
@@ -1512,9 +1535,10 @@ fn print_origin_status(data: &serde_json::Value, json: bool) {
                 c["path"].as_str().unwrap_or("")
             );
         }
+        let last_checked = d["last_checked"].as_str().map(cmd::relative_time);
         println!(
             "  last checked: {}",
-            d["last_checked"].as_str().unwrap_or("never")
+            last_checked.as_deref().unwrap_or("never")
         );
     }
     for e in data["errors"].as_array().unwrap_or(&empty) {
@@ -1664,15 +1688,6 @@ async fn run_data(command: Command, db: Option<PathBuf>, json: bool) -> anyhow::
                 "destination_domain": destination_domain,
                 "update_links": !no_update_links,
             }),
-            config,
-        ),
-        Command::Delete {
-            identifier,
-            domain,
-            config,
-        } => (
-            "delete_engram",
-            json!({ "identifier": identifier, "domain": domain }),
             config,
         ),
         Command::Search {
@@ -1902,6 +1917,57 @@ async fn domain_export_dispatch(
     Ok(())
 }
 
+/// `delete`: remove an engram, resolved through the same `delete_engram` tool
+/// the MCP surface uses. Prompts for confirmation first when a person is
+/// plausibly at the keyboard - stdin is a live terminal, `--force` was not
+/// given and `--json` was not requested - by resolving the target's address
+/// through `read_engram` (the same resolution `delete_engram` itself does)
+/// and printing it before asking. Every other combination - piped stdin,
+/// `--force`, `--json` - deletes immediately with no prompt, exactly the
+/// behavior before this flag existed: a script piping into `delete` must
+/// never hang waiting on a question nobody can answer.
+async fn delete_dispatch(
+    identifier: String,
+    domain: String,
+    force: bool,
+    config: Option<PathBuf>,
+    db: Option<PathBuf>,
+    json: bool,
+) -> anyhow::Result<()> {
+    use serde_json::json as j;
+    if std::io::stdin().is_terminal() && !force && !json {
+        let resolved = crystalline_service::run_tool(
+            "read_engram",
+            j!({ "identifier": identifier, "domain": domain }),
+            db.as_deref(),
+            config.as_deref(),
+        )
+        .await?;
+        let url = resolved
+            .get("url")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("crystalline://{domain}/{identifier}"));
+        print!("delete {url}? [y/N] ");
+        std::io::stdout().flush()?;
+        let mut answer = String::new();
+        std::io::stdin().read_line(&mut answer)?;
+        if !matches!(answer.trim(), "y" | "Y") {
+            println!("aborted");
+            return Ok(());
+        }
+    }
+    let value = crystalline_service::run_tool(
+        "delete_engram",
+        j!({ "identifier": identifier, "domain": domain }),
+        db.as_deref(),
+        config.as_deref(),
+    )
+    .await?;
+    print_value(&value, json);
+    Ok(())
+}
+
 /// `mcp`: attach to a running daemon (or start one), or run the stack
 /// in-process, and serve MCP over stdio. The server starts cleanly with no
 /// domains registered; domains are created at runtime through the `add_domain`
@@ -1968,9 +2034,11 @@ async fn domain_add_dispatch(
         return Ok(());
     }
 
-    let path =
-        path.ok_or_else(|| anyhow::anyhow!("`domain add` requires a path (or use --virtual)"))?;
-    let abs = cmd::domain_add_register(&name, &path, config.as_deref())?;
+    // An absent path defaults to `<domains_root>/<name>` inside
+    // `domain_add_register`, mirroring the MCP `add_domain` tool's default
+    // placement; the resolved directory still needs a pre-scaffolded
+    // MANIFEST.md either way.
+    let abs = cmd::domain_add_register(&name, path.as_deref(), config.as_deref())?;
     if no_sync {
         cmd::print_domain_add_no_sync(&name, &abs, json);
         return Ok(());

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,7 +5,7 @@
 //! a socket or a network connection, and none starts a Tokio runtime. Every
 //! other subcommand lands in a later milestone.
 
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
@@ -19,6 +19,7 @@ mod doctor;
 mod hook;
 mod install;
 mod receipt;
+mod render;
 
 /// Local-first knowledge management for humans and AI agents.
 #[derive(Parser, Debug)]
@@ -1736,7 +1737,28 @@ async fn run_data(command: Command, db: Option<PathBuf>, json: bool) -> anyhow::
     };
 
     let value = crystalline_service::run_tool(tool, args, db.as_deref(), config.as_deref()).await?;
-    print_value(&value, json);
+    if json {
+        // `--json` keeps the exact byte-for-byte shape every tool has always
+        // emitted; nothing routes through the human renderers.
+        print_value(&value, true);
+        return Ok(());
+    }
+    // Human mode: give the read-heavy verbs a terminal-friendly view and leave
+    // every other data command on its pretty-JSON default. Each renderer
+    // degrades to that same pretty JSON when the value is not the shape it
+    // expects, so the fallback arm and the renderers print identically.
+    let mut out = std::io::stdout().lock();
+    match tool {
+        "read_engram" => render::render_read(&value, &mut out)?,
+        "search_engrams" => render::render_search(&value, &mut out)?,
+        "recent_activity" => render::render_recent(&value, &mut out)?,
+        "build_context" => render::render_context(&value, &mut out)?,
+        "write_engram" => render::render_write(&value, &mut out)?,
+        _ => {
+            let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
+            writeln!(out, "{text}")?;
+        }
+    }
     Ok(())
 }
 

--- a/crates/cli/src/render.rs
+++ b/crates/cli/src/render.rs
@@ -1,0 +1,296 @@
+//! Human renderings of the engine's JSON results for the CLI data commands.
+//!
+//! Each renderer takes the raw `serde_json::Value` a tool returned and writes a
+//! terminal-friendly view of it. They are used only when the global `--json`
+//! flag is off; with `--json` the caller prints the value unchanged. A renderer
+//! only formats the value it is handed - it never queries the engine again - and
+//! when the value lacks the keys it expects it degrades to pretty JSON rather
+//! than panicking or printing a half-formed line, so an unfamiliar shape is
+//! shown in full instead of mangled.
+
+use std::collections::HashMap;
+use std::io::{self, Write};
+
+use serde_json::Value;
+
+/// Emit pretty JSON, byte-identical to the CLI's `print_value(value, false)`
+/// path. Every renderer falls back to this when the value is not the shape it
+/// knows how to format.
+fn pretty_fallback(v: &Value, out: &mut impl Write) -> io::Result<()> {
+    let text = serde_json::to_string_pretty(v).unwrap_or_else(|_| v.to_string());
+    writeln!(out, "{text}")
+}
+
+/// `read`: the engram address on the first line, a blank line, then the engram
+/// content verbatim (real newlines, no JSON escaping).
+pub fn render_read(v: &Value, out: &mut impl Write) -> io::Result<()> {
+    let (Some(domain), Some(permalink), Some(content)) = (
+        v.get("domain").and_then(Value::as_str),
+        v.get("permalink").and_then(Value::as_str),
+        v.get("content").and_then(Value::as_str),
+    ) else {
+        return pretty_fallback(v, out);
+    };
+    writeln!(out, "crystalline://{domain}/{permalink}")?;
+    writeln!(out)?;
+    write!(out, "{content}")
+}
+
+/// `search`: one line per hit, then a `showing N of TOTAL (page P)` footer.
+pub fn render_search(v: &Value, out: &mut impl Write) -> io::Result<()> {
+    let (Some(hits), Some(total), Some(count)) = (
+        v.get("hits").and_then(Value::as_array),
+        v.get("total").and_then(Value::as_u64),
+        v.get("count").and_then(Value::as_u64),
+    ) else {
+        return pretty_fallback(v, out);
+    };
+    let page = v.get("page").and_then(Value::as_u64).unwrap_or(1);
+    render_hit_list(hits, count, total, page, out)
+}
+
+/// `recent`: the same hit list as search. Recent activity does not paginate, so
+/// the footer reports the whole result as a single page.
+pub fn render_recent(v: &Value, out: &mut impl Write) -> io::Result<()> {
+    let (Some(engrams), Some(count)) = (
+        v.get("engrams").and_then(Value::as_array),
+        v.get("count").and_then(Value::as_u64),
+    ) else {
+        return pretty_fallback(v, out);
+    };
+    render_hit_list(engrams, count, count, 1, out)
+}
+
+/// The shared body of `search` and `recent`: one primary line per engram with
+/// its domain, title and address, an indented snippet line when the engram
+/// carries one, and a paged footer. An empty result prints a friendly line.
+fn render_hit_list(
+    items: &[Value],
+    count: u64,
+    total: u64,
+    page: u64,
+    out: &mut impl Write,
+) -> io::Result<()> {
+    if total == 0 {
+        return writeln!(out, "no results");
+    }
+    for item in items {
+        let title = item
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("(untitled)");
+        let domain = item.get("domain").and_then(Value::as_str).unwrap_or("");
+        let permalink = item.get("permalink").and_then(Value::as_str).unwrap_or("");
+        writeln!(
+            out,
+            "{title}  [{domain}]  crystalline://{domain}/{permalink}"
+        )?;
+        if let Some(snippet) = item.get("snippet").and_then(Value::as_str) {
+            let snippet = snippet.trim();
+            if !snippet.is_empty() {
+                writeln!(out, "    {snippet}")?;
+            }
+        }
+    }
+    writeln!(out, "showing {count} of {total} (page {page})")
+}
+
+/// `context`: a header naming the anchor, then one line per related engram
+/// labelled with the relation type it was reached over (or its domain when no
+/// relation edge points at it).
+pub fn render_context(v: &Value, out: &mut impl Write) -> io::Result<()> {
+    let (Some(anchor), Some(nodes)) = (
+        v.get("anchor").and_then(Value::as_str),
+        v.get("nodes").and_then(Value::as_array),
+    ) else {
+        return pretty_fallback(v, out);
+    };
+    let empty = Vec::new();
+    let edges = v.get("edges").and_then(Value::as_array).unwrap_or(&empty);
+
+    // The first inbound relation type per node, used to label how each related
+    // engram connects into the neighbourhood.
+    let mut rel_by_node: HashMap<i64, &str> = HashMap::new();
+    for edge in edges {
+        if let (Some(to), Some(rel)) = (
+            edge.get("to").and_then(Value::as_i64),
+            edge.get("rel_type").and_then(Value::as_str),
+        ) {
+            rel_by_node.entry(to).or_insert(rel);
+        }
+    }
+
+    writeln!(out, "context for {anchor}")?;
+    let mut related = 0usize;
+    for node in nodes {
+        if node.get("seed").and_then(Value::as_bool).unwrap_or(false) {
+            continue;
+        }
+        related += 1;
+        let title = node
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or("(untitled)");
+        let domain = node.get("domain").and_then(Value::as_str).unwrap_or("");
+        let permalink = node.get("permalink").and_then(Value::as_str).unwrap_or("");
+        let label = node
+            .get("id")
+            .and_then(Value::as_i64)
+            .and_then(|id| rel_by_node.get(&id).copied())
+            .unwrap_or(domain);
+        writeln!(
+            out,
+            "  {label}: {title}  crystalline://{domain}/{permalink}"
+        )?;
+    }
+    if related == 0 {
+        writeln!(out, "  (no related engrams)")?;
+    }
+    Ok(())
+}
+
+/// `write`: a single confirmation line carrying the new engram's address.
+pub fn render_write(v: &Value, out: &mut impl Write) -> io::Result<()> {
+    let (Some(domain), Some(permalink)) = (
+        v.get("domain").and_then(Value::as_str),
+        v.get("permalink").and_then(Value::as_str),
+    ) else {
+        return pretty_fallback(v, out);
+    };
+    let action = v.get("action").and_then(Value::as_str).unwrap_or("wrote");
+    writeln!(out, "{action} crystalline://{domain}/{permalink}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn render_to_string(f: impl Fn(&Value, &mut Vec<u8>) -> io::Result<()>, v: &Value) -> String {
+        let mut buf = Vec::new();
+        f(v, &mut buf).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn read_prints_address_blank_line_then_verbatim_content() {
+        let v = json!({
+            "domain": "eng",
+            "permalink": "alpha",
+            "content": "line one\nline \"two\"\n",
+        });
+        let out = render_to_string(render_read, &v);
+        assert_eq!(out, "crystalline://eng/alpha\n\nline one\nline \"two\"\n");
+    }
+
+    #[test]
+    fn read_falls_back_to_pretty_json_when_content_missing() {
+        let v = json!({ "domain": "eng", "permalink": "alpha" });
+        let out = render_to_string(render_read, &v);
+        assert_eq!(
+            out,
+            format!("{}\n", serde_json::to_string_pretty(&v).unwrap())
+        );
+    }
+
+    #[test]
+    fn search_lists_each_hit_with_snippet_and_footer() {
+        let v = json!({
+            "mode": "text",
+            "total": 3,
+            "page": 2,
+            "limit": 1,
+            "count": 1,
+            "hits": [
+                { "domain": "eng", "permalink": "alpha", "title": "Alpha", "snippet": "  a snippet  " },
+            ],
+        });
+        let out = render_to_string(render_search, &v);
+        assert_eq!(
+            out,
+            "Alpha  [eng]  crystalline://eng/alpha\n    a snippet\nshowing 1 of 3 (page 2)\n"
+        );
+    }
+
+    #[test]
+    fn search_empty_prints_no_results() {
+        let v =
+            json!({ "mode": "text", "total": 0, "page": 1, "limit": 10, "count": 0, "hits": [] });
+        let out = render_to_string(render_search, &v);
+        assert_eq!(out, "no results\n");
+    }
+
+    #[test]
+    fn recent_footer_is_single_page() {
+        let v = json!({
+            "timeframe": "7d",
+            "count": 2,
+            "engrams": [
+                { "domain": "eng", "permalink": "alpha", "title": "Alpha" },
+                { "domain": "eng", "permalink": "beta", "title": "Beta" },
+            ],
+        });
+        let out = render_to_string(render_recent, &v);
+        assert_eq!(
+            out,
+            "Alpha  [eng]  crystalline://eng/alpha\nBeta  [eng]  crystalline://eng/beta\nshowing 2 of 2 (page 1)\n"
+        );
+    }
+
+    #[test]
+    fn context_labels_related_by_relation_then_domain() {
+        let v = json!({
+            "anchor": "crystalline://eng/alpha",
+            "depth": 1,
+            "timeframe": null,
+            "nodes": [
+                { "id": 1, "domain": "eng", "permalink": "alpha", "title": "Alpha", "seed": true },
+                { "id": 2, "domain": "eng", "permalink": "beta", "title": "Beta", "seed": false },
+                { "id": 3, "domain": "ops", "permalink": "gamma", "title": "Gamma", "seed": false },
+            ],
+            "edges": [
+                { "from": 1, "to": 2, "rel_type": "depends_on", "kind": "relation" },
+            ],
+        });
+        let out = render_to_string(render_context, &v);
+        assert_eq!(
+            out,
+            "context for crystalline://eng/alpha\n  depends_on: Beta  crystalline://eng/beta\n  ops: Gamma  crystalline://ops/gamma\n"
+        );
+    }
+
+    #[test]
+    fn context_with_only_the_seed_says_no_related() {
+        let v = json!({
+            "anchor": "crystalline://eng/alpha",
+            "depth": 1,
+            "timeframe": null,
+            "nodes": [
+                { "id": 1, "domain": "eng", "permalink": "alpha", "title": "Alpha", "seed": true },
+            ],
+            "edges": [],
+        });
+        let out = render_to_string(render_context, &v);
+        assert_eq!(
+            out,
+            "context for crystalline://eng/alpha\n  (no related engrams)\n"
+        );
+    }
+
+    #[test]
+    fn write_confirms_action_and_address() {
+        let v = json!({ "domain": "eng", "permalink": "zeta", "action": "created" });
+        let out = render_to_string(render_write, &v);
+        assert_eq!(out, "created crystalline://eng/zeta\n");
+    }
+
+    #[test]
+    fn write_falls_back_when_permalink_missing() {
+        let v = json!({ "domain": "eng", "action": "created" });
+        let out = render_to_string(render_write, &v);
+        assert_eq!(
+            out,
+            format!("{}\n", serde_json::to_string_pretty(&v).unwrap())
+        );
+    }
+}

--- a/crates/cli/tests/data.rs
+++ b/crates/cli/tests/data.rs
@@ -564,3 +564,136 @@ fn domain_add_no_sync_registers_without_indexing() {
         "--no-sync leaves the domain unindexed: {search}"
     );
 }
+
+#[test]
+fn status_human_output_with_no_domains_points_at_domain_add() {
+    let work = tempfile::tempdir().unwrap();
+    let config = work.path().join("config.yaml");
+    let db = work.path().join("state/index.db");
+
+    // Neither the config nor the index exists yet: a first run against a
+    // clean machine before any domain has been registered.
+    let out = bin()
+        .args(["status", "--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("No domains registered yet. Run: crystalline domain add"),
+        "status with nothing registered points at domain add: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Run: crystalline sync"),
+        "status with nothing registered must not send a first-time user to sync: {stdout}"
+    );
+}
+
+#[test]
+fn delete_without_force_still_deletes_when_stdin_is_not_a_terminal() {
+    let work = tempfile::tempdir().unwrap();
+    let (config, db) = seed_two_engrams(work.path());
+
+    // assert_cmd spawns the child with a closed (non-terminal) stdin, so the
+    // confirmation prompt `delete` would otherwise print is skipped entirely
+    // here - a script piping into `delete` must never block on it. This is
+    // the load-bearing case: without the terminal check, a naive prompt
+    // would read EOF and hang or misbehave under a real pipe.
+    bin()
+        .args(["delete", "alpha", "eng", "--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .assert()
+        .success();
+
+    let out = bin()
+        .args(["--json", "search", "zephyrtoken", "--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    let search: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(
+        search["total"].as_u64().unwrap(),
+        1,
+        "alpha was deleted with no hang and no confirmation block: {search}"
+    );
+}
+
+#[test]
+fn delete_force_deletes_without_prompting() {
+    let work = tempfile::tempdir().unwrap();
+    let (config, db) = seed_two_engrams(work.path());
+
+    bin()
+        .args(["delete", "beta", "eng", "--force", "--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .assert()
+        .success();
+
+    let out = bin()
+        .args(["--json", "search", "zephyrtoken", "--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    let search: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(
+        search["total"].as_u64().unwrap(),
+        1,
+        "beta was deleted with --force and no prompt: {search}"
+    );
+}
+
+#[test]
+fn domain_add_without_a_path_registers_at_the_default_domains_root() {
+    let work = tempfile::tempdir().unwrap();
+    let config = work.path().join("config.yaml");
+    let domains_root = work.path().join("root");
+    std::fs::write(
+        &config,
+        format!("domains_root: {}\n", domains_root.display()),
+    )
+    .unwrap();
+
+    // `domain add` never auto-scaffolds a MANIFEST.md, even at the default
+    // root: it needs the same pre-existing one an explicit path would, via
+    // `domain init`.
+    let default_path = domains_root.join("eng");
+    bin()
+        .args(["domain", "init"])
+        .arg(&default_path)
+        .args(["--name", "eng"])
+        .assert()
+        .success();
+
+    let db = work.path().join("state/index.db");
+    let out = bin()
+        .args(["domain", "add", "eng", "--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{out:?}");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let canonical_default = std::fs::canonicalize(&default_path).unwrap();
+    assert!(
+        stdout.contains(&canonical_default.display().to_string()),
+        "domain add without a path prints the resolved default root: {stdout}"
+    );
+
+    let saved = std::fs::read_to_string(&config).unwrap();
+    assert!(
+        saved.contains(&canonical_default.display().to_string()),
+        "config persists the domain rooted at the default: {saved}"
+    );
+}

--- a/crates/cli/tests/data.rs
+++ b/crates/cli/tests/data.rs
@@ -2,7 +2,7 @@
 //! config and a temp index. Search itself is covered by the index crate's
 //! Store-API tests; the CLI search command lands in M5 with the data commands.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use assert_cmd::Command;
 
@@ -16,6 +16,284 @@ fn write(dir: &Path, rel: &str, content: &str) {
         std::fs::create_dir_all(parent).unwrap();
     }
     std::fs::write(path, content).unwrap();
+}
+
+/// Register a domain `eng` holding two engrams for the human-render tests:
+/// `alpha` (which `depends_on` `beta`, and carries a multi-line body marker) and
+/// `beta`, both mentioning the token `zephyrtoken` so a search matches both.
+/// Returns the config and db paths the data commands read.
+fn seed_two_engrams(work: &Path) -> (PathBuf, PathBuf) {
+    let domain_dir = work.join("kb");
+    let config = work.join("config.yaml");
+    let db = work.join("state/index.db");
+
+    bin()
+        .args(["domain", "init"])
+        .arg(&domain_dir)
+        .args(["--name", "eng"])
+        .assert()
+        .success();
+    write(
+        &domain_dir,
+        "alpha.md",
+        "---\ntype: engram\ntitle: Alpha\npermalink: alpha\ntags:\n  - t\nstatus: current\nrecorded_at: 2026-01-01\n---\n\nAlpha body mentions zephyrtoken.\nfirst-line-marker\nsecond-line-marker\n\n- depends_on [[Beta]]\n",
+    );
+    write(
+        &domain_dir,
+        "beta.md",
+        "---\ntype: engram\ntitle: Beta\npermalink: beta\ntags:\n  - t\nstatus: current\nrecorded_at: 2026-01-01\n---\n\nBeta body mentions zephyrtoken.\n",
+    );
+    bin()
+        .args(["domain", "add", "eng"])
+        .arg(&domain_dir)
+        .args(["--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .assert()
+        .success();
+
+    (config, db)
+}
+
+/// The sorted top-level keys of a JSON object, for shape assertions.
+fn object_keys(v: &serde_json::Value) -> Vec<String> {
+    let mut keys: Vec<String> = v
+        .as_object()
+        .expect("top-level JSON is an object")
+        .keys()
+        .cloned()
+        .collect();
+    keys.sort();
+    keys
+}
+
+#[test]
+fn read_human_output_prints_url_header_and_verbatim_content() {
+    let work = tempfile::tempdir().unwrap();
+    let (config, db) = seed_two_engrams(work.path());
+
+    let out = bin()
+        .args(["read", "alpha", "--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // The first thing a human sees is the engram address.
+    assert!(
+        stdout.contains("crystalline://eng/alpha"),
+        "read prints the crystalline:// address header: {stdout}"
+    );
+    // The body is written verbatim: a real newline between the two markers, not
+    // the `\n` escape that a JSON string would carry.
+    assert!(
+        stdout.contains("first-line-marker\nsecond-line-marker"),
+        "read prints the content verbatim with real newlines: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("\\n"),
+        "human read output must not contain escaped newlines: {stdout:?}"
+    );
+}
+
+#[test]
+fn search_human_output_lists_hits_with_footer() {
+    let work = tempfile::tempdir().unwrap();
+    let (config, db) = seed_two_engrams(work.path());
+
+    let out = bin()
+        .args(["search", "zephyrtoken", "--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    for needle in [
+        "Alpha",
+        "Beta",
+        "crystalline://eng/alpha",
+        "crystalline://eng/beta",
+        "showing 2 of 2 (page 1)",
+    ] {
+        assert!(
+            stdout.contains(needle),
+            "search human output missing {needle:?}: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn recent_human_output_lists_engrams_with_footer() {
+    let work = tempfile::tempdir().unwrap();
+    let (config, db) = seed_two_engrams(work.path());
+
+    let out = bin()
+        .args(["recent", "--timeframe", "10y", "--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    for needle in [
+        "Alpha",
+        "Beta",
+        "crystalline://eng/alpha",
+        "crystalline://eng/beta",
+        "showing",
+    ] {
+        assert!(
+            stdout.contains(needle),
+            "recent human output missing {needle:?}: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn context_human_output_lists_related_engrams() {
+    let work = tempfile::tempdir().unwrap();
+    let (config, db) = seed_two_engrams(work.path());
+
+    let out = bin()
+        .args(["context", "crystalline://eng/alpha", "--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // A header naming the anchor, then the related engram reached over the
+    // `depends_on` relation.
+    assert!(
+        stdout.contains("crystalline://eng/alpha"),
+        "context header names the anchor: {stdout}"
+    );
+    for needle in ["depends_on", "Beta", "crystalline://eng/beta"] {
+        assert!(
+            stdout.contains(needle),
+            "context human output missing {needle:?}: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn write_human_output_confirms_url() {
+    let work = tempfile::tempdir().unwrap();
+    let (config, db) = seed_two_engrams(work.path());
+
+    let out = bin()
+        .args([
+            "write",
+            "eng",
+            "Zeta",
+            "--content",
+            "- [fact] a zeta fact #eng",
+        ])
+        .args(["--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        stdout.contains("crystalline://eng/zeta"),
+        "write confirms the new engram's address: {stdout}"
+    );
+    assert!(
+        stdout.contains("created"),
+        "write reports the create action: {stdout}"
+    );
+}
+
+#[test]
+fn json_shapes_unchanged() {
+    let work = tempfile::tempdir().unwrap();
+    let (config, db) = seed_two_engrams(work.path());
+
+    let run = |args: &[&str]| -> serde_json::Value {
+        let out = bin()
+            .arg("--json")
+            .args(args)
+            .args(["--config"])
+            .arg(&config)
+            .args(["--db"])
+            .arg(&db)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "command {args:?} succeeds");
+        serde_json::from_slice(&out.stdout)
+            .unwrap_or_else(|e| panic!("command {args:?} emits valid JSON: {e}"))
+    };
+
+    let search = run(&["search", "zephyrtoken"]);
+    assert_eq!(
+        object_keys(&search),
+        ["count", "hits", "limit", "mode", "page", "total"],
+        "search JSON shape unchanged: {search}"
+    );
+
+    let read = run(&["read", "alpha"]);
+    assert_eq!(
+        object_keys(&read),
+        [
+            "checksum",
+            "content",
+            "domain",
+            "frontmatter",
+            "observations",
+            "path",
+            "permalink",
+            "relations",
+            "status",
+            "title",
+            "type",
+            "url",
+        ],
+        "read JSON shape unchanged: {read}"
+    );
+
+    let recent = run(&["recent", "--timeframe", "10y"]);
+    assert_eq!(
+        object_keys(&recent),
+        ["count", "engrams", "timeframe"],
+        "recent JSON shape unchanged: {recent}"
+    );
+
+    let context = run(&["context", "crystalline://eng/alpha"]);
+    assert_eq!(
+        object_keys(&context),
+        ["anchor", "depth", "edges", "nodes", "timeframe"],
+        "context JSON shape unchanged: {context}"
+    );
+
+    let written = run(&["write", "eng", "Omega", "--content", "- [fact] omega #eng"]);
+    assert_eq!(
+        object_keys(&written),
+        [
+            "action",
+            "domain",
+            "path",
+            "permalink",
+            "status",
+            "title",
+            "type"
+        ],
+        "write JSON shape unchanged: {written}"
+    );
 }
 
 #[test]

--- a/crates/cli/tests/install.rs
+++ b/crates/cli/tests/install.rs
@@ -865,6 +865,57 @@ fn a_matching_crystalline_on_the_path_earns_no_version_notice() {
     );
 }
 
+#[test]
+fn install_into_an_empty_home_prints_the_no_domains_notice() {
+    let work = tempfile::tempdir().unwrap();
+    let home = work.path().join("home");
+    let bin_dir = work.path().join("bin");
+    let log = work.path().join("claude.log");
+    write_shim(&bin_dir, "claude", &log);
+
+    let out = install_cmd(&home, &bin_dir)
+        .args(["install", "claude-code"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        stdout.contains("No domains registered yet. Create one with: crystalline domain add"),
+        "a domain-less install points at domain add: {stdout}"
+    );
+}
+
+#[test]
+fn install_with_a_registered_domain_omits_the_no_domains_notice() {
+    let work = tempfile::tempdir().unwrap();
+    let home = work.path().join("home");
+    let bin_dir = work.path().join("bin");
+    let log = work.path().join("claude.log");
+    write_shim(&bin_dir, "claude", &log);
+
+    // The global config the isolated home resolves to (XDG_CONFIG_HOME is
+    // <home>/config), pre-seeded with one registered domain; install never
+    // touches the domain itself, so the path does not need to exist.
+    let config_path = home.join("config").join("crystalline").join("config.yaml");
+    std::fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &config_path,
+        "domains:\n  eng:\n    path: /tmp/does-not-need-to-exist\n",
+    )
+    .unwrap();
+
+    let out = install_cmd(&home, &bin_dir)
+        .args(["install", "claude-code"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        !stdout.contains("No domains registered"),
+        "an install with a registered domain omits the notice: {stdout}"
+    );
+}
+
 /// The receipt path under an isolated home: state_dir honors
 /// XDG_STATE_HOME, which install_cmd points at <home>/state.
 fn receipt_file(home: &Path) -> PathBuf {

--- a/crates/cli/tests/service.rs
+++ b/crates/cli/tests/service.rs
@@ -959,9 +959,9 @@ fn status_with_a_daemon_renders_text_with_the_daemon_line() {
     assert!(value["domains"].is_array(), "{value}");
 }
 
-/// Without a daemon, `status` says so in its first line and renders the same
-/// human shape from a direct index read; a registered domain that was never
-/// synced shows as not indexed yet rather than disappearing.
+/// Without a daemon and with nothing registered, `status` says so in its
+/// first line and points a first-time user at `domain add` rather than
+/// `sync` - there is nothing to sync yet either.
 #[test]
 fn status_without_a_daemon_says_not_running() {
     let env = Env::new("status-down");
@@ -972,7 +972,35 @@ fn status_without_a_daemon_says_not_running() {
         out.starts_with("Daemon: not running; reading the index directly"),
         "{out}"
     );
+    assert!(
+        out.contains("No domains registered yet. Run: crystalline domain add"),
+        "{out}"
+    );
+}
+
+/// Without a daemon, once a domain is registered but never synced, `status`
+/// still renders the same human shape from a direct index read and shows the
+/// domain as not indexed yet rather than disappearing - `sync` is now the
+/// right pointer, unlike the nothing-registered case above.
+#[test]
+fn status_without_a_daemon_and_no_index_reports_registered_domains_as_not_indexed_yet() {
+    let env = Env::new("status-down-registered");
+    std::fs::create_dir_all(env.config_path().parent().unwrap()).unwrap();
+    std::fs::write(
+        env.config_path(),
+        "domains:\n  eng:\n    path: /tmp/does-not-need-to-exist\n",
+    )
+    .unwrap();
+
+    let (ok, out) = env.run(&["status"]);
+    assert!(ok, "{out}");
+    assert!(
+        out.starts_with("Daemon: not running; reading the index directly"),
+        "{out}"
+    );
     assert!(out.contains("No index at "), "{out}");
+    assert!(out.contains("Run: crystalline sync"), "{out}");
+    assert!(out.contains("eng\t(not indexed yet)"), "{out}");
 }
 
 /// `--db`/`--config` overrides bypass the daemon on purpose; the first line

--- a/crates/core/src/parse.rs
+++ b/crates/core/src/parse.rs
@@ -9,6 +9,7 @@
 //! spans are masked before link and observation detection so knowledge inside
 //! code never leaks into the graph.
 
+use std::borrow::Cow;
 use std::ops::Range;
 
 use chrono::{DateTime, FixedOffset, NaiveDate};
@@ -442,25 +443,32 @@ fn scan_body(
         }
 
         // Wikilinks anywhere on the line, excluding a relation target and
-        // deduplicated per line.
-        let masked = mask_inline_code(line);
-        let mut seen: Vec<LinkTarget> = Vec::new();
-        let mut excluded = relation_target.is_none();
-        for inner in find_wikilinks(&masked) {
-            let target = LinkTarget::parse(&inner);
-            if !excluded
-                && let Some(rt) = &relation_target
-                && &target == rt
-            {
-                excluded = true;
-                continue;
-            }
-            if !seen.contains(&target) {
-                seen.push(target.clone());
-                links.push(WikiLink {
-                    line: line_no,
-                    target,
-                });
+        // deduplicated per line. Nothing to find on a line without "[[", and
+        // masking is only needed when a backtick could hide one.
+        if line.contains("[[") {
+            let masked: Cow<'_, str> = if line.contains('`') {
+                Cow::Owned(mask_inline_code(line))
+            } else {
+                Cow::Borrowed(line)
+            };
+            let mut seen: Vec<LinkTarget> = Vec::new();
+            let mut excluded = relation_target.is_none();
+            for inner in find_wikilinks(&masked) {
+                let target = LinkTarget::parse(&inner);
+                if !excluded
+                    && let Some(rt) = &relation_target
+                    && &target == rt
+                {
+                    excluded = true;
+                    continue;
+                }
+                if !seen.contains(&target) {
+                    seen.push(target.clone());
+                    links.push(WikiLink {
+                        line: line_no,
+                        target,
+                    });
+                }
             }
         }
     }
@@ -599,9 +607,13 @@ fn parse_relation(content: &str) -> Option<(String, LinkTarget)> {
 
 /// Replace inline code span contents (including the backticks) with spaces so
 /// wikilinks and observation markers inside code are ignored.
+///
+/// Masks in place in a single `Vec<char>`: every index the scan reads is
+/// fully read before any slot in that span is written, and once a span is
+/// blanked the scan pointer jumps past it, so a read never observes a
+/// write from an earlier iteration.
 pub(crate) fn mask_inline_code(line: &str) -> String {
-    let chars: Vec<char> = line.chars().collect();
-    let mut out = chars.clone();
+    let mut chars: Vec<char> = line.chars().collect();
     let n = chars.len();
     let mut i = 0;
     while i < n {
@@ -629,7 +641,7 @@ pub(crate) fn mask_inline_code(line: &str) -> String {
                 }
             }
             if let Some(end) = found {
-                for slot in out.iter_mut().take(end).skip(i) {
+                for slot in chars.iter_mut().take(end).skip(i) {
                     *slot = ' ';
                 }
                 i = end;
@@ -641,7 +653,7 @@ pub(crate) fn mask_inline_code(line: &str) -> String {
         }
         i += 1;
     }
-    out.into_iter().collect()
+    chars.into_iter().collect()
 }
 
 fn find_wikilinks(masked: &str) -> Vec<String> {
@@ -657,4 +669,79 @@ fn find_wikilinks(masked: &str) -> Vec<String> {
         }
     }
     res
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pins the current mask_inline_code/scan_body behavior before the
+    // single-buffer and contains-guard refactor so the refactor cannot
+    // change observable output.
+
+    #[test]
+    fn mask_inline_code_leaves_unterminated_backtick_run_unmasked() {
+        let line = "text `unterminated [[Link]] end";
+        assert_eq!(mask_inline_code(line), line);
+    }
+
+    #[test]
+    fn mask_inline_code_masks_whole_span_with_unequal_nested_backtick_runs() {
+        let line = "before ``a`b`` after";
+        let masked = mask_inline_code(line);
+        assert_eq!(masked.chars().count(), line.chars().count());
+        assert!(masked.starts_with("before "));
+        assert!(masked.ends_with(" after"));
+        let middle = &masked["before ".len()..masked.len() - " after".len()];
+        assert!(
+            middle.chars().all(|c| c == ' '),
+            "expected the whole unequal nested run masked to spaces, got {middle:?}"
+        );
+    }
+
+    #[test]
+    fn mask_inline_code_is_identity_when_no_backticks_present() {
+        let line = "plain text with [[Wikilink]] and no backticks at all";
+        assert_eq!(mask_inline_code(line), line);
+    }
+
+    #[test]
+    fn mask_inline_code_blanks_multibyte_content_by_char_not_byte() {
+        let prefix = "日本";
+        let inner = "コード";
+        let suffix = "語";
+        let line = format!("{prefix}`{inner}`{suffix}");
+        let masked = mask_inline_code(&line);
+        assert_eq!(masked.chars().count(), line.chars().count());
+        assert!(masked.starts_with(prefix));
+        assert!(masked.ends_with(suffix));
+        assert!(!masked.contains(inner));
+        for ch in inner.chars() {
+            assert!(!masked.contains(ch));
+        }
+        assert!(!masked.contains('`'));
+    }
+
+    #[test]
+    fn mask_inline_code_hides_wikilink_inside_code_span() {
+        let line = "prefix `[[Inside]]` suffix";
+        let masked = mask_inline_code(line);
+        assert!(find_wikilinks(&masked).is_empty());
+    }
+
+    #[test]
+    fn scan_body_keeps_wikilink_outside_code_span_and_drops_one_inside() {
+        let body = "see `[[Inside]]` and [[Outside]] too";
+        let (_, _, links, _) = scan_body(body, 1);
+        assert_eq!(links.len(), 1);
+        assert_eq!(links[0].target.target, "Outside");
+        assert_eq!(links[0].line, 1);
+    }
+
+    #[test]
+    fn scan_body_returns_no_links_when_line_has_no_wikilink_markers() {
+        let body = "just `code` here, nothing to link";
+        let (_, _, links, _) = scan_body(body, 1);
+        assert!(links.is_empty());
+    }
 }

--- a/crates/core/src/verify/links.rs
+++ b/crates/core/src/verify/links.rs
@@ -6,6 +6,7 @@
 //! whose named domain is outside the scan set cannot be judged broken or
 //! sound, so it is only ever informational (`L006`), never a warning.
 
+use std::borrow::Cow;
 use std::collections::{BTreeSet, HashMap};
 
 use crate::address::{self, CrystallineUrl, LinkResolver, LookupTable, Resolution};
@@ -235,7 +236,11 @@ fn check_crystalline_urls(
         if bl.in_fence {
             continue;
         }
-        let masked = mask_inline_code(bl.text);
+        let masked: Cow<'_, str> = if bl.text.contains('`') {
+            Cow::Owned(mask_inline_code(bl.text))
+        } else {
+            Cow::Borrowed(bl.text)
+        };
         for url in find_urls(&masked) {
             let Some(parsed) = CrystallineUrl::parse(&url) else {
                 continue;

--- a/crates/index/src/embed/chunk.rs
+++ b/crates/index/src/embed/chunk.rs
@@ -126,7 +126,7 @@ pub fn fingerprint(model_id: &str, text: &str) -> String {
     h.update(model_id.as_bytes());
     h.update(b":");
     h.update(text.as_bytes());
-    hex(&h.finalize())
+    crate::hex_lower(&h.finalize())
 }
 
 fn build_header(title: &str, description: Option<&str>) -> String {
@@ -220,12 +220,4 @@ fn split_paragraphs(body: &str) -> Vec<String> {
     }
     flush(&mut current, &mut paras);
     paras
-}
-
-fn hex(bytes: &[u8]) -> String {
-    let mut s = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        s.push_str(&format!("{b:02x}"));
-    }
-    s
 }

--- a/crates/index/src/embed/local.rs
+++ b/crates/index/src/embed/local.rs
@@ -10,14 +10,17 @@
 //! or corrupt cache self-heals: the model directory is wiped and fetched once
 //! more before giving up.
 
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::bert::{BertModel, Config};
 use crystalline_core::config::{self, EmbeddingsConfig};
+use hf_hub::api::Progress;
 use hf_hub::api::sync::ApiBuilder;
 use hf_hub::{Cache, Repo, RepoType};
 use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams};
@@ -134,33 +137,116 @@ struct ModelFiles {
     weights: PathBuf,
 }
 
-/// Fetch `config.json`, `tokenizer.json` and `model.safetensors` into the cache,
-/// announcing a first-use download once to stderr.
+/// Adapts hf-hub's per-chunk [`Progress`] callbacks (one `update` call per
+/// ~8 KiB read, `std::io::copy`'s default buffer) into a single
+/// carriage-return byte-progress line on stderr, throttled to about ten
+/// renders a second so a fast local connection does not flood the terminal
+/// with one write per chunk. Only ever constructed when stderr is a live
+/// terminal (see [`ensure_files`]), so it never needs to check that itself.
+struct ByteProgress {
+    filename: String,
+    total: usize,
+    downloaded: usize,
+    last_render: Option<Instant>,
+}
+
+impl ByteProgress {
+    fn new() -> Self {
+        ByteProgress {
+            filename: String::new(),
+            total: 0,
+            downloaded: 0,
+            last_render: None,
+        }
+    }
+
+    fn render(&self) {
+        let mb = |bytes: usize| bytes as f64 / (1024.0 * 1024.0);
+        eprint!(
+            "\r  {}: {:.1} / {:.1} MB",
+            self.filename,
+            mb(self.downloaded),
+            mb(self.total)
+        );
+        let _ = std::io::stderr().flush();
+    }
+}
+
+impl Progress for ByteProgress {
+    fn init(&mut self, size: usize, filename: &str) {
+        self.total = size;
+        self.downloaded = 0;
+        self.filename = filename.to_string();
+        self.last_render = Some(Instant::now());
+        self.render();
+    }
+
+    fn update(&mut self, size: usize) {
+        self.downloaded += size;
+        let now = Instant::now();
+        let due = self
+            .last_render
+            .is_none_or(|t| now.duration_since(t) >= Duration::from_millis(100));
+        if due {
+            self.last_render = Some(now);
+            self.render();
+        }
+    }
+
+    fn finish(&mut self) {
+        // A final render so the line lands on the true total even when the
+        // last chunk landed inside the throttle window, then a newline so
+        // whatever prints next starts clean instead of overwriting this line.
+        self.render();
+        eprintln!();
+    }
+}
+
+/// Fetch `config.json`, `tokenizer.json` and `model.safetensors` into the
+/// cache, announcing a first-use download once to stderr. When the whole
+/// download is needed (nothing cached yet) and stderr is a live terminal, each
+/// file also gets a `\r`-updated byte-progress line via [`ByteProgress`];
+/// piped or redirected stderr (a log file, `--json`'s non-interactive
+/// callers, CI) keeps exactly the single notice line, never per-byte output.
+/// A file already present in the cache is resolved with no network call at
+/// all, so a fully warmed cache - the air-gapped and CI-prefetch paths -
+/// never dials out just to check.
 fn ensure_files(cache_dir: &Path) -> Result<ModelFiles> {
     std::fs::create_dir_all(cache_dir).map_err(|e| IndexError::Io {
         path: cache_dir.display().to_string(),
         source: e,
     })?;
 
-    let cached = Cache::new(cache_dir.to_path_buf())
-        .repo(Repo::new(HF_REPO.to_string(), RepoType::Model))
-        .get("model.safetensors")
-        .is_some();
+    let hub_cache =
+        Cache::new(cache_dir.to_path_buf()).repo(Repo::new(HF_REPO.to_string(), RepoType::Model));
+    let cached = hub_cache.get("model.safetensors").is_some();
     if !cached {
         eprintln!(
             "crystalline: downloading embedding model {HF_REPO} to {} (first use, about 130 MB)...",
             cache_dir.display()
         );
     }
+    let show_progress = !cached && std::io::stderr().is_terminal();
 
     let api = ApiBuilder::new()
         .with_cache_dir(cache_dir.to_path_buf())
+        // Ours only: a stable, testable byte counter instead of hf-hub's own
+        // default indicatif bar, so exactly one progress mechanism is ever
+        // active and it is the one this module controls and TTY-gates itself.
+        .with_progress(false)
         .build()
         .map_err(|e| IndexError::Embedding(format!("hub client: {e}")))?;
     let repo = api.model(HF_REPO.to_string());
     let fetch = |name: &str| -> Result<PathBuf> {
-        repo.get(name)
-            .map_err(|e| IndexError::Embedding(format!("downloading {name}: {e}")))
+        if let Some(path) = hub_cache.get(name) {
+            return Ok(path);
+        }
+        if show_progress {
+            repo.download_with_progress(name, ByteProgress::new())
+        } else {
+            repo.download(name)
+        }
+        .map_err(|e| IndexError::Embedding(format!("downloading {name}: {e}")))
     };
     Ok(ModelFiles {
         config: fetch("config.json")?,

--- a/crates/index/src/embed/mod.rs
+++ b/crates/index/src/embed/mod.rs
@@ -20,7 +20,7 @@ use async_trait::async_trait;
 use crystalline_core::config::EmbeddingsConfig;
 
 use crate::error::{IndexError, Result};
-use crate::store::{EmbeddingRow, Store};
+use crate::store::{ChunkJob, EmbeddingRow, Store};
 
 pub use chunk::{
     ChunkParams, DEFAULT_MAX_TOKENS, DEFAULT_MODEL_ID, chunk_engram, chunk_engram_with,
@@ -137,6 +137,19 @@ pub struct EmbedReport {
     pub batches: usize,
 }
 
+/// Order jobs ascending by estimated token count before batching.
+///
+/// The local tokenizer pads every batch to its longest member
+/// (`PaddingStrategy::BatchLongest`), so a batch that mixes one long chunk into
+/// fifteen short ones pays the long sequence's cost sixteen times over. Sorting
+/// first makes batches length-homogeneous and cuts that padding waste on full
+/// passes. Correctness never depends on batch order: each vector is written
+/// back against its own `chunk_id`. The sort is stable so equal-length jobs
+/// keep the order the store returned them in.
+pub fn order_jobs_for_batching(jobs: &mut [ChunkJob]) {
+    jobs.sort_by_key(|job| estimate_tokens(&job.text));
+}
+
 /// Embed every chunk that needs it for the active provider's model, in batches,
 /// writing the vectors back through the store. `progress` is called after each
 /// batch with `(done, total)`.
@@ -150,9 +163,10 @@ pub async fn run_embedding_pass(
 ) -> Result<EmbedReport> {
     // The standalone `sync --embed` / `reindex --embed` fill embeds every domain
     // (`None`); the daemon's background queue scopes its own pass instead.
-    let jobs = store
+    let mut jobs = store
         .chunks_needing_embedding(provider.model_id(), None)
         .await?;
+    order_jobs_for_batching(&mut jobs);
     let total = jobs.len();
     if total == 0 {
         return Ok(EmbedReport::default());

--- a/crates/index/src/embed/mod.rs
+++ b/crates/index/src/embed/mod.rs
@@ -147,7 +147,10 @@ pub struct EmbedReport {
 /// back against its own `chunk_id`. The sort is stable so equal-length jobs
 /// keep the order the store returned them in.
 pub fn order_jobs_for_batching(jobs: &mut [ChunkJob]) {
-    jobs.sort_by_key(|job| estimate_tokens(&job.text));
+    // Cache each job's token estimate so the counter runs once per job rather
+    // than once per comparison; the sort stays stable so equal-length jobs keep
+    // the store's order.
+    jobs.sort_by_cached_key(|job| estimate_tokens(&job.text));
 }
 
 /// Embed every chunk that needs it for the active provider's model, in batches,

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -25,7 +25,7 @@ pub mod turso;
 
 pub use embed::{
     ChunkParams, EmbedReport, EmbeddingProvider, ModelDownload, chunk_engram, configured_model_id,
-    download_local_model, provider_from_config, run_embedding_pass,
+    download_local_model, order_jobs_for_batching, provider_from_config, run_embedding_pass,
 };
 pub use error::{IndexError, Result};
 pub use factory::open_store;

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -41,3 +41,29 @@ pub use turso::TursoStore;
 
 #[cfg(feature = "postgres")]
 pub use postgres::PostgresStore;
+
+/// Encode bytes as lowercase hexadecimal into a pre-sized string. The shared
+/// SHA-256 formatter for the whole crate: chunk fingerprints, file checksums and
+/// the service crate's content hashing all route through it so the digest text is
+/// identical everywhere.
+pub fn hex_lower(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+#[cfg(test)]
+mod hex_tests {
+    use super::hex_lower;
+
+    #[test]
+    fn hex_lower_encodes_empty_and_multibyte() {
+        assert_eq!(hex_lower(&[]), "");
+        // Boundary byte values and a two-nibble value keep the fixed width.
+        assert_eq!(hex_lower(&[0x00, 0xff]), "00ff");
+        assert_eq!(hex_lower(&[0x0a, 0xb3, 0x01]), "0ab301");
+    }
+}

--- a/crates/index/src/postgres/mod.rs
+++ b/crates/index/src/postgres/mod.rs
@@ -254,6 +254,12 @@ pub(super) enum Param {
     Text(String),
     Int(i64),
     Vector(pgvector::Vector),
+    // Nullable variants for multi-row child inserts, where a NULL context,
+    // `to_domain`, or a carried-over chunk's model/dims/embedding binds as a
+    // typed NULL rather than a literal.
+    TextOpt(Option<String>),
+    IntOpt(Option<i64>),
+    VectorOpt(Option<pgvector::Vector>),
 }
 
 fn bind_all<'q>(
@@ -265,9 +271,60 @@ fn bind_all<'q>(
             Param::Text(s) => q.bind(s),
             Param::Int(i) => q.bind(i),
             Param::Vector(v) => q.bind(v),
+            Param::TextOpt(s) => q.bind(s),
+            Param::IntOpt(i) => q.bind(i),
+            Param::VectorOpt(v) => q.bind(v),
         };
     }
     q
+}
+
+/// Execute a statement with dynamically bound parameters, returning the affected
+/// row count. The multi-row child inserts route through this; the RETURNING
+/// observation insert uses [`query_all`] instead.
+pub(super) async fn exec(conn: &mut PgConnection, sql: &str, params: Vec<Param>) -> Result<u64> {
+    Ok(bind_all(sqlx::query(AssertSqlSafe(sql)), params)
+        .execute(&mut *conn)
+        .await
+        .map_err(IndexError::from)?
+        .rows_affected())
+}
+
+/// The maximum number of value tuples in one multi-row INSERT. Postgres caps a
+/// statement at 65535 bind parameters, far above this, so the chunk size stays in
+/// step with the Turso backend rather than tracking a different ceiling.
+const INSERT_CHUNK: usize = 100;
+
+/// Build the parenthesized value tuples for a multi-row INSERT: `count` tuples of
+/// `width` sequential `$n` placeholders each, plus an optional fixed trailing
+/// column (a literal `NULL` `to_id` for relations and links). `count` must be
+/// non-zero; callers iterate chunks of a possibly-empty slice and skip the
+/// statement entirely when there is nothing to insert.
+fn value_rows(width: usize, count: usize, trailing: Option<&str>) -> String {
+    let mut n = 1;
+    let mut rows = Vec::with_capacity(count);
+    for _ in 0..count {
+        let mut cells = Vec::with_capacity(width + usize::from(trailing.is_some()));
+        for _ in 0..width {
+            cells.push(format!("${n}"));
+            n += 1;
+        }
+        if let Some(t) = trailing {
+            cells.push(t.to_string());
+        }
+        rows.push(format!("({})", cells.join(",")));
+    }
+    rows.join(",")
+}
+
+/// The multi-row observation INSERT for `count` rows, returning each new row's id
+/// with its source line so observation tags map to the right observation without
+/// depending on `RETURNING` row order.
+fn observation_insert_sql(count: usize) -> String {
+    format!(
+        "INSERT INTO observation(engram_id, line, category, content, context) VALUES {} RETURNING id, line",
+        value_rows(5, count, None)
+    )
 }
 
 pub(super) async fn query_all(
@@ -518,70 +575,102 @@ impl Store for PostgresStore {
             delete_children(&mut *c, engram_id).await?;
         }
 
-        for obs in &record.observations {
-            let oid: (i64,) = sqlx::query_as(
-                "INSERT INTO observation(engram_id, line, category, content, context) VALUES($1,$2,$3,$4,$5) RETURNING id",
-            )
-            .bind(engram_id)
-            .bind(obs.line as i64)
-            .bind(&obs.category)
-            .bind(&obs.content)
-            .bind(obs.context.as_deref())
-            .fetch_one(&mut *c)
-            .await
-            .map_err(IndexError::from)?;
-            for tag in &obs.tags {
-                let tid = self.tag_id(&mut *c, tag).await?;
-                sqlx::query("INSERT INTO observation_tag(observation_id, tag_id) VALUES($1,$2) ON CONFLICT DO NOTHING")
-                    .bind(oid.0)
-                    .bind(tid)
-                    .execute(&mut *c)
-                    .await
-                    .map_err(IndexError::from)?;
+        // Observations: insert in chunks and read each new row's id back joined
+        // on its source line (unique within one engram), so observation tags map
+        // to the right observation without relying on RETURNING row order.
+        let mut obs_id_by_line: HashMap<i64, i64> = HashMap::new();
+        for batch in record.observations.chunks(INSERT_CHUNK) {
+            let mut params: Vec<Param> = Vec::with_capacity(batch.len() * 5);
+            for obs in batch {
+                params.push(Param::Int(engram_id));
+                params.push(Param::Int(obs.line as i64));
+                params.push(Param::Text(obs.category.clone()));
+                params.push(Param::Text(obs.content.clone()));
+                params.push(Param::TextOpt(obs.context.clone()));
+            }
+            let rows = query_all(&mut *c, &observation_insert_sql(batch.len()), params).await?;
+            for r in &rows {
+                if let (Some(id), Some(line)) = (cell_i64(r, 0), cell_i64(r, 1)) {
+                    obs_id_by_line.insert(line, id);
+                }
             }
         }
 
-        for rel in &record.relations {
-            sqlx::query(
-                "INSERT INTO relation(engram_id, domain_id, line, rel_type, to_target, to_domain, to_id) \
-                 VALUES($1,$2,$3,$4,$5,$6,NULL)",
-            )
-            .bind(engram_id)
-            .bind(domain.0)
-            .bind(rel.line as i64)
-            .bind(&rel.rel_type)
-            .bind(&rel.to_target)
-            .bind(rel.to_domain.as_deref())
-            .execute(&mut *c)
-            .await
-            .map_err(IndexError::from)?;
+        // Observation tags: intern each tag through the cache, then insert the
+        // (observation, tag) pairs in multi-row statements.
+        let mut obs_tag_pairs: Vec<(i64, i64)> = Vec::new();
+        for obs in &record.observations {
+            let Some(&oid) = obs_id_by_line.get(&(obs.line as i64)) else {
+                continue;
+            };
+            for tag in &obs.tags {
+                let tid = self.tag_id(&mut *c, tag).await?;
+                obs_tag_pairs.push((oid, tid));
+            }
+        }
+        for batch in obs_tag_pairs.chunks(INSERT_CHUNK) {
+            let mut params: Vec<Param> = Vec::with_capacity(batch.len() * 2);
+            for (oid, tid) in batch {
+                params.push(Param::Int(*oid));
+                params.push(Param::Int(*tid));
+            }
+            let sql = format!(
+                "INSERT INTO observation_tag(observation_id, tag_id) VALUES {} ON CONFLICT DO NOTHING",
+                value_rows(2, batch.len(), None)
+            );
+            exec(&mut *c, &sql, params).await?;
         }
 
-        for link in &record.links {
-            sqlx::query(
-                "INSERT INTO link(engram_id, domain_id, line, to_target, to_domain, to_id) \
-                 VALUES($1,$2,$3,$4,$5,NULL)",
-            )
-            .bind(engram_id)
-            .bind(domain.0)
-            .bind(link.line as i64)
-            .bind(&link.to_target)
-            .bind(link.to_domain.as_deref())
-            .execute(&mut *c)
-            .await
-            .map_err(IndexError::from)?;
+        for batch in record.relations.chunks(INSERT_CHUNK) {
+            let mut params: Vec<Param> = Vec::with_capacity(batch.len() * 6);
+            for rel in batch {
+                params.push(Param::Int(engram_id));
+                params.push(Param::Int(domain.0));
+                params.push(Param::Int(rel.line as i64));
+                params.push(Param::Text(rel.rel_type.clone()));
+                params.push(Param::Text(rel.to_target.clone()));
+                params.push(Param::TextOpt(rel.to_domain.clone()));
+            }
+            let sql = format!(
+                "INSERT INTO relation(engram_id, domain_id, line, rel_type, to_target, to_domain, to_id) VALUES {}",
+                value_rows(6, batch.len(), Some("NULL"))
+            );
+            exec(&mut *c, &sql, params).await?;
         }
 
+        for batch in record.links.chunks(INSERT_CHUNK) {
+            let mut params: Vec<Param> = Vec::with_capacity(batch.len() * 5);
+            for link in batch {
+                params.push(Param::Int(engram_id));
+                params.push(Param::Int(domain.0));
+                params.push(Param::Int(link.line as i64));
+                params.push(Param::Text(link.to_target.clone()));
+                params.push(Param::TextOpt(link.to_domain.clone()));
+            }
+            let sql = format!(
+                "INSERT INTO link(engram_id, domain_id, line, to_target, to_domain, to_id) VALUES {}",
+                value_rows(5, batch.len(), Some("NULL"))
+            );
+            exec(&mut *c, &sql, params).await?;
+        }
+
+        // Engram tags: intern each tag, then insert the pairs in multi-row
+        // statements.
+        let mut tag_ids: Vec<i64> = Vec::with_capacity(record.tags.len());
         for tag in &record.tags {
-            let tid = self.tag_id(&mut *c, tag).await?;
-            sqlx::query(
-                "INSERT INTO engram_tag(engram_id, tag_id) VALUES($1,$2) ON CONFLICT DO NOTHING",
-            )
-            .bind(engram_id)
-            .bind(tid)
-            .execute(&mut *c)
-            .await
-            .map_err(IndexError::from)?;
+            tag_ids.push(self.tag_id(&mut *c, tag).await?);
+        }
+        for batch in tag_ids.chunks(INSERT_CHUNK) {
+            let mut params: Vec<Param> = Vec::with_capacity(batch.len() * 2);
+            for tid in batch {
+                params.push(Param::Int(engram_id));
+                params.push(Param::Int(*tid));
+            }
+            let sql = format!(
+                "INSERT INTO engram_tag(engram_id, tag_id) VALUES {} ON CONFLICT DO NOTHING",
+                value_rows(2, batch.len(), None)
+            );
+            exec(&mut *c, &sql, params).await?;
         }
 
         Ok(EngramId(engram_id))
@@ -979,37 +1068,34 @@ impl Store for PostgresStore {
             .await
             .map_err(IndexError::from)?;
 
-        for chunk in chunks {
-            match carry.get(&chunk.text_hash) {
-                Some((model, dims, emb)) => {
-                    sqlx::query(
-                        "INSERT INTO chunk(engram_id, seq, text, text_hash, model, dims, embedding) \
-                         VALUES($1,$2,$3,$4,$5,$6,$7)",
-                    )
-                    .bind(eid)
-                    .bind(chunk.seq)
-                    .bind(&chunk.text)
-                    .bind(&chunk.text_hash)
-                    .bind(model.as_deref())
-                    .bind(*dims)
-                    .bind(emb.clone())
-                    .execute(&mut *c)
-                    .await
-                    .map_err(IndexError::from)?;
-                }
-                None => {
-                    sqlx::query(
-                        "INSERT INTO chunk(engram_id, seq, text, text_hash) VALUES($1,$2,$3,$4)",
-                    )
-                    .bind(eid)
-                    .bind(chunk.seq)
-                    .bind(&chunk.text)
-                    .bind(&chunk.text_hash)
-                    .execute(&mut *c)
-                    .await
-                    .map_err(IndexError::from)?;
+        // One 7-column multi-row insert for every chunk: a carry hit binds its
+        // preserved model, dims and embedding, a miss binds NULL for all three
+        // and leaves the chunk pending re-embedding.
+        for batch in chunks.chunks(INSERT_CHUNK) {
+            let mut params: Vec<Param> = Vec::with_capacity(batch.len() * 7);
+            for chunk in batch {
+                params.push(Param::Int(eid));
+                params.push(Param::Int(chunk.seq));
+                params.push(Param::Text(chunk.text.clone()));
+                params.push(Param::Text(chunk.text_hash.clone()));
+                match carry.get(&chunk.text_hash) {
+                    Some((model, dims, emb)) => {
+                        params.push(Param::TextOpt(model.clone()));
+                        params.push(Param::IntOpt(*dims));
+                        params.push(Param::VectorOpt(Some(emb.clone())));
+                    }
+                    None => {
+                        params.push(Param::TextOpt(None));
+                        params.push(Param::IntOpt(None));
+                        params.push(Param::VectorOpt(None));
+                    }
                 }
             }
+            let sql = format!(
+                "INSERT INTO chunk(engram_id, seq, text, text_hash, model, dims, embedding) VALUES {}",
+                value_rows(7, batch.len(), None)
+            );
+            exec(&mut *c, &sql, params).await?;
         }
         Ok(())
     }
@@ -1063,8 +1149,8 @@ impl Store for PostgresStore {
     }
 
     async fn store_embeddings(&self, batch: &[EmbeddingRow], model: &str) -> Result<()> {
-        let mut conn = self.acquire().await?;
-        let c = conn.as_mut();
+        // Validate the whole batch before any write so a bad row never leaves
+        // earlier rows committed.
         for row in batch {
             if row.embedding.len() != row.dims {
                 return Err(IndexError::Invalid(format!(
@@ -1073,17 +1159,45 @@ impl Store for PostgresStore {
                     row.dims
                 )));
             }
-            self.ensure_embedding_width(&mut *c, row.dims).await?;
-            let vector = pgvector::Vector::from(row.embedding.clone());
-            sqlx::query("UPDATE chunk SET embedding=$1, dims=$2, model=$3 WHERE id=$4")
-                .bind(vector)
-                .bind(row.dims as i64)
-                .bind(model)
-                .bind(row.chunk_id)
-                .execute(&mut *c)
-                .await
-                .map_err(IndexError::from)?;
         }
+        let mut conn = self.acquire().await?;
+        let c = conn.as_mut();
+        // `dims` is per row, and a width change may DDL (resize the column, drop
+        // and recreate the index), so make each distinct width current once and
+        // before the transaction opens rather than once per row inside it.
+        let mut widths: Vec<usize> = Vec::new();
+        for row in batch {
+            if !widths.contains(&row.dims) {
+                widths.push(row.dims);
+            }
+        }
+        for dims in widths {
+            self.ensure_embedding_width(&mut *c, dims).await?;
+        }
+        // The per-row updates then commit together, mirroring `wipe`.
+        sqlx::query("BEGIN")
+            .execute(&mut *c)
+            .await
+            .map_err(IndexError::from)?;
+        for row in batch {
+            let vector = pgvector::Vector::from(row.embedding.clone());
+            if let Err(e) =
+                sqlx::query("UPDATE chunk SET embedding=$1, dims=$2, model=$3 WHERE id=$4")
+                    .bind(vector)
+                    .bind(row.dims as i64)
+                    .bind(model)
+                    .bind(row.chunk_id)
+                    .execute(&mut *c)
+                    .await
+            {
+                let _ = sqlx::query("ROLLBACK").execute(&mut *c).await;
+                return Err(e.into());
+            }
+        }
+        sqlx::query("COMMIT")
+            .execute(&mut *c)
+            .await
+            .map_err(IndexError::from)?;
         Ok(())
     }
 

--- a/crates/index/src/postgres/search.rs
+++ b/crates/index/src/postgres/search.rs
@@ -127,7 +127,8 @@ async fn scored_lexical(
 
     let mut scored: Vec<(f64, Candidate)> = Vec::with_capacity(rows.len());
     for r in &rows {
-        let c = Candidate::from_row(r);
+        let mut c = Candidate::from_row(r);
+        c.lower();
         let score = c.score(terms);
         scored.push((score, c));
     }
@@ -610,6 +611,9 @@ fn clone_params(params: &[Param]) -> Vec<Param> {
             Param::Text(s) => Param::Text(s.clone()),
             Param::Int(i) => Param::Int(*i),
             Param::Vector(v) => Param::Vector(v.clone()),
+            Param::TextOpt(s) => Param::TextOpt(s.clone()),
+            Param::IntOpt(i) => Param::IntOpt(*i),
+            Param::VectorOpt(v) => Param::VectorOpt(v.clone()),
         })
         .collect()
 }
@@ -624,6 +628,14 @@ struct Candidate {
     status: String,
     description: Option<String>,
     content: String,
+    // Lowercased title, description and content, computed once by `lower` on the
+    // lexical scoring path and reused by `score`, `into_hit` and `text_snippet`
+    // so those methods never re-lowercase per term. Left empty on the semantic
+    // and filter-only paths, which never term-score, so those paths pay nothing;
+    // the methods that read these run only on lexically constructed candidates.
+    title_lower: String,
+    desc_lower: String,
+    content_lower: String,
 }
 
 impl Candidate {
@@ -637,18 +649,31 @@ impl Candidate {
             status: cell_text(r, 5).unwrap_or_default(),
             description: cell_text(r, 6),
             content: cell_text(r, 7).unwrap_or_default(),
+            title_lower: String::new(),
+            desc_lower: String::new(),
+            content_lower: String::new(),
         }
     }
 
+    /// Lowercase title, description and content once for the lexical path.
+    /// `to_lowercase` (full Unicode case folding) is kept rather than an
+    /// ASCII-only comparison so a non-ASCII term still matches its own case.
+    fn lower(&mut self) {
+        self.title_lower = self.title.to_lowercase();
+        self.desc_lower = self
+            .description
+            .as_deref()
+            .unwrap_or_default()
+            .to_lowercase();
+        self.content_lower = self.content.to_lowercase();
+    }
+
     fn score(&self, terms: &[String]) -> f64 {
-        let title = self.title.to_lowercase();
-        let desc = self.description.clone().unwrap_or_default().to_lowercase();
-        let content = self.content.to_lowercase();
         let mut score = 0.0;
         for term in terms {
-            score += 3.0 * count_occ(&title, term) as f64;
-            score += 2.0 * count_occ(&desc, term) as f64;
-            score += count_occ(&content, term) as f64;
+            score += 3.0 * count_occ(&self.title_lower, term) as f64;
+            score += 2.0 * count_occ(&self.desc_lower, term) as f64;
+            score += count_occ(&self.content_lower, term) as f64;
         }
         score
     }
@@ -659,15 +684,9 @@ impl Candidate {
         terms: &[String],
         score: f64,
     ) -> Result<SearchHit> {
-        let in_title = terms
-            .iter()
-            .any(|t| count_occ(&self.title.to_lowercase(), t) > 0);
-        let in_desc = self
-            .description
-            .as_ref()
-            .map(|d| d.to_lowercase())
-            .map(|d| terms.iter().any(|t| count_occ(&d, t) > 0))
-            .unwrap_or(false);
+        let in_title = terms.iter().any(|t| count_occ(&self.title_lower, t) > 0);
+        let in_desc =
+            self.description.is_some() && terms.iter().any(|t| count_occ(&self.desc_lower, t) > 0);
 
         // When the match is not in the title or description, prefer an
         // observation-level hit so the caller gets the source line.
@@ -690,10 +709,7 @@ impl Candidate {
         }
 
         let snippet_src = if in_title || !in_desc {
-            if terms
-                .iter()
-                .any(|t| count_occ(&self.content.to_lowercase(), t) > 0)
-            {
+            if terms.iter().any(|t| count_occ(&self.content_lower, t) > 0) {
                 self.content.clone()
             } else if let Some(d) = self.description.clone().filter(|d| !d.is_empty()) {
                 d
@@ -728,10 +744,7 @@ impl Candidate {
     /// A snippet windowed around the first matching term, for the lexical half
     /// of a hybrid hit.
     fn text_snippet(&self, terms: &[String]) -> String {
-        let src = if terms
-            .iter()
-            .any(|t| count_occ(&self.content.to_lowercase(), t) > 0)
-        {
+        let src = if terms.iter().any(|t| count_occ(&self.content_lower, t) > 0) {
             &self.content
         } else if let Some(d) = self.description.as_ref().filter(|d| !d.is_empty()) {
             d

--- a/crates/index/src/sync.rs
+++ b/crates/index/src/sync.rs
@@ -169,7 +169,7 @@ pub async fn sync_domain_with<S: Store + ?Sized>(
     }
 
     // Hash (and read) the survivors off-thread with bounded concurrency.
-    let hashed = hash_files(to_hash).await;
+    let hashed = hash_files(to_hash, &mut report).await;
 
     // Deleted candidates: recorded files no longer present on disk.
     let deleted_paths: Vec<String> = existing
@@ -319,12 +319,17 @@ struct Parsed {
     previously_indexed: bool,
 }
 
-async fn hash_files(files: Vec<Scanned>) -> Vec<(Scanned, Hashed)> {
+async fn hash_files(files: Vec<Scanned>, report: &mut SyncReport) -> Vec<(Scanned, Hashed)> {
     let sem = Arc::new(Semaphore::new(CONCURRENCY));
     let mut set: JoinSet<(Scanned, std::io::Result<Hashed>)> = JoinSet::new();
+    // The file identity moves into its task, so a task that panics outright
+    // would otherwise vanish without a trace. Keep a task-id to relative-path
+    // map so a panicked task is still attributable in `failed`.
+    let mut ids: HashMap<tokio::task::Id, String> = HashMap::new();
     for scanned in files {
         let sem = sem.clone();
-        set.spawn(async move {
+        let rel = scanned.rel.clone();
+        let handle = set.spawn(async move {
             let _permit = sem.acquire_owned().await.expect("semaphore open");
             let abs = scanned.abs.clone();
             let res = tokio::task::spawn_blocking(move || read_and_hash(&abs))
@@ -332,21 +337,35 @@ async fn hash_files(files: Vec<Scanned>) -> Vec<(Scanned, Hashed)> {
                 .unwrap_or_else(|e| Err(std::io::Error::other(e.to_string())));
             (scanned, res)
         });
+        ids.insert(handle.id(), rel);
     }
     let mut out = Vec::new();
-    while let Some(joined) = set.join_next().await {
-        if let Ok((scanned, Ok(hashed))) = joined {
-            out.push((scanned, hashed));
-        } else if let Ok((scanned, Err(_))) = joined {
-            // Unreadable file: surface it as a change with no content so the
-            // parse phase reports the failure.
-            out.push((
-                scanned,
-                Hashed {
-                    sha256: String::new(),
-                    content: None,
-                },
-            ));
+    while let Some(joined) = set.join_next_with_id().await {
+        match joined {
+            Ok((id, (scanned, Ok(hashed)))) => {
+                ids.remove(&id);
+                out.push((scanned, hashed));
+            }
+            Ok((id, (scanned, Err(_)))) => {
+                ids.remove(&id);
+                // Unreadable file: surface it as a change with no content so the
+                // parse phase reports the failure.
+                out.push((
+                    scanned,
+                    Hashed {
+                        sha256: String::new(),
+                        content: None,
+                    },
+                ));
+            }
+            Err(join_err) => {
+                let rel = ids
+                    .remove(&join_err.id())
+                    .unwrap_or_else(|| "unknown".to_string());
+                report
+                    .failed
+                    .push((rel, format!("task panicked: {join_err}")));
+            }
         }
     }
     out
@@ -356,7 +375,7 @@ fn read_and_hash(path: &Path) -> std::io::Result<Hashed> {
     let bytes = std::fs::read(path)?;
     let mut hasher = Sha256::new();
     hasher.update(&bytes);
-    let sha256 = hex(&hasher.finalize());
+    let sha256 = crate::hex_lower(&hasher.finalize());
     let content = String::from_utf8(bytes).ok();
     Ok(Hashed { sha256, content })
 }
@@ -367,9 +386,14 @@ async fn parse_files(
 ) -> Vec<Parsed> {
     let sem = Arc::new(Semaphore::new(CONCURRENCY));
     let mut set: JoinSet<ParseOutcome> = JoinSet::new();
+    // The relative path moves into its task (it lands in the `ParseOutcome`), so
+    // a task that panics outright would lose it. Keep a task-id to path map so a
+    // panicked task is still attributable in `failed`.
+    let mut ids: HashMap<tokio::task::Id, String> = HashMap::new();
     for (scanned, hashed, previously_indexed) in changed {
         let sem = sem.clone();
-        set.spawn(async move {
+        let rel = scanned.rel.clone();
+        let handle = set.spawn(async move {
             let _permit = sem.acquire_owned().await.expect("semaphore open");
             let Some(content) = hashed.content else {
                 return ParseOutcome::Failed(scanned.rel, "file is not valid UTF-8".to_string());
@@ -392,17 +416,31 @@ async fn parse_files(
                 Err(e) => ParseOutcome::Failed(scanned.rel, e.to_string()),
             }
         });
+        ids.insert(handle.id(), rel);
     }
 
     let mut out = Vec::new();
-    while let Some(joined) = set.join_next().await {
+    while let Some(joined) = set.join_next_with_id().await {
         match joined {
-            Ok(ParseOutcome::Ok(record, previously_indexed)) => out.push(Parsed {
-                previously_indexed,
-                record: *record,
-            }),
-            Ok(ParseOutcome::Failed(path, err)) => report.failed.push((path, err)),
-            Err(_) => {}
+            Ok((id, ParseOutcome::Ok(record, previously_indexed))) => {
+                ids.remove(&id);
+                out.push(Parsed {
+                    previously_indexed,
+                    record: *record,
+                });
+            }
+            Ok((id, ParseOutcome::Failed(path, err))) => {
+                ids.remove(&id);
+                report.failed.push((path, err));
+            }
+            Err(join_err) => {
+                let rel = ids
+                    .remove(&join_err.id())
+                    .unwrap_or_else(|| "unknown".to_string());
+                report
+                    .failed
+                    .push((rel, format!("task panicked: {join_err}")));
+            }
         }
     }
     out
@@ -429,14 +467,6 @@ fn rel_path(root: &Path, path: &Path) -> String {
         .map(|c| c.as_os_str().to_string_lossy().into_owned())
         .collect::<Vec<_>>()
         .join("/")
-}
-
-fn hex(bytes: &[u8]) -> String {
-    let mut s = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        s.push_str(&format!("{b:02x}"));
-    }
-    s
 }
 
 fn duration_ms(d: Duration) -> u64 {

--- a/crates/index/src/turso/mod.rs
+++ b/crates/index/src/turso/mod.rs
@@ -224,6 +224,43 @@ fn opt_text(o: &Option<String>) -> Value {
     }
 }
 
+/// The maximum number of value tuples in one multi-row INSERT. Chunking keeps the
+/// bind-parameter count under SQLite's 999-parameter ceiling for every child
+/// table (the widest is chunk at 7 params per row).
+const INSERT_CHUNK: usize = 100;
+
+/// Build the parenthesized value tuples for a multi-row INSERT: `count` tuples of
+/// `width` sequential `?n` placeholders each, plus an optional fixed trailing
+/// column (a literal `NULL` `to_id` for relations and links). `count` must be
+/// non-zero; an empty VALUES list is not valid SQL, so callers iterate chunks of
+/// a possibly-empty slice and skip the statement entirely when there is nothing.
+fn value_rows(width: usize, count: usize, trailing: Option<&str>) -> String {
+    let mut n = 1;
+    let mut rows = Vec::with_capacity(count);
+    for _ in 0..count {
+        let mut cells = Vec::with_capacity(width + usize::from(trailing.is_some()));
+        for _ in 0..width {
+            cells.push(format!("?{n}"));
+            n += 1;
+        }
+        if let Some(t) = trailing {
+            cells.push(t.to_string());
+        }
+        rows.push(format!("({})", cells.join(",")));
+    }
+    rows.join(",")
+}
+
+/// The multi-row observation INSERT for `count` rows, returning each new row's id
+/// with its source line so observation tags map to the right observation without
+/// depending on `RETURNING` row order.
+fn observation_insert_sql(count: usize) -> String {
+    format!(
+        "INSERT INTO observation(engram_id, line, category, content, context) VALUES {} RETURNING id, line",
+        value_rows(5, count, None)
+    )
+}
+
 /// The stored discriminator string for a domain kind.
 fn kind_str(kind: DomainKind) -> &'static str {
     match kind {
@@ -387,74 +424,102 @@ impl Store for TursoStore {
             None => self.conn.last_insert_rowid(),
         };
 
-        for obs in &record.observations {
-            self.conn
-                .execute(
-                    "INSERT INTO observation(engram_id, line, category, content, context) VALUES(?1,?2,?3,?4,?5)",
-                    vec![
-                        Value::Integer(engram_id),
-                        Value::Integer(obs.line as i64),
-                        Value::Text(obs.category.clone()),
-                        Value::Text(obs.content.clone()),
-                        opt_text(&obs.context),
-                    ],
-                )
-                .await?;
-            if !obs.tags.is_empty() {
-                let oid = self.conn.last_insert_rowid();
-                for tag in &obs.tags {
-                    let tid = self.tag_id(tag).await?;
-                    self.conn
-                        .execute(
-                            "INSERT OR IGNORE INTO observation_tag(observation_id, tag_id) VALUES(?1,?2)",
-                            vec![Value::Integer(oid), Value::Integer(tid)],
-                        )
-                        .await?;
+        // Observations: insert in chunks and read each new row's id back joined
+        // on its source line (unique within one engram), so observation tags map
+        // to the right observation without relying on RETURNING row order.
+        let mut obs_id_by_line: HashMap<i64, i64> = HashMap::new();
+        for batch in record.observations.chunks(INSERT_CHUNK) {
+            let mut params: Vec<Value> = Vec::with_capacity(batch.len() * 5);
+            for obs in batch {
+                params.push(Value::Integer(engram_id));
+                params.push(Value::Integer(obs.line as i64));
+                params.push(Value::Text(obs.category.clone()));
+                params.push(Value::Text(obs.content.clone()));
+                params.push(opt_text(&obs.context));
+            }
+            let rows = query_all(&self.conn, &observation_insert_sql(batch.len()), params).await?;
+            for r in &rows {
+                if let (Some(id), Some(line)) = (cell_i64(r, 0), cell_i64(r, 1)) {
+                    obs_id_by_line.insert(line, id);
                 }
             }
         }
 
-        for rel in &record.relations {
-            self.conn
-                .execute(
-                    "INSERT INTO relation(engram_id, domain_id, line, rel_type, to_target, to_domain, to_id) \
-                     VALUES(?1,?2,?3,?4,?5,?6,NULL)",
-                    vec![
-                        Value::Integer(engram_id),
-                        Value::Integer(domain.0),
-                        Value::Integer(rel.line as i64),
-                        Value::Text(rel.rel_type.clone()),
-                        Value::Text(rel.to_target.clone()),
-                        opt_text(&rel.to_domain),
-                    ],
-                )
-                .await?;
+        // Observation tags: intern each tag through the cache, then insert the
+        // (observation, tag) pairs in multi-row statements.
+        let mut obs_tag_pairs: Vec<(i64, i64)> = Vec::new();
+        for obs in &record.observations {
+            let Some(&oid) = obs_id_by_line.get(&(obs.line as i64)) else {
+                continue;
+            };
+            for tag in &obs.tags {
+                let tid = self.tag_id(tag).await?;
+                obs_tag_pairs.push((oid, tid));
+            }
+        }
+        for batch in obs_tag_pairs.chunks(INSERT_CHUNK) {
+            let mut params: Vec<Value> = Vec::with_capacity(batch.len() * 2);
+            for (oid, tid) in batch {
+                params.push(Value::Integer(*oid));
+                params.push(Value::Integer(*tid));
+            }
+            let sql = format!(
+                "INSERT OR IGNORE INTO observation_tag(observation_id, tag_id) VALUES {}",
+                value_rows(2, batch.len(), None)
+            );
+            self.conn.execute(&sql, params).await?;
         }
 
-        for link in &record.links {
-            self.conn
-                .execute(
-                    "INSERT INTO link(engram_id, domain_id, line, to_target, to_domain, to_id) \
-                     VALUES(?1,?2,?3,?4,?5,NULL)",
-                    vec![
-                        Value::Integer(engram_id),
-                        Value::Integer(domain.0),
-                        Value::Integer(link.line as i64),
-                        Value::Text(link.to_target.clone()),
-                        opt_text(&link.to_domain),
-                    ],
-                )
-                .await?;
+        for batch in record.relations.chunks(INSERT_CHUNK) {
+            let mut params: Vec<Value> = Vec::with_capacity(batch.len() * 6);
+            for rel in batch {
+                params.push(Value::Integer(engram_id));
+                params.push(Value::Integer(domain.0));
+                params.push(Value::Integer(rel.line as i64));
+                params.push(Value::Text(rel.rel_type.clone()));
+                params.push(Value::Text(rel.to_target.clone()));
+                params.push(opt_text(&rel.to_domain));
+            }
+            let sql = format!(
+                "INSERT INTO relation(engram_id, domain_id, line, rel_type, to_target, to_domain, to_id) VALUES {}",
+                value_rows(6, batch.len(), Some("NULL"))
+            );
+            self.conn.execute(&sql, params).await?;
         }
 
+        for batch in record.links.chunks(INSERT_CHUNK) {
+            let mut params: Vec<Value> = Vec::with_capacity(batch.len() * 5);
+            for link in batch {
+                params.push(Value::Integer(engram_id));
+                params.push(Value::Integer(domain.0));
+                params.push(Value::Integer(link.line as i64));
+                params.push(Value::Text(link.to_target.clone()));
+                params.push(opt_text(&link.to_domain));
+            }
+            let sql = format!(
+                "INSERT INTO link(engram_id, domain_id, line, to_target, to_domain, to_id) VALUES {}",
+                value_rows(5, batch.len(), Some("NULL"))
+            );
+            self.conn.execute(&sql, params).await?;
+        }
+
+        // Engram tags: intern each tag, then insert the pairs in multi-row
+        // statements.
+        let mut tag_ids: Vec<i64> = Vec::with_capacity(record.tags.len());
         for tag in &record.tags {
-            let tid = self.tag_id(tag).await?;
-            self.conn
-                .execute(
-                    "INSERT OR IGNORE INTO engram_tag(engram_id, tag_id) VALUES(?1,?2)",
-                    vec![Value::Integer(engram_id), Value::Integer(tid)],
-                )
-                .await?;
+            tag_ids.push(self.tag_id(tag).await?);
+        }
+        for batch in tag_ids.chunks(INSERT_CHUNK) {
+            let mut params: Vec<Value> = Vec::with_capacity(batch.len() * 2);
+            for tid in batch {
+                params.push(Value::Integer(engram_id));
+                params.push(Value::Integer(*tid));
+            }
+            let sql = format!(
+                "INSERT OR IGNORE INTO engram_tag(engram_id, tag_id) VALUES {}",
+                value_rows(2, batch.len(), None)
+            );
+            self.conn.execute(&sql, params).await?;
         }
 
         Ok(EngramId(engram_id))
@@ -835,39 +900,34 @@ impl Store for TursoStore {
             )
             .await?;
 
-        for c in chunks {
-            match carry.get(&c.text_hash) {
-                Some((model, dims, emb)) => {
-                    self.conn
-                        .execute(
-                            "INSERT INTO chunk(engram_id, seq, text, text_hash, model, dims, embedding) \
-                             VALUES(?1,?2,?3,?4,?5,?6,?7)",
-                            vec![
-                                Value::Integer(eid),
-                                Value::Integer(c.seq),
-                                Value::Text(c.text.clone()),
-                                Value::Text(c.text_hash.clone()),
-                                model.clone(),
-                                dims.clone(),
-                                Value::Blob(emb.clone()),
-                            ],
-                        )
-                        .await?;
-                }
-                None => {
-                    self.conn
-                        .execute(
-                            "INSERT INTO chunk(engram_id, seq, text, text_hash) VALUES(?1,?2,?3,?4)",
-                            vec![
-                                Value::Integer(eid),
-                                Value::Integer(c.seq),
-                                Value::Text(c.text.clone()),
-                                Value::Text(c.text_hash.clone()),
-                            ],
-                        )
-                        .await?;
+        // One 7-column multi-row insert for every chunk: a carry hit binds its
+        // preserved model, dims and embedding, a miss binds NULL for all three
+        // and leaves the chunk pending re-embedding.
+        for batch in chunks.chunks(INSERT_CHUNK) {
+            let mut params: Vec<Value> = Vec::with_capacity(batch.len() * 7);
+            for c in batch {
+                params.push(Value::Integer(eid));
+                params.push(Value::Integer(c.seq));
+                params.push(Value::Text(c.text.clone()));
+                params.push(Value::Text(c.text_hash.clone()));
+                match carry.get(&c.text_hash) {
+                    Some((model, dims, emb)) => {
+                        params.push(model.clone());
+                        params.push(dims.clone());
+                        params.push(Value::Blob(emb.clone()));
+                    }
+                    None => {
+                        params.push(Value::Null);
+                        params.push(Value::Null);
+                        params.push(Value::Null);
+                    }
                 }
             }
+            let sql = format!(
+                "INSERT INTO chunk(engram_id, seq, text, text_hash, model, dims, embedding) VALUES {}",
+                value_rows(7, batch.len(), None)
+            );
+            self.conn.execute(&sql, params).await?;
         }
         Ok(())
     }
@@ -920,6 +980,10 @@ impl Store for TursoStore {
     }
 
     async fn store_embeddings(&self, batch: &[EmbeddingRow], model: &str) -> Result<()> {
+        // Validate the whole batch before opening the transaction so a bad row
+        // never leaves earlier rows committed. The transaction then makes the
+        // per-row updates all-or-nothing against a mid-batch database error,
+        // mirroring `wipe`.
         for row in batch {
             if row.embedding.len() != row.dims {
                 return Err(IndexError::Invalid(format!(
@@ -928,11 +992,15 @@ impl Store for TursoStore {
                     row.dims
                 )));
             }
+        }
+        self.conn.execute("BEGIN", ()).await?;
+        for row in batch {
             let mut bytes = Vec::with_capacity(row.embedding.len() * 4);
             for f in &row.embedding {
                 bytes.extend_from_slice(&f.to_le_bytes());
             }
-            self.conn
+            if let Err(e) = self
+                .conn
                 .execute(
                     "UPDATE chunk SET embedding=?1, dims=?2, model=?3 WHERE id=?4",
                     vec![
@@ -942,8 +1010,13 @@ impl Store for TursoStore {
                         Value::Integer(row.chunk_id),
                     ],
                 )
-                .await?;
+                .await
+            {
+                let _ = self.conn.execute("ROLLBACK", ()).await;
+                return Err(e.into());
+            }
         }
+        self.conn.execute("COMMIT", ()).await?;
         Ok(())
     }
 
@@ -1154,5 +1227,129 @@ impl Store for TursoStore {
     async fn rollback(&self) -> Result<()> {
         self.conn.execute("ROLLBACK", ()).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::store::{FileStamp, ObservationRecord};
+
+    #[test]
+    fn observation_insert_is_one_statement_with_a_tuple_per_row() {
+        let sql = observation_insert_sql(3);
+        assert_eq!(sql.matches("INSERT").count(), 1, "one INSERT: {sql}");
+        // One `(?` opens each value tuple, so three tuples for three rows.
+        assert_eq!(sql.matches("(?").count(), 3, "three value tuples: {sql}");
+        assert!(
+            sql.contains("VALUES (?1,?2,?3,?4,?5),(?6,?7,?8,?9,?10),(?11,?12,?13,?14,?15)"),
+            "sequential placeholders across all rows: {sql}"
+        );
+        assert!(
+            sql.ends_with("RETURNING id, line"),
+            "returns id and line: {sql}"
+        );
+    }
+
+    fn obs(line: usize, content: &str, tags: &[&str]) -> ObservationRecord {
+        ObservationRecord {
+            line,
+            category: "fact".to_string(),
+            content: content.to_string(),
+            tags: tags.iter().map(|t| t.to_string()).collect(),
+            context: None,
+        }
+    }
+
+    fn record_with_observations(observations: Vec<ObservationRecord>) -> EngramRecord {
+        EngramRecord {
+            path: "a.md".to_string(),
+            permalink: "a".to_string(),
+            title: "A".to_string(),
+            engram_type: "engram".to_string(),
+            status: "current".to_string(),
+            recorded_at: Some("2026-01-01".to_string()),
+            valid_from: None,
+            valid_to: None,
+            timestamp: None,
+            description: None,
+            content: "body".to_string(),
+            metadata: serde_json::json!({}),
+            tags: Vec::new(),
+            observations,
+            relations: Vec::new(),
+            links: Vec::new(),
+            stamp: FileStamp {
+                mtime: 0,
+                size: 4,
+                sha256: "sha".to_string(),
+            },
+        }
+    }
+
+    /// Every observation's tag set read back keyed by source line, so a
+    /// mismapped tag surfaces against the wrong line.
+    async fn tags_by_line(store: &TursoStore, engram_id: i64) -> Vec<(i64, Vec<String>)> {
+        let rows = query_all(
+            &store.conn,
+            "SELECT o.line, t.name FROM observation o \
+             LEFT JOIN observation_tag ot ON ot.observation_id=o.id \
+             LEFT JOIN tag t ON t.id=ot.tag_id \
+             WHERE o.engram_id=?1 ORDER BY o.line, t.name",
+            vec![Value::Integer(engram_id)],
+        )
+        .await
+        .unwrap();
+        let mut map: BTreeMap<i64, Vec<String>> = BTreeMap::new();
+        for r in &rows {
+            let line = cell_i64(r, 0).unwrap();
+            let entry = map.entry(line).or_default();
+            if let Some(name) = cell_text(r, 1) {
+                entry.push(name);
+            }
+        }
+        map.into_iter().collect()
+    }
+
+    #[tokio::test]
+    async fn observation_tags_map_to_correct_observations() {
+        let store = TursoStore::open_in_memory().await.unwrap();
+        let domain = store
+            .upsert_domain("d", Some("/tmp/d"), DomainKind::File)
+            .await
+            .unwrap();
+        // Distinct lines, distinct tag sets, one observation deliberately
+        // untagged, and a tag shared by two observations.
+        let record = record_with_observations(vec![
+            obs(3, "first fact", &["alpha", "shared"]),
+            obs(7, "second fact", &["beta"]),
+            obs(11, "third fact", &[]),
+            obs(15, "fourth fact", &["shared", "gamma"]),
+        ]);
+        let id = store.upsert_engram(domain, &record).await.unwrap().0;
+
+        let expected = vec![
+            (3i64, vec!["alpha".to_string(), "shared".to_string()]),
+            (7, vec!["beta".to_string()]),
+            (11, Vec::new()),
+            (15, vec!["gamma".to_string(), "shared".to_string()]),
+        ];
+        assert_eq!(
+            tags_by_line(&store, id).await,
+            expected,
+            "each tag set maps to its own observation after the first upsert"
+        );
+
+        // A re-upsert clears and recreates the child rows; join-on-line keeps the
+        // mapping stable where a positional RETURNING map could scramble it.
+        let id2 = store.upsert_engram(domain, &record).await.unwrap().0;
+        assert_eq!(id2, id, "the same path keeps its engram id");
+        assert_eq!(
+            tags_by_line(&store, id).await,
+            expected,
+            "the mapping survives a re-upsert"
+        );
     }
 }

--- a/crates/index/src/turso/search.rs
+++ b/crates/index/src/turso/search.rs
@@ -119,7 +119,8 @@ async fn scored_lexical(
 
     let mut scored: Vec<(f64, Candidate)> = Vec::with_capacity(rows.len());
     for r in &rows {
-        let c = Candidate::from_row(r);
+        let mut c = Candidate::from_row(r);
+        c.lower();
         let score = c.score(terms);
         scored.push((score, c));
     }
@@ -630,6 +631,14 @@ struct Candidate {
     status: String,
     description: Option<String>,
     content: String,
+    // Lowercased title, description and content, computed once by `lower` on the
+    // lexical scoring path and reused by `score`, `into_hit` and `text_snippet`
+    // so those methods never re-lowercase per term. Left empty on the semantic
+    // and filter-only paths, which never term-score, so those paths pay nothing;
+    // the methods that read these run only on lexically constructed candidates.
+    title_lower: String,
+    desc_lower: String,
+    content_lower: String,
 }
 
 impl Candidate {
@@ -643,32 +652,39 @@ impl Candidate {
             status: cell_text(r, 5).unwrap_or_default(),
             description: cell_text(r, 6),
             content: cell_text(r, 7).unwrap_or_default(),
+            title_lower: String::new(),
+            desc_lower: String::new(),
+            content_lower: String::new(),
         }
     }
 
+    /// Lowercase title, description and content once for the lexical path.
+    /// `to_lowercase` (full Unicode case folding) is kept rather than an
+    /// ASCII-only comparison so a non-ASCII term still matches its own case.
+    fn lower(&mut self) {
+        self.title_lower = self.title.to_lowercase();
+        self.desc_lower = self
+            .description
+            .as_deref()
+            .unwrap_or_default()
+            .to_lowercase();
+        self.content_lower = self.content.to_lowercase();
+    }
+
     fn score(&self, terms: &[String]) -> f64 {
-        let title = self.title.to_lowercase();
-        let desc = self.description.clone().unwrap_or_default().to_lowercase();
-        let content = self.content.to_lowercase();
         let mut score = 0.0;
         for term in terms {
-            score += 3.0 * count_occ(&title, term) as f64;
-            score += 2.0 * count_occ(&desc, term) as f64;
-            score += count_occ(&content, term) as f64;
+            score += 3.0 * count_occ(&self.title_lower, term) as f64;
+            score += 2.0 * count_occ(&self.desc_lower, term) as f64;
+            score += count_occ(&self.content_lower, term) as f64;
         }
         score
     }
 
     async fn into_hit(self, conn: &Connection, terms: &[String], score: f64) -> Result<SearchHit> {
-        let in_title = terms
-            .iter()
-            .any(|t| count_occ(&self.title.to_lowercase(), t) > 0);
-        let in_desc = self
-            .description
-            .as_ref()
-            .map(|d| d.to_lowercase())
-            .map(|d| terms.iter().any(|t| count_occ(&d, t) > 0))
-            .unwrap_or(false);
+        let in_title = terms.iter().any(|t| count_occ(&self.title_lower, t) > 0);
+        let in_desc =
+            self.description.is_some() && terms.iter().any(|t| count_occ(&self.desc_lower, t) > 0);
 
         // When the match is not in the title or description, prefer an
         // observation-level hit so the caller gets the source line.
@@ -692,10 +708,7 @@ impl Candidate {
 
         let snippet_src = if in_title || !in_desc {
             // Prefer a content window; fall back to description or title.
-            if terms
-                .iter()
-                .any(|t| count_occ(&self.content.to_lowercase(), t) > 0)
-            {
+            if terms.iter().any(|t| count_occ(&self.content_lower, t) > 0) {
                 self.content.clone()
             } else if let Some(d) = self.description.clone().filter(|d| !d.is_empty()) {
                 d
@@ -730,10 +743,7 @@ impl Candidate {
     /// A snippet windowed around the first matching term, for the lexical half
     /// of a hybrid hit.
     fn text_snippet(&self, terms: &[String]) -> String {
-        let src = if terms
-            .iter()
-            .any(|t| count_occ(&self.content.to_lowercase(), t) > 0)
-        {
+        let src = if terms.iter().any(|t| count_occ(&self.content_lower, t) > 0) {
             &self.content
         } else if let Some(d) = self.description.as_ref().filter(|d| !d.is_empty()) {
             d

--- a/crates/index/tests/embed.rs
+++ b/crates/index/tests/embed.rs
@@ -3,11 +3,13 @@
 //! path, the min-similarity cutoff and the unchanged-file zero-rework guarantee.
 
 use std::path::Path;
+use std::sync::Mutex;
 
 use async_trait::async_trait;
+use crystalline_index::embed::estimate_tokens;
 use crystalline_index::{
-    ChunkParams, EmbeddingProvider, IndexError, Result, SearchMode, SearchQuery, Store, TursoStore,
-    chunk_engram, run_embedding_pass, sync_domain_with,
+    ChunkJob, ChunkParams, EmbeddingProvider, IndexError, Result, SearchMode, SearchQuery, Store,
+    TursoStore, chunk_engram, order_jobs_for_batching, run_embedding_pass, sync_domain_with,
 };
 
 // --- chunking (no store) -----------------------------------------------------
@@ -93,6 +95,42 @@ fn fingerprints_are_stable_and_model_scoped() {
         ca1[0].text_hash, cb[0].text_hash,
         "the model id namespaces the fingerprint"
     );
+}
+
+// --- batch ordering (no store) ------------------------------------------------
+
+fn job(chunk_id: i64, text: &str) -> ChunkJob {
+    ChunkJob {
+        chunk_id,
+        engram_id: 1,
+        seq: 0,
+        text: text.to_string(),
+        text_hash: "h".to_string(),
+    }
+}
+
+#[test]
+fn order_jobs_for_batching_sorts_ascending_and_keeps_ties_stable() {
+    // Four jobs: two tie at the shortest length, one is medium, one is the
+    // longest. The two tied jobs start out separated by the longer ones so a
+    // non-stable sort could plausibly swap them.
+    let mut jobs = vec![
+        job(1, &"b".repeat(40)), // 10 tokens, longest
+        job(2, &"a".repeat(4)),  // 1 token, tie group, appears first
+        job(3, &"d".repeat(20)), // 5 tokens, medium
+        job(4, &"c".repeat(4)),  // 1 token, tie group, appears second
+    ];
+    order_jobs_for_batching(&mut jobs);
+    let ids: Vec<i64> = jobs.iter().map(|j| j.chunk_id).collect();
+    assert_eq!(
+        ids,
+        vec![2, 4, 3, 1],
+        "ascending by estimated tokens, ties (2 before 4) keep their original order"
+    );
+    let tokens: Vec<usize> = jobs.iter().map(|j| estimate_tokens(&j.text)).collect();
+    for w in tokens.windows(2) {
+        assert!(w[0] <= w[1], "non-decreasing token counts: {tokens:?}");
+    }
 }
 
 // --- fake provider -----------------------------------------------------------
@@ -516,4 +554,79 @@ async fn editing_one_paragraph_only_reembeds_that_chunk() {
         coverage.embedded_chunks,
         coverage.total_chunks
     );
+}
+
+// --- batch ordering (store) ---------------------------------------------------
+
+/// A [`FakeProvider`] that also records every `embed` call's input texts, so a
+/// test can inspect batch composition after the fact.
+struct RecordingProvider {
+    model: String,
+    calls: Mutex<Vec<Vec<String>>>,
+}
+
+impl RecordingProvider {
+    fn new(model: &str) -> RecordingProvider {
+        RecordingProvider {
+            model: model.to_string(),
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for RecordingProvider {
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        self.calls.lock().unwrap().push(texts.to_vec());
+        Ok(texts.iter().map(|t| embed_one(t)).collect())
+    }
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+    fn dims(&self) -> usize {
+        8
+    }
+    fn max_input_tokens(&self) -> usize {
+        512
+    }
+}
+
+#[tokio::test]
+async fn run_embedding_pass_batches_jobs_length_ordered() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // Forty single-paragraph engrams (well over one 16-chunk batch) with
+    // strictly increasing body lengths, so each becomes exactly one chunk with
+    // a distinct estimated token count. Filesystem walk order does not sort
+    // these by length, so a monotonic embed order can only come from
+    // `order_jobs_for_batching`.
+    for i in 0..40 {
+        let body = "word ".repeat(i + 1);
+        write(
+            root,
+            &format!("e{i}.md"),
+            &engram(&format!("E{i}"), &format!("e{i}"), "", &body),
+        );
+    }
+    let store = open().await;
+    let provider = RecordingProvider::new("fake-8");
+    let params = ChunkParams::for_model(provider.model_id());
+    sync_domain_with(&store, "d", root, &params).await.unwrap();
+    run_embedding_pass(&store, &provider, |_, _| {})
+        .await
+        .unwrap();
+
+    let calls = provider.calls.lock().unwrap();
+    assert!(
+        calls.len() > 1,
+        "the corpus spans more than one embed batch"
+    );
+    let flattened: Vec<usize> = calls.iter().flatten().map(|t| estimate_tokens(t)).collect();
+    assert!(flattened.len() >= 40, "one chunk per engram");
+    for w in flattened.windows(2) {
+        assert!(
+            w[0] <= w[1],
+            "batches are length-ordered across the whole pass: {flattened:?}"
+        );
+    }
 }

--- a/crates/index/tests/store.rs
+++ b/crates/index/tests/store.rs
@@ -1288,6 +1288,64 @@ parity!(
     embedding_width_follows_provider
 );
 
+/// `store_embeddings` writes the whole batch or nothing. A row whose embedding
+/// length contradicts its declared dims aborts the call, and because the batch is
+/// validated up front and written inside one transaction, no earlier row stays
+/// committed. Before the transactional write the first row's UPDATE committed
+/// before the bad row aborted, leaving a chunk embedded.
+async fn store_embeddings_mid_batch_mismatch_leaves_nothing(store: &dyn Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(
+        root,
+        "a.md",
+        &engram("A", "a", "engram", "", "alpha alpha alpha body one"),
+    );
+    write(
+        root,
+        "b.md",
+        &engram("B", "b", "engram", "", "beta beta beta body two"),
+    );
+    sync_domain(store, "d", root).await.unwrap();
+
+    let jobs = store.chunks_needing_embedding("m8", None).await.unwrap();
+    assert!(
+        jobs.len() >= 2,
+        "need at least two chunks to exercise a mid-batch failure, got {}",
+        jobs.len()
+    );
+
+    // First row valid, a later row's embedding length contradicts its declared
+    // dims. The whole call must fail and leave nothing embedded.
+    let rows = vec![
+        EmbeddingRow {
+            chunk_id: jobs[0].chunk_id,
+            embedding: vec![0.1f32; 8],
+            dims: 8,
+        },
+        EmbeddingRow {
+            chunk_id: jobs[1].chunk_id,
+            embedding: vec![0.1f32; 7],
+            dims: 8,
+        },
+    ];
+    let result = store.store_embeddings(&rows, "m8").await;
+    assert!(
+        result.is_err(),
+        "a mid-batch dims mismatch must fail the call"
+    );
+
+    let coverage = store.embedding_coverage().await.unwrap();
+    assert_eq!(
+        coverage.embedded_chunks, 0,
+        "no chunk stays embedded after the batch fails"
+    );
+}
+parity!(
+    store_embeddings_is_atomic_on_mid_batch_dims_mismatch,
+    store_embeddings_mid_batch_mismatch_leaves_nothing
+);
+
 /// Models routinely double-encode nested tool arguments, sending the
 /// `metadata_filters` object as a JSON string. The wire parser accepts
 /// that form by parsing the string first; everything else non-object

--- a/crates/service/src/daemon.rs
+++ b/crates/service/src/daemon.rs
@@ -259,6 +259,11 @@ pub async fn run_serve(
         if read_only {
             eprintln!("crystalline serving read-only: content-mutating tools are disabled");
         }
+        if loaded.effective.domains.is_empty() {
+            eprintln!(
+                "no domains registered yet - agents can create one with add_domain, or run: crystalline domain add <name> <path>"
+            );
+        }
     }
 
     // The watcher arms every startup domain's watch and only then fires this
@@ -726,11 +731,24 @@ fn domain_roots(config: &GlobalConfig) -> Vec<(String, PathBuf)> {
 }
 
 /// The domain names whose root is a prefix of the event path.
+///
+/// `domains` roots are already canonical (see [`domain_roots`]), so a raw
+/// prefix match against the event path is tried first and needs no syscall.
+/// Only when that finds nothing is the event path itself canonicalized and
+/// retried, which still matches a root reached through a symlink.
 fn domains_for(path: &Path, domains: &[(String, PathBuf)]) -> Vec<String> {
+    let raw_hits: Vec<String> = domains
+        .iter()
+        .filter(|(_, root)| path.starts_with(root))
+        .map(|(name, _)| name.clone())
+        .collect();
+    if !raw_hits.is_empty() {
+        return raw_hits;
+    }
     let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     domains
         .iter()
-        .filter(|(_, root)| canonical.starts_with(root) || path.starts_with(root))
+        .filter(|(_, root)| canonical.starts_with(root))
         .map(|(name, _)| name.clone())
         .collect()
 }
@@ -930,6 +948,57 @@ mod tests {
         assert_eq!(
             cfg.allowed_hosts,
             vec!["localhost", "127.0.0.1", "::1", "muthur.lan"]
+        );
+    }
+
+    // domains_for: the raw prefix match must short-circuit before any
+    // canonicalize syscall, and the canonicalize fallback must still resolve
+    // an event path reached through a symlinked root.
+
+    #[test]
+    fn domains_for_matches_via_raw_prefix_without_canonicalizing() {
+        // A path that does not exist on disk still matches through the raw
+        // check, proving the fallback canonicalize call is never reached.
+        let root = PathBuf::from("/some/canonical/root");
+        let domains = vec![("domain".to_string(), root.clone())];
+        let event_path = root.join("sub/does-not-exist.md");
+        assert_eq!(
+            domains_for(&event_path, &domains),
+            vec!["domain".to_string()]
+        );
+    }
+
+    #[test]
+    fn domains_for_returns_empty_when_no_root_matches() {
+        let root = PathBuf::from("/some/canonical/root");
+        let domains = vec![("domain".to_string(), root)];
+        let event_path = PathBuf::from("/completely/unrelated/path/file.md");
+        assert!(domains_for(&event_path, &domains).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn domains_for_matches_a_symlinked_event_path_via_canonicalize_fallback() {
+        let base = tempfile::tempdir().unwrap();
+        let real_root = base.path().join("real");
+        std::fs::create_dir(&real_root).unwrap();
+        std::fs::write(real_root.join("note.md"), "body").unwrap();
+        // domain_roots stores the already-canonicalized root, so mirror that
+        // here rather than the raw pre-canonicalize path.
+        let canonical_root = std::fs::canonicalize(&real_root).unwrap();
+
+        let link = base.path().join("link");
+        std::os::unix::fs::symlink(&real_root, &link).unwrap();
+
+        let domains = vec![("domain".to_string(), canonical_root)];
+        // The event path travels through the symlink, so it does not
+        // textually start with the canonical root: only the canonicalize
+        // fallback resolves it.
+        let event_path = link.join("note.md");
+
+        assert_eq!(
+            domains_for(&event_path, &domains),
+            vec!["domain".to_string()]
         );
     }
 }

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -650,6 +650,13 @@ impl Engine {
         self.config.read().unwrap().clone()
     }
 
+    /// Whether team collaboration is enabled, read fresh under the config guard
+    /// without cloning the whole config. `config()` stays for callers that need
+    /// a full snapshot.
+    pub fn github_enabled(&self) -> bool {
+        self.config.read().unwrap().github_enabled()
+    }
+
     /// The active embedding model id.
     pub fn model_id(&self) -> &str {
         &self.model_id
@@ -1451,7 +1458,12 @@ impl Engine {
             }
             if let ContentSource::File { root } = &src_source {
                 let src_abs = join_rel(root, &src.path);
-                let _ = std::fs::remove_file(&src_abs);
+                if let Err(e) = std::fs::remove_file(&src_abs) {
+                    tracing::warn!(
+                        "could not remove moved source {}: {e}; leaving it in place",
+                        src_abs.display()
+                    );
+                }
             }
             let store = self.store.lock().await;
             store.delete_engram(src.domain_id, &src.path).await?;
@@ -1629,13 +1641,22 @@ impl Engine {
                 parse_metadata_filters(mf).map_err(|e| EngineError::Invalid(e.to_string()))?;
         }
 
-        let store = self.store.lock().await;
-        let effective = self
-            .effective_mode(&*store, requested, text.is_some())
-            .await?;
+        // Phase the store lock so it is never held across the provider embed
+        // call, the same discipline as `embed_pending`: fetch the provider once,
+        // hold the store lock only to resolve the effective mode (which reads
+        // embedding coverage), then drop it before embedding the query and
+        // relock for the search. The coverage snapshot can go stale between the
+        // mode decision and the search, an accepted race of the same class as
+        // already exists across two separate search calls.
+        let provider = self.provider();
+        let effective = {
+            let store = self.store.lock().await;
+            self.effective_mode(&*store, requested, text.is_some(), provider.is_some())
+                .await?
+        };
         query.mode = effective;
         if matches!(effective, SearchMode::Semantic | SearchMode::Hybrid)
-            && let Some(provider) = self.provider()
+            && let Some(provider) = &provider
         {
             let q = text.clone().unwrap_or_default();
             let vecs = provider
@@ -1646,6 +1667,7 @@ impl Engine {
             query.active_model = Some(self.model_id.clone());
         }
 
+        let store = self.store.lock().await;
         let page = store.search(&query).await?;
         Ok(json!({
             "mode": mode_str(effective),
@@ -1662,11 +1684,12 @@ impl Engine {
         store: &dyn Store,
         requested: SearchMode,
         has_text: bool,
+        has_provider: bool,
     ) -> Result<SearchMode> {
         if !matches!(requested, SearchMode::Semantic | SearchMode::Hybrid) {
             return Ok(requested);
         }
-        if !has_text || self.provider().is_none() {
+        if !has_text || !has_provider {
             return Ok(SearchMode::Text);
         }
         let coverage = store.embedding_coverage().await?;
@@ -2349,10 +2372,13 @@ impl Engine {
         let _activity = ActivityState::begin(&self.activity, "sync", only);
         let targets = self.sync_targets(only)?;
         let collab = !self.instance_id.is_empty();
-        let store = self.store.lock().await;
         let mut reports = Vec::new();
         let mut skipped = Vec::new();
+        // Acquire the store lock per domain so the guard drops between domains
+        // instead of spanning the whole run; a domain's claim and sync stay
+        // under one acquisition, keeping per-domain single-writer semantics.
         for (name, root) in &targets {
+            let store = self.store.lock().await;
             if collab {
                 match self.claim_file_host(&*store, name, root, take_over).await? {
                     HostClaim::Acquired => {}
@@ -2395,36 +2421,33 @@ impl Engine {
         let _activity = ActivityState::begin(&self.activity, "reindex", None);
         let targets = self.sync_targets(None)?;
         let collab = !self.instance_id.is_empty();
-        let store = self.store.lock().await;
-        // In collaboration mode reduce to the domains this instance may rebuild
-        // (the ones it hosts); outside it, every file domain is fair game.
-        let mut active: Vec<(String, PathBuf)> = Vec::new();
+        let mut reports = Vec::new();
+        // Acquire the store lock per domain so the guard drops between domains.
+        // Claim, clear-if-full and sync interleave per domain under one
+        // acquisition rather than claiming every domain up front; per-domain
+        // single-writer semantics are unchanged. In collaboration mode a domain
+        // hosted by another live instance is left untouched.
         for (name, root) in targets {
+            let store = self.store.lock().await;
             if collab {
                 match self.claim_file_host(&*store, &name, &root, false).await? {
-                    HostClaim::Acquired => active.push((name, root)),
+                    HostClaim::Acquired => {}
                     HostClaim::HeldByOther(host) => {
                         tracing::info!(
                             "skipping reindex of '{name}' hosted by instance {}",
                             host.instance_id
                         );
+                        continue;
                     }
                 }
-            } else {
-                active.push((name, root));
             }
-        }
-        if full {
-            for (name, root) in &active {
+            if full {
                 let domain_id = store
-                    .upsert_domain(name, Some(&root.to_string_lossy()), DomainKind::File)
+                    .upsert_domain(&name, Some(&root.to_string_lossy()), DomainKind::File)
                     .await?;
                 store.clear_domain(domain_id).await?;
             }
-        }
-        let mut reports = Vec::new();
-        for (name, root) in &active {
-            let report = sync_domain_with(&*store, name, root, &self.chunk_params)
+            let report = sync_domain_with(&*store, &name, &root, &self.chunk_params)
                 .await
                 .map_err(|e| EngineError::Internal(format!("reindex of '{name}' failed: {e}")))?;
             reports.push(report);
@@ -2747,7 +2770,7 @@ impl Engine {
     /// freshly added domain, or an `update_domain` pull) and the very next
     /// `list_tools` must reflect that.
     pub fn provisioning_declared(&self) -> bool {
-        crystalline_core::provision::any_domain_declares(&self.config())
+        crystalline_core::provision::any_domain_declares(&self.config.read().unwrap())
     }
 
     /// Apply, inspect or record a decision for domain-declared artifact
@@ -5026,12 +5049,7 @@ fn virtual_stamp(content: &str) -> FileStamp {
 fn sha256_hex(bytes: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
-    let digest = hasher.finalize();
-    let mut s = String::with_capacity(digest.len() * 2);
-    for b in digest {
-        s.push_str(&format!("{b:02x}"));
-    }
-    s
+    crystalline_index::hex_lower(&hasher.finalize())
 }
 
 fn mtime_secs(meta: &std::fs::Metadata) -> i64 {

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -33,7 +33,8 @@ use crystalline_core::{
 use crystalline_index::{
     ChunkParams, DomainHost, DomainId, DomainKind, EmbeddingProvider, EngramDescriptor, EngramId,
     EngramRecord, FileStamp, HostClaim, RecentFilter, SearchMode, SearchQuery, Store, chunk_engram,
-    configured_model_id, parse_metadata_filters, provider_from_config, sync_domain_with,
+    configured_model_id, order_jobs_for_batching, parse_metadata_filters, provider_from_config,
+    sync_domain_with,
 };
 use crystalline_remote::ops;
 use crystalline_remote::{
@@ -2582,7 +2583,7 @@ impl Engine {
         // collaboration mode the scan is scoped to the file domains this instance
         // hosts plus all virtual domains, so a non-host does not wastefully
         // re-embed a chunk another instance owns; standalone it embeds everything.
-        let jobs = {
+        let mut jobs = {
             let store = self.store.lock().await;
             let scope = self.embed_scope(&*store).await?;
             store
@@ -2592,6 +2593,10 @@ impl Engine {
         if jobs.is_empty() {
             return Ok(0);
         }
+        // Length-sort so batches pay for their longest member once instead of
+        // padding every short chunk out to whatever long one happened to land
+        // in the same batch.
+        order_jobs_for_batching(&mut jobs);
         let _activity = ActivityState::begin(&self.activity, "embed", None);
         let mut embedded = 0usize;
         for batch in jobs.chunks(EMBED_BATCH) {

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -31,6 +31,6 @@ pub use daemon::run_serve;
 pub use engine::{Engine, EngineError};
 pub use harness_cli::{CliRun, SystemMcpRunner, run_harness_cli};
 pub use mcp::McpServer;
-pub use origin::parse_origin_spec;
+pub use origin::{default_domain_folder, parse_origin_spec};
 pub use overlay::{EnvDomain, EnvOverlay, LoadedConfig};
 pub use stub::{DegradedServer, StubStatus};

--- a/crates/service/src/mcp.rs
+++ b/crates/service/src/mcp.rs
@@ -422,9 +422,9 @@ impl McpServer {
             return result.map_err(to_error).and_then(ok);
         }
 
-        let before = self.engine.config().github_enabled();
+        let before = self.engine.github_enabled();
         self.apply_settings(&p).await?;
-        let after = self.engine.config().github_enabled();
+        let after = self.engine.github_enabled();
         if before != after
             && let Err(e) = peer.notify_tool_list_changed().await
         {
@@ -777,7 +777,7 @@ impl ServerHandler for McpServer {
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
         let read_only = self.engine.read_only();
-        let github_enabled = self.engine.config().github_enabled();
+        let github_enabled = self.engine.github_enabled();
         let provisioning_declared = self.engine.provisioning_declared();
         let mut tools = Self::tool_router().list_all();
         tools.retain(|t| {
@@ -808,7 +808,7 @@ impl ServerHandler for McpServer {
             return None;
         }
         if is_collab_tool(name) {
-            let github_enabled = self.engine.config().github_enabled();
+            let github_enabled = self.engine.github_enabled();
             if hidden_collab_tool(name, github_enabled, read_only) {
                 return None;
             }

--- a/crates/service/src/mcp.rs
+++ b/crates/service/src/mcp.rs
@@ -270,7 +270,7 @@ impl McpServer {
     #[tool(
         name = "search_engrams",
         title = "Search engrams",
-        description = "Search across every registered domain by default (an all-domain sweep) or a chosen few to recall relevant knowledge and experience. Defaults to hybrid lexical-plus-semantic ranking and falls back to plain text when embeddings are not ready. Filter by type, tags, status, arbitrary frontmatter or a recorded-after date; a filter-only search with no query text is allowed. Every hit is labelled with its domain, and a hit inside an observation carries its line. A hit's snippet is a short window around the match, never the whole engram: read_engram returns the full content, so read before citing or summarizing what a hit only previews.",
+        description = "Search across every registered domain by default (an all-domain sweep) or a chosen few to recall relevant knowledge and experience. Defaults to hybrid lexical-plus-semantic ranking and falls back to plain text when embeddings are not ready. Filter by type, tags, status, arbitrary frontmatter or a recorded-after date; a filter-only search with no query text is allowed. Every hit is labelled with its domain, and a hit inside an observation carries its line. A hit's snippet is a short window around the match, never the whole engram: read_engram returns the full content, so read before citing or summarizing what a hit only previews. The result reports total, page, limit and count; when count is below total, request the next page to see the rest.",
         annotations(read_only_hint = true, open_world_hint = false)
     )]
     async fn search_engrams(

--- a/crates/service/src/origin.rs
+++ b/crates/service/src/origin.rs
@@ -41,9 +41,11 @@ pub(crate) fn default_domain_name(repo: &str) -> String {
 /// The domain folder a domain-creating call uses when the caller does not
 /// supply one: `<root>/<domain>`, where `root` is the configured domains root
 /// (`GlobalConfig::domains_root`, `~/Documents/Crystalline` by default). Kept a
-/// free function over the already-resolved root so both `origin_add` and the
-/// local-domain path share one placement rule.
-pub(crate) fn default_domain_folder(root: &Path, domain: &str) -> PathBuf {
+/// free function over the already-resolved root so both `origin_add`, the
+/// local-domain path and the standalone CLI's `domain add` (which has no
+/// engine to call into) share one placement rule. Public (re-exported from
+/// the crate root) for that last caller.
+pub fn default_domain_folder(root: &Path, domain: &str) -> PathBuf {
     root.join(domain)
 }
 

--- a/crates/service/tests/origin.rs
+++ b/crates/service/tests/origin.rs
@@ -1791,3 +1791,67 @@ async fn domain_add_local_schedules_embedding_on_the_worker_channel() {
         "domain_add_local must schedule a background embed instead of embedding inline"
     );
 }
+
+// --- hybrid search lock discipline (M2.1) ------------------------------------
+
+/// Pins the three-phase `search_engrams` contract that the A2+A12 lock
+/// restructure must preserve: with active embeddings and a stub provider a
+/// hybrid search reports `mode: hybrid`, still returns hits and embeds the
+/// query exactly once. It passes before and after the change (a regression pin,
+/// not a red-first test); the win is that no store guard is held across the
+/// provider embed call, which structural review guards, so this asserts
+/// behavior only and never times a lock.
+#[tokio::test]
+async fn hybrid_search_returns_hits_and_embeds_the_query_once() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mock = Arc::new(MockProvider::new());
+    let eng = engine_with(
+        &tmp.path().join("config.yaml"),
+        &tmp.path().join("origins"),
+        mock,
+        false,
+        false,
+    )
+    .await;
+    let embedder = Arc::new(CountingEmbedder::new());
+    eng.set_provider(embedder.clone());
+
+    // A local domain with one engram, synced and embedded inline: no embed
+    // channel is wired, so `domain_add_local` runs the embed pass itself and the
+    // store ends up with active embeddings for the engine's model.
+    let folder = tmp.path().join("local-notes");
+    std::fs::create_dir_all(folder.join("notes")).unwrap();
+    std::fs::write(folder.join("MANIFEST.md"), manifest()).unwrap();
+    std::fs::write(
+        folder.join("notes/alpha.md"),
+        engram("Alpha", "alpha", "alpha body"),
+    )
+    .unwrap();
+    eng.domain_add_local(Some("local-notes"), Some(folder.to_str().unwrap()))
+        .await
+        .unwrap();
+
+    let before = embedder.calls.load(std::sync::atomic::Ordering::SeqCst);
+    assert!(before >= 1, "the inline embed pass ran during domain add");
+
+    let hits = eng
+        .search_engrams(&SearchParams {
+            query: Some("alpha".to_string()),
+            search_type: Some("hybrid".to_string()),
+            domains: vec!["local-notes".to_string()],
+            ..SearchParams::default()
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        hits["mode"], "hybrid",
+        "active embeddings keep the mode hybrid"
+    );
+    assert!(
+        hits["total"].as_u64().unwrap() >= 1,
+        "the hybrid search still returns hits"
+    );
+    let after = embedder.calls.load(std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(after, before + 1, "the query was embedded exactly once");
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -88,7 +88,7 @@ flowchart LR
     D --> I[Index in /var/lib/crystalline]
 ```
 
-## Published read-only knowledge base
+## Published read-only domains
 
 When a team curates knowledge as a reviewed git repository instead of writing into the container directly, `examples/docker/compose.git-sync.yaml` adds a sidecar that pulls the repository into a shared volume every 60 seconds and mounts it read-only into Crystalline. The daemon runs with `--read-only`, so the four content-mutating tools disappear from the MCP tool list and agents can only search and read, while sync, the file watcher and embedding keep following every pull. A team domain connected to a GitHub origin (see [Team knowledge on GitHub](#team-knowledge-on-github)) gets the same effect natively, no sidecar container needed: `update_domain` and `origin_status` stay visible even in read-only mode, so a read-only instance keeps a team domain current on its own background poll schedule. A third option needs no mounted config and no sidecar at all: an immutable image started with `CRYSTALLINE_SERVICE_READ_ONLY=true`, `CRYSTALLINE_GITHUB_ENABLED=true`, one or more `CRYSTALLINE_DOMAIN_<NAME>` and `CRYSTALLINE_DOMAIN_<NAME>_ORIGIN` pairs and `CRYSTALLINE_GITHUB_TOKEN` for a headless sign-in bootstraps each team domain itself on first start and keeps it current on the same background poll schedule, with nothing left to mount or edit ever again. See [Read-only deployments](#read-only-deployments) and [Configure through environment variables](#configure-through-environment-variables) for the full behavior and variable list.
 


### PR DESCRIPTION
Five milestones from a four-track audit (index, service, core+cli, UX surfaces). Low-risk perf/reliability pure wins plus the UX batch; medium-risk findings are recorded as follow-ups in the plan, not implemented.

- Index: store_embeddings validates up front and writes in one transaction on both backends; child rows and replaced chunks insert as chunked multi-row statements with observation ids joined back on the source line via RETURNING; lexical candidates lowercase once; shared hex encoder; panicked hash/parse tasks land in the sync report.
- Engine: the store lock is never held across the query-embedding call in search; sync and reindex acquire the store per domain; list_tools stops deep-cloning the config; failed source removal on cross-domain moves is warned.
- Core/build: the body scanner skips masking on lines without wikilink openers and masks in a single buffer; release profile gains thin LTO and one codegen unit; the watcher prefix-matches before canonicalizing.
- CLI UX: human renderings for read, search, recent, context and write with --json byte-identical; delete confirms at a TTY with --force for scripts; domain add defaults its path; quickstart epilog, first-run guidance, relative timestamps, per-domain sync progress and byte progress for model downloads.

Verification: 1103 tests green plus doctests, clippy -D warnings, fmt and style-lint; deterministic atomicity and mapping tests instead of timing assertions; perf corpus warm sync unchanged at 3 ms; 13-check UX smoke against the release binary passed. Windows CI on this PR is the backstop for the IsTerminal paths.