### PR TITLE
Tier 2: search hot path, embed resilience, sync scalability and probe-driven tuning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,6 +1184,7 @@ name = "crystalline-index"
 version = "0.8.7"
 dependencies = [
  "async-trait",
+ "axum",
  "candle-core",
  "candle-nn",
  "candle-transformers",

--- a/crates/cli/src/cmd.rs
+++ b/crates/cli/src/cmd.rs
@@ -925,6 +925,15 @@ pub async fn reindex(
     if embed {
         embed_pass(&*store, &cfg).await?;
     }
+
+    if full {
+        // A full reindex is the biggest single rewrite the database sees;
+        // shrink the WAL back down rather than leaving it to grow until the
+        // next natural checkpoint. A no-op on Postgres (no local WAL file);
+        // on Turso this replaces the downstream Docker image build's shell-out
+        // to `sqlite3` for the same purpose.
+        store.checkpoint_wal().await?;
+    }
     Ok(())
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -957,7 +957,7 @@ fn main() -> anyhow::Result<()> {
             config,
         }) => on_runtime(move || reindex_dispatch(full, embed, config, cli.db, cli.json)),
         Some(Command::Status { config }) => {
-            on_runtime(move || status_dispatch(config, cli.db, cli.json))
+            on_runtime_current_thread(move || status_dispatch(config, cli.db, cli.json))
         }
         Some(Command::Model { command }) => match command {
             ModelCommand::Download { config } => {
@@ -1014,14 +1014,14 @@ fn main() -> anyhow::Result<()> {
         }) => on_runtime(move || mcp_dispatch(embedded, read_only, config, cli.db)),
         Some(Command::Ctl { command }) => on_runtime(move || run_ctl(command, cli.json)),
         Some(
-            cmd @ (Command::Write { .. }
-            | Command::Read { .. }
-            | Command::Edit { .. }
-            | Command::Move { .. }
+            cmd @ (Command::Read { .. }
             | Command::Search { .. }
             | Command::Context { .. }
             | Command::Recent { .. }),
-        ) => on_runtime(move || run_data(cmd, cli.db, cli.json)),
+        ) => on_runtime_current_thread(move || run_data(cmd, cli.db, cli.json)),
+        Some(cmd @ (Command::Write { .. } | Command::Edit { .. } | Command::Move { .. })) => {
+            on_runtime(move || run_data(cmd, cli.db, cli.json))
+        }
         Some(Command::Delete {
             identifier,
             domain,
@@ -1826,6 +1826,54 @@ where
     }
 }
 
+/// Run an async command body on a fresh single-threaded Tokio runtime. For the
+/// read-only verbs (status, search, read, recent, context, domain list): they
+/// never need worker-pool concurrency, so `current_thread` skips spinning up a
+/// pool multi_thread always creates, even for a one-shot command that awaits
+/// one thing at a time. Kept off the four content-mutating data commands
+/// (write, edit, move, delete) and everything else that touches the daemon,
+/// sync, reindex, import or embed, which stay on [`on_runtime`].
+fn on_runtime_current_thread<F, Fut>(make: F) -> anyhow::Result<()>
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = anyhow::Result<()>>,
+{
+    on_runtime_value_current_thread(make)?
+}
+
+/// Like [`on_runtime_current_thread`] but for a future that yields a plain
+/// value, the `current_thread` sibling of [`on_runtime_value`].
+///
+/// Still spawns the same dedicated 8 MiB worker thread `on_runtime_value`
+/// does, for the same reason: a `current_thread` runtime's `block_on` still
+/// executes the future on whatever thread calls it (a `current_thread`
+/// runtime has no worker threads of its own to hand the future to - that is
+/// exactly what makes it lighter than `multi_thread`), so the Windows
+/// 1 MiB-main-thread-stack risk `on_runtime_value`'s doc comment describes is
+/// unchanged by the choice of scheduler and the dedicated thread stays.
+fn on_runtime_value_current_thread<T, F, Fut>(make: F) -> anyhow::Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: std::future::Future<Output = T>,
+{
+    let worker = std::thread::Builder::new()
+        .name("crystalline-cmd".into())
+        .stack_size(8 * 1024 * 1024)
+        .spawn(move || {
+            anyhow::Ok(
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()?
+                    .block_on(make()),
+            )
+        })?;
+    match worker.join() {
+        Ok(result) => result,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
 fn run_domain(command: DomainCommand, db: Option<PathBuf>, json: bool) -> anyhow::Result<()> {
     match command {
         DomainCommand::Init { path, name } => cmd::domain_init(&path, name.as_deref(), json),
@@ -1842,7 +1890,7 @@ fn run_domain(command: DomainCommand, db: Option<PathBuf>, json: bool) -> anyhow
                 name, path, is_virtual, origin, branch, config, db, no_sync, json,
             )
         }),
-        DomainCommand::List { config } => on_runtime(move || async move {
+        DomainCommand::List { config } => on_runtime_current_thread(move || async move {
             cmd::domain_list(config.as_deref(), db.as_deref(), json).await
         }),
         DomainCommand::Import {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -462,15 +462,35 @@ pub fn save_bytes(path: &Path, bytes: &[u8]) -> Result<(), ConfigError> {
             source,
         })?;
     }
-    let tmp = temp_sibling(path);
-    std::fs::write(&tmp, bytes).map_err(|source| ConfigError::Io {
-        path: tmp.display().to_string(),
-        source,
-    })?;
-    std::fs::rename(&tmp, path).map_err(|source| ConfigError::Io {
+    write_atomic(path, bytes).map_err(|source| ConfigError::Io {
         path: path.display().to_string(),
         source,
-    })?;
+    })
+}
+
+/// Write `bytes` to `path` atomically: write a sibling temporary file, then
+/// rename it into place, so a crash or a concurrent read mid-write never
+/// observes a truncated file. `pub(crate)` since callers outside this module
+/// (the importer's markdown write path, `crate::import`) are all within this
+/// crate; each wraps the plain `io::Error` in its own error type, matching
+/// `save_bytes` above. Does not create the parent directory - callers that
+/// need one (like `save_bytes`) create it first.
+pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = temp_sibling(path);
+    std::fs::write(&tmp, bytes)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+/// Copy `src` to `dest` atomically: copy into a sibling temporary file next to
+/// `dest`, then rename it into place. The copy half of the same crash-hygiene
+/// pattern as [`write_atomic`], for a caller (the importer's verbatim
+/// non-markdown copy path) that has a source file to duplicate rather than an
+/// already-encoded payload in memory. Does not create the parent directory.
+pub(crate) fn copy_atomic(src: &Path, dest: &Path) -> std::io::Result<()> {
+    let tmp = temp_sibling(dest);
+    std::fs::copy(src, &tmp)?;
+    std::fs::rename(&tmp, dest)?;
     Ok(())
 }
 

--- a/crates/core/src/import.rs
+++ b/crates/core/src/import.rs
@@ -234,7 +234,10 @@ fn copy_verbatim(
         let same_file = dest.exists()
             && std::fs::canonicalize(&entry.abs).ok() == std::fs::canonicalize(&dest).ok();
         if !same_file {
-            std::fs::copy(&entry.abs, &dest).map_err(io_err(&entry.abs))?;
+            // Copy-then-rename (crate::config::copy_atomic), not a direct
+            // copy: a crash mid-copy can no longer leave a truncated file at
+            // `dest` for a reader (or a re-import) to trip over.
+            crate::config::copy_atomic(&entry.abs, &dest).map_err(io_err(&entry.abs))?;
         }
     }
     report.files_copied += 1;
@@ -304,7 +307,10 @@ fn convert_markdown(
         if let Some(parent) = dest.parent() {
             std::fs::create_dir_all(parent).map_err(io_err(parent))?;
         }
-        std::fs::write(&dest, &output).map_err(io_err(&dest))?;
+        // Write-then-rename (crate::config::write_atomic), not a direct
+        // write: a crash mid-write can no longer leave a truncated engram
+        // file at `dest`.
+        crate::config::write_atomic(&dest, output.as_bytes()).map_err(io_err(&dest))?;
     }
 
     report.files_converted += 1;

--- a/crates/core/src/verify/links.rs
+++ b/crates/core/src/verify/links.rs
@@ -11,10 +11,9 @@ use std::collections::{BTreeSet, HashMap};
 
 use crate::address::{self, CrystallineUrl, LinkResolver, LookupTable, Resolution};
 use crate::engram::{Engram, LinkTarget};
-use crate::parse::{body_lines, mask_inline_code};
+use crate::parse::{BodyLine, mask_inline_code};
 
 use super::scanner::{Domain, ScannedFile};
-use super::util::body_line_start;
 use super::{Severity, Sink};
 
 /// Build the cross-domain permalink/title lookup used to resolve every
@@ -43,15 +42,19 @@ pub(crate) fn effective_permalink(file: &ScannedFile, engram: &Engram) -> String
         .unwrap_or_else(|| address::slugify(&file.rel_path.to_string_lossy()))
 }
 
+/// `file_lines` holds each file's engram body tokenized once by the verify
+/// entry point (`run_rules` in `mod.rs`), aligned by index with
+/// `domain.files`, and shared here rather than retokenized per file.
 pub(crate) fn check(
     domain: &Domain,
     domain_names: &BTreeSet<&str>,
     lookup: &LookupTable,
+    file_lines: &[Vec<BodyLine>],
     sink: &mut Sink,
 ) {
     check_duplicates(domain, sink);
 
-    for file in &domain.files {
+    for (file, lines) in domain.files.iter().zip(file_lines) {
         let Ok(engram) = &file.parsed else { continue };
         let own_permalink = effective_permalink(file, engram);
         let own_title = engram.frontmatter.title.trim().to_lowercase();
@@ -83,7 +86,7 @@ pub(crate) fn check(
             );
         }
 
-        check_crystalline_urls(file, engram, domain_names, lookup, sink);
+        check_crystalline_urls(file, lines, domain_names, lookup, sink);
     }
 }
 
@@ -226,13 +229,12 @@ fn check_target(
 /// naming a domain that is in the scan set but a permalink that is not.
 fn check_crystalline_urls(
     file: &ScannedFile,
-    engram: &Engram,
+    lines: &[BodyLine],
     domain_names: &BTreeSet<&str>,
     lookup: &LookupTable,
     sink: &mut Sink,
 ) {
-    let start = body_line_start(&file.source);
-    for bl in body_lines(&engram.body, start) {
+    for bl in lines {
         if bl.in_fence {
             continue;
         }

--- a/crates/core/src/verify/mod.rs
+++ b/crates/core/src/verify/mod.rs
@@ -30,6 +30,7 @@ use std::path::Path;
 use serde::Serialize;
 
 use crate::engram::Engram;
+use crate::parse::{BodyLine, body_lines};
 
 pub use report::{Format, render, to_github, to_human, to_json};
 pub use scanner::ScanError;
@@ -238,11 +239,25 @@ fn run_rules(domains: &[scanner::Domain], options: &VerifyOptions) -> VerifyRepo
         );
         manifest_rules::check(domain, &mut sink);
         schema_rules::check(domain, &mut sink);
-        links::check(domain, &domain_names, &lookup, &mut sink);
-        for file in &domain.files {
+
+        // Tokenize each file's body once here, aligned by index with
+        // `domain.files`, and share the slice with the L- and Q-family rules
+        // below rather than have each rule (four call sites total: one in
+        // links.rs, three in quality.rs) retokenize the same body on its own.
+        let file_lines: Vec<Vec<BodyLine>> = domain
+            .files
+            .iter()
+            .map(|f| match &f.parsed {
+                Ok(engram) => body_lines(&engram.body, util::body_line_start(&f.source)),
+                Err(_) => Vec::new(),
+            })
+            .collect();
+
+        links::check(domain, &domain_names, &lookup, &file_lines, &mut sink);
+        for (file, lines) in domain.files.iter().zip(&file_lines) {
             format::check(file, &domain.name, &mut sink);
             temporal::check(file, &mut sink);
-            quality::check(file, domain, &mut sink);
+            quality::check(file, domain, lines, &mut sink);
         }
     }
 

--- a/crates/core/src/verify/quality.rs
+++ b/crates/core/src/verify/quality.rs
@@ -9,10 +9,9 @@
 use std::collections::HashMap;
 
 use crate::engram::{Engram, Heading};
-use crate::parse::body_lines;
+use crate::parse::BodyLine;
 
 use super::scanner::{Domain, ScannedFile};
-use super::util::body_line_start;
 use super::{Severity, Sink};
 
 const DEFAULT_TOKEN_BUDGET: usize = 2500;
@@ -20,23 +19,26 @@ const MIN_CONTENT_LINES: usize = 3;
 const SIMILARITY_THRESHOLD: f64 = 0.85;
 const SIMILARITY_MIN_CHARS: usize = 80;
 
-pub(crate) fn check(file: &ScannedFile, domain: &Domain, sink: &mut Sink) {
+/// `lines` is the engram body tokenized once by the verify entry point
+/// (`run_rules` in `mod.rs`) and shared across every rule in this module that
+/// needs it, instead of each one retokenizing the same body separately.
+pub(crate) fn check(file: &ScannedFile, domain: &Domain, lines: &[BodyLine], sink: &mut Sink) {
     let Ok(engram) = &file.parsed else { return };
 
-    check_content(file, engram, sink);
+    check_content(file, lines, sink);
     check_token_budget(file, engram, domain, sink);
     check_duplicate_headings(file, engram, sink);
-    check_similar_sections(file, engram, sink);
-    check_near_miss_bullets(file, engram, sink);
+    check_similar_sections(file, engram, lines, sink);
+    check_near_miss_bullets(file, lines, sink);
 }
 
 /// Q001: an Engram with no meaningful content beyond its frontmatter is
 /// unlikely to be worth routing to. Counts non-blank body lines outside
 /// fenced code, matching the "meaningful content" convention documented for
 /// this rule family.
-fn check_content(file: &ScannedFile, engram: &Engram, sink: &mut Sink) {
-    let meaningful = body_lines(&engram.body, 1)
-        .into_iter()
+fn check_content(file: &ScannedFile, lines: &[BodyLine], sink: &mut Sink) {
+    let meaningful = lines
+        .iter()
         .filter(|l| !l.in_fence && !l.text.trim().is_empty())
         .count();
     if meaningful < MIN_CONTENT_LINES {
@@ -120,8 +122,13 @@ fn normalize_heading(text: &str) -> String {
 
 /// Q004: two `## ` sections within the same file that are near-duplicates of
 /// each other, most often a copy-paste that was not later diverged.
-fn check_similar_sections(file: &ScannedFile, engram: &Engram, sink: &mut Sink) {
-    let sections = h2_section_texts(engram, &file.source);
+fn check_similar_sections(
+    file: &ScannedFile,
+    engram: &Engram,
+    lines: &[BodyLine],
+    sink: &mut Sink,
+) {
+    let sections = h2_section_texts(engram, lines);
     for i in 0..sections.len() {
         for j in (i + 1)..sections.len() {
             let (_, a_text, a_norm) = &sections[i];
@@ -152,9 +159,7 @@ fn check_similar_sections(file: &ScannedFile, engram: &Engram, sink: &mut Sink) 
 /// Extract every `## ` section's heading line, heading text and normalized
 /// content (lowercased, non-alphanumeric collapsed to spaces, fenced code
 /// excluded).
-fn h2_section_texts(engram: &Engram, source: &str) -> Vec<(usize, String, String)> {
-    let start = body_line_start(source);
-    let lines = body_lines(&engram.body, start);
+fn h2_section_texts(engram: &Engram, lines: &[BodyLine]) -> Vec<(usize, String, String)> {
     let headings: Vec<&Heading> = engram.headings.iter().collect();
 
     let mut result = Vec::new();
@@ -168,7 +173,7 @@ fn h2_section_texts(engram: &Engram, source: &str) -> Vec<(usize, String, String
             .map(|nh| nh.line)
             .unwrap_or(usize::MAX);
         let mut buf = String::new();
-        for l in &lines {
+        for l in lines {
             if l.line_no > h.line && l.line_no < end && !l.in_fence {
                 let t = l.text.trim();
                 if !t.is_empty() {
@@ -235,9 +240,8 @@ fn bigrams(s: &str) -> Vec<(char, char)> {
 /// observation or relation grammar - most often a typo (missing space,
 /// unclosed bracket) that would otherwise silently vanish from the body's
 /// structured data with no warning at all.
-fn check_near_miss_bullets(file: &ScannedFile, engram: &Engram, sink: &mut Sink) {
-    let start = body_line_start(&file.source);
-    for bl in body_lines(&engram.body, start) {
+fn check_near_miss_bullets(file: &ScannedFile, lines: &[BodyLine], sink: &mut Sink) {
+    for bl in lines {
         if bl.in_fence {
             continue;
         }

--- a/crates/index/Cargo.toml
+++ b/crates/index/Cargo.toml
@@ -70,3 +70,4 @@ hf-hub = { workspace = true, optional = true, features = ["native-tls"] }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
+axum = { workspace = true }

--- a/crates/index/src/embed/remote.rs
+++ b/crates/index/src/embed/remote.rs
@@ -3,9 +3,9 @@
 //! Posts `{model, input: [texts]}` to `{endpoint}/embeddings` and reads
 //! `data[].embedding`, ordered by `data[].index`. The API key comes from the
 //! configured environment variable. The dimensionality is not known up front; it
-//! is taken from the first response and cached. There is a single request per
-//! batch with a request timeout and no retry beyond that one attempt: the M5
-//! daemon queue owns backoff.
+//! is taken from the first response and cached. A transient failure of the POST
+//! is retried with bounded backoff (see [`RemoteProvider::embed`]) so one blip
+//! does not abort a whole embedding pass; a non-transient failure fails at once.
 
 use std::sync::Mutex;
 use std::time::Duration;
@@ -20,6 +20,19 @@ use crate::error::{IndexError, Result};
 /// The per-request timeout for the remote endpoint.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
+/// The first retry's backoff, doubled on each subsequent retry (500 ms, 1 s,
+/// 2 s). See the retry policy on [`RemoteProvider::embed`].
+const BACKOFF_BASE: Duration = Duration::from_millis(500);
+
+/// The most retries a transient failure earns, beyond the initial attempt, so a
+/// wedged endpoint aborts the pass instead of spinning forever.
+const MAX_RETRIES: u32 = 3;
+
+/// The ceiling on the summed backoff across all retries. A `Retry-After` the
+/// endpoint asks for is honored only up to what keeps the total under this
+/// bound, so a large `Retry-After` cannot stall the pass indefinitely.
+const MAX_TOTAL_BACKOFF: Duration = Duration::from_secs(15);
+
 /// An OpenAI-compatible embedding provider.
 pub struct RemoteProvider {
     client: reqwest::Client,
@@ -27,12 +40,23 @@ pub struct RemoteProvider {
     model: String,
     api_key: Option<String>,
     dims: Mutex<usize>,
+    /// The first retry backoff, doubled on each further retry. Production uses
+    /// [`BACKOFF_BASE`]; tests inject a near-zero value so the suite never
+    /// waits on real backoff.
+    backoff_base: Duration,
 }
 
 impl RemoteProvider {
     /// Build a provider from its configuration, reading the API key from the
     /// configured environment variable when one is named.
     pub fn from_config(cfg: &EmbeddingsConfig) -> Result<RemoteProvider> {
+        Self::build(cfg, BACKOFF_BASE)
+    }
+
+    /// The shared constructor behind [`from_config`](Self::from_config), taking
+    /// the retry backoff base so tests drive it near zero. The public API only
+    /// ever supplies [`BACKOFF_BASE`].
+    fn build(cfg: &EmbeddingsConfig, backoff_base: Duration) -> Result<RemoteProvider> {
         let endpoint = cfg
             .endpoint
             .as_deref()
@@ -70,16 +94,115 @@ impl RemoteProvider {
             model: cfg.model.clone(),
             api_key,
             dims: Mutex::new(0),
+            backoff_base,
         })
     }
 
     fn url(&self) -> String {
         format!("{}/embeddings", self.endpoint)
     }
+
+    /// One POST to the endpoint, classified into success, a transient failure
+    /// worth retrying or a fatal one. The caller ([`embed`](Self::embed)) owns
+    /// the retry loop and the dims cache.
+    async fn embed_once(
+        &self,
+        request: &EmbeddingRequest<'_>,
+        inputs: usize,
+    ) -> std::result::Result<Vec<Vec<f32>>, AttemptOutcome> {
+        let mut builder = self.client.post(self.url()).json(request);
+        if let Some(key) = &self.api_key {
+            builder = builder.bearer_auth(key);
+        }
+
+        let response = match builder.send().await {
+            Ok(response) => response,
+            Err(e) => {
+                // A connect failure or a timeout is transient: the endpoint may
+                // be restarting or briefly unreachable.
+                let outcome = if e.is_timeout() || e.is_connect() {
+                    AttemptOutcome::Transient {
+                        err: e.into(),
+                        retry_after: None,
+                    }
+                } else {
+                    AttemptOutcome::Fatal(e.into())
+                };
+                return Err(outcome);
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            let code = status.as_u16();
+            // 429 and every 5xx are transient; the endpoint is rate-limiting or
+            // briefly unhealthy. Only a rate-limit-style response carries a
+            // Retry-After the endpoint wants honored.
+            let transient = code == 429 || status.is_server_error();
+            let retry_after = if code == 429 || code == 503 {
+                parse_retry_after(response.headers())
+            } else {
+                None
+            };
+            let body = response.text().await.unwrap_or_default();
+            let body = body.chars().take(500).collect::<String>();
+            let err = IndexError::Remote(format!("endpoint returned {status}: {body}"));
+            return Err(if transient {
+                AttemptOutcome::Transient { err, retry_after }
+            } else {
+                AttemptOutcome::Fatal(err)
+            });
+        }
+
+        let parsed: EmbeddingResponse = match response.json().await {
+            Ok(parsed) => parsed,
+            // A malformed body is the endpoint's fault, not a blip; replaying it
+            // would only fail the same way.
+            Err(e) => return Err(AttemptOutcome::Fatal(e.into())),
+        };
+        let mut data = parsed.data;
+        if data.len() != inputs {
+            return Err(AttemptOutcome::Fatal(IndexError::Remote(format!(
+                "endpoint returned {} embeddings for {} inputs",
+                data.len(),
+                inputs
+            ))));
+        }
+        data.sort_by_key(|d| d.index);
+        Ok(data.into_iter().map(|d| d.embedding).collect())
+    }
+}
+
+/// One attempt's failure, split by whether replaying the idempotent POST could
+/// plausibly succeed.
+enum AttemptOutcome {
+    /// Worth retrying: a 429, a 5xx, a connect error or a timeout. Carries the
+    /// `Retry-After` the endpoint asked for when it sent one.
+    Transient {
+        err: IndexError,
+        retry_after: Option<Duration>,
+    },
+    /// Not worth retrying: any other 4xx or a malformed response.
+    Fatal(IndexError),
+}
+
+/// Parse a `Retry-After` header in delta-seconds form. The HTTP-date form is not
+/// read; endpoints that rate-limit an API answer in seconds in practice.
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    let value = headers.get(reqwest::header::RETRY_AFTER)?;
+    let secs: u64 = value.to_str().ok()?.trim().parse().ok()?;
+    Some(Duration::from_secs(secs))
 }
 
 #[async_trait]
 impl EmbeddingProvider for RemoteProvider {
+    /// Retry policy: a transient failure (HTTP 429, any 5xx, a connect error or
+    /// a timeout) is retried up to [`MAX_RETRIES`] times with backoff doubling
+    /// from [`BACKOFF_BASE`]; a 429 or 503 that carries a `Retry-After` in
+    /// seconds waits the larger of that and the backoff. The summed wait is
+    /// capped at [`MAX_TOTAL_BACKOFF`]. Any other 4xx and a malformed response
+    /// are non-transient and fail on the first attempt. The POST is idempotent,
+    /// so replaying it is safe.
     async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
         if texts.is_empty() {
             return Ok(Vec::new());
@@ -89,37 +212,35 @@ impl EmbeddingProvider for RemoteProvider {
             model: &self.model,
             input: texts,
         };
-        let mut builder = self.client.post(self.url()).json(&request);
-        if let Some(key) = &self.api_key {
-            builder = builder.bearer_auth(key);
-        }
 
-        let response = builder.send().await?;
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            let body = body.chars().take(500).collect::<String>();
-            return Err(IndexError::Remote(format!(
-                "endpoint returned {status}: {body}"
-            )));
+        let mut waited = Duration::ZERO;
+        let mut retries = 0u32;
+        loop {
+            let (err, retry_after) = match self.embed_once(&request, texts.len()).await {
+                Ok(vectors) => {
+                    if let Some(first) = vectors.first() {
+                        *self.dims.lock().unwrap() = first.len();
+                    }
+                    return Ok(vectors);
+                }
+                Err(AttemptOutcome::Fatal(err)) => return Err(err),
+                Err(AttemptOutcome::Transient { err, retry_after }) => (err, retry_after),
+            };
+            if retries >= MAX_RETRIES {
+                return Err(err);
+            }
+            let backoff = self.backoff_base * (1u32 << retries);
+            let wanted = match retry_after {
+                Some(after) => after.max(backoff),
+                None => backoff,
+            };
+            // Never let the summed wait cross the ceiling: a wedged endpoint
+            // asking for a long Retry-After cannot stall the pass indefinitely.
+            let wait = wanted.min(MAX_TOTAL_BACKOFF.saturating_sub(waited));
+            tokio::time::sleep(wait).await;
+            waited += wait;
+            retries += 1;
         }
-
-        let parsed: EmbeddingResponse = response.json().await?;
-        let mut data = parsed.data;
-        if data.len() != texts.len() {
-            return Err(IndexError::Remote(format!(
-                "endpoint returned {} embeddings for {} inputs",
-                data.len(),
-                texts.len()
-            )));
-        }
-        data.sort_by_key(|d| d.index);
-        let vectors: Vec<Vec<f32>> = data.into_iter().map(|d| d.embedding).collect();
-
-        if let Some(first) = vectors.first() {
-            *self.dims.lock().unwrap() = first.len();
-        }
-        Ok(vectors)
     }
 
     fn model_id(&self) -> &str {
@@ -153,4 +274,143 @@ struct EmbeddingData {
     embedding: Vec<f32>,
     #[serde(default)]
     index: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use axum::Router;
+    use axum::extract::State;
+    use axum::http::StatusCode;
+    use axum::response::{IntoResponse, Response};
+    use axum::routing::post;
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    /// Serve `router` on an ephemeral localhost port and return its base URL.
+    async fn spawn(router: Router) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    /// A provider pointed at `base` with a near-zero backoff so the retry tests
+    /// never wait on real time; only the endpoint's Retry-After (kept at 0 in
+    /// the stubs) and this base contribute to the wait, both effectively zero.
+    fn provider(base: &str) -> RemoteProvider {
+        let cfg = EmbeddingsConfig {
+            provider: "openai".to_string(),
+            model: "test-model".to_string(),
+            endpoint: Some(base.to_string()),
+            api_key_env: None,
+        };
+        RemoteProvider::build(&cfg, Duration::from_millis(0)).unwrap()
+    }
+
+    /// One embedding for one input, the success shape the provider expects.
+    fn ok_body() -> Response {
+        axum::Json(serde_json::json!({
+            "data": [{ "embedding": [0.1f32, 0.2, 0.3], "index": 0 }]
+        }))
+        .into_response()
+    }
+
+    // A transient 429 that clears: the first two attempts are rate-limited with
+    // `Retry-After: 0`, the third succeeds. The pass must recover after exactly
+    // three requests, proving the two retries happened and then stopped.
+    #[tokio::test]
+    async fn retries_transient_429_then_succeeds() {
+        let count = Arc::new(AtomicUsize::new(0));
+        async fn handler(State(count): State<Arc<AtomicUsize>>) -> Response {
+            let n = count.fetch_add(1, Ordering::SeqCst);
+            if n < 2 {
+                (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    [("retry-after", "0")],
+                    "slow down",
+                )
+                    .into_response()
+            } else {
+                ok_body()
+            }
+        }
+        let app = Router::new()
+            .route("/embeddings", post(handler))
+            .with_state(count.clone());
+        let base = spawn(app).await;
+
+        let vectors = provider(&base)
+            .embed(&["hello".to_string()])
+            .await
+            .expect("a transient 429 that clears must yield success");
+        assert_eq!(vectors.len(), 1);
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            3,
+            "two retries after two 429s, then the success"
+        );
+    }
+
+    // A 400 is a client fault a retry cannot fix: fail on the first request,
+    // never retry.
+    #[tokio::test]
+    async fn does_not_retry_client_error_400() {
+        let count = Arc::new(AtomicUsize::new(0));
+        async fn handler(State(count): State<Arc<AtomicUsize>>) -> Response {
+            count.fetch_add(1, Ordering::SeqCst);
+            (StatusCode::BAD_REQUEST, "bad input").into_response()
+        }
+        let app = Router::new()
+            .route("/embeddings", post(handler))
+            .with_state(count.clone());
+        let base = spawn(app).await;
+
+        let err = provider(&base)
+            .embed(&["hello".to_string()])
+            .await
+            .expect_err("a 400 must fail immediately");
+        assert!(matches!(err, IndexError::Remote(_)));
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            1,
+            "a non-transient status is never retried"
+        );
+    }
+
+    // A persistent 503 exhausts the retry budget: four requests total (the
+    // first plus three retries), then the last transient error surfaces.
+    #[tokio::test]
+    async fn exhausts_retries_on_persistent_503() {
+        let count = Arc::new(AtomicUsize::new(0));
+        async fn handler(State(count): State<Arc<AtomicUsize>>) -> Response {
+            count.fetch_add(1, Ordering::SeqCst);
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                [("retry-after", "0")],
+                "unavailable",
+            )
+                .into_response()
+        }
+        let app = Router::new()
+            .route("/embeddings", post(handler))
+            .with_state(count.clone());
+        let base = spawn(app).await;
+
+        let err = provider(&base)
+            .embed(&["hello".to_string()])
+            .await
+            .expect_err("a persistent 503 must fail after the retry budget");
+        assert!(matches!(err, IndexError::Remote(_)));
+        assert_eq!(
+            count.load(Ordering::SeqCst),
+            4,
+            "the first request plus three retries"
+        );
+    }
 }

--- a/crates/index/src/postgres/migrations.rs
+++ b/crates/index/src/postgres/migrations.rs
@@ -41,6 +41,11 @@ pub const MIGRATIONS: &[Migration] = &[
         label: "domain host lock",
         sql: SCHEMA_V3,
     },
+    Migration {
+        version: 4,
+        label: "title-lower expression index",
+        sql: SCHEMA_V4,
+    },
 ];
 
 // The whole current schema in one step. The temporal columns stay TEXT ISO
@@ -182,6 +187,16 @@ CREATE TABLE domain_lock (
     acquired_at TEXT NOT NULL,
     heartbeat_at TEXT NOT NULL
 );
+"#;
+
+// The Postgres twin of Turso's v5: a case-insensitive title index for
+// forward-reference resolution. Relations resolve their target with
+// `lower(e.title) = lower(...)` scoped to a domain, and the find/inbound paths
+// share the pattern; without an index each match is a full engram scan. Postgres
+// supports functional indexes natively, so the existing queries are left
+// untouched and only gain the index.
+const SCHEMA_V4: &str = r#"
+CREATE INDEX idx_engram_title_lower ON engram(domain_id, lower(title));
 "#;
 
 /// The tables cleared by `wipe()`, child rows first so the enforced foreign

--- a/crates/index/src/postgres/mod.rs
+++ b/crates/index/src/postgres/mod.rs
@@ -43,7 +43,7 @@ use crate::store::{
     ChunkJob, ChunkModelCount, DomainHost, DomainId, DomainKind, DomainStats, EdgeKind,
     EmbeddingCoverage, EmbeddingRow, EngramDescriptor, EngramId, EngramRecord, EngramSummary,
     FileStamp, FtsMode, GraphSlice, HostClaim, InboundRef, NewChunk, Page, RecentFilter, SearchHit,
-    SearchQuery, Store, StoreInfo, StoredEngram,
+    SearchMode, SearchQuery, Store, StoreInfo, StoredEngram,
 };
 
 /// A PostgreSQL-backed store. Open one with [`PostgresStore::open`].
@@ -68,6 +68,20 @@ pub struct PostgresStore {
     // until the first call; set by `ensure_embedding_width`, never by wipe
     // (wiping rows never changes the column type).
     embedding_width: Mutex<Option<i64>>,
+    // The last computed embedding coverage snapshot, shared by effective_mode,
+    // the search staleness gate and CLI status so they issue one aggregate scan,
+    // not three. `None` means recompute on the next read. Interior mutability with
+    // the same std::sync discipline as tag_cache: the guard is taken in a tight
+    // scope and never held across an await (clippy::await_holding_lock).
+    //
+    // Invalidated (set to `None`) by exactly the Store methods that can change a
+    // chunk's embedding state, derived from the trait: store_embeddings (writes
+    // embeddings), replace_chunks (deletes and reinserts an engram's chunks),
+    // delete_engram (deletes an engram's chunks), clear_domain (deletes a domain's
+    // chunks), wipe (deletes every chunk) and rollback (reverts any of the above
+    // that ran inside the transaction). upsert_engram, upsert_engram_checked and
+    // rename_engram never touch the chunk table, so they are not invalidators.
+    coverage_cache: Mutex<Option<EmbeddingCoverage>>,
 }
 
 /// A connection handle for one store method: either the pinned transaction
@@ -133,6 +147,52 @@ impl PostgresStore {
             schema,
             tag_cache: Mutex::new(HashMap::new()),
             embedding_width: Mutex::new(None),
+            coverage_cache: Mutex::new(None),
+        })
+    }
+
+    /// Drop the cached embedding coverage snapshot so the next read recomputes it.
+    /// Called by every mutator that can change a chunk's embedding state. Kept in a
+    /// tight scope with no await so the std::sync guard never crosses a suspension
+    /// point.
+    fn invalidate_coverage(&self) {
+        *self.coverage_cache.lock().unwrap() = None;
+    }
+
+    /// Recompute the embedding coverage snapshot from the chunk table. This is the
+    /// one aggregate scan the cached `embedding_coverage()` fills from on a miss.
+    async fn compute_coverage(&self) -> Result<EmbeddingCoverage> {
+        let mut conn = self.acquire().await?;
+        let c = conn.as_mut();
+        let total = scalar_i64(&mut *c, "SELECT count(*) FROM chunk", vec![])
+            .await?
+            .max(0) as usize;
+        let rows = query_all(
+            &mut *c,
+            "SELECT model, dims, count(*) FROM chunk WHERE embedding IS NOT NULL \
+             GROUP BY model, dims ORDER BY count(*) DESC",
+            vec![],
+        )
+        .await?;
+        let mut models = Vec::new();
+        let mut embedded = 0usize;
+        for r in &rows {
+            let count = cell_i64(r, 2).unwrap_or(0).max(0) as usize;
+            embedded += count;
+            let model = cell_text(r, 0).unwrap_or_default();
+            if model.is_empty() {
+                continue;
+            }
+            models.push(ChunkModelCount {
+                model,
+                dims: cell_i64(r, 1).unwrap_or(0).max(0) as usize,
+                count,
+            });
+        }
+        Ok(EmbeddingCoverage {
+            total_chunks: total,
+            embedded_chunks: embedded,
+            models,
         })
     }
 
@@ -740,6 +800,8 @@ impl Store for PostgresStore {
     }
 
     async fn clear_domain(&self, domain: DomainId) -> Result<()> {
+        // Deletes this domain's chunks, so the coverage snapshot is now stale.
+        self.invalidate_coverage();
         // Delete a single domain's engram and child rows, keeping the domain
         // row. Child rows first so the enforced foreign keys are satisfied.
         let mut conn = self.acquire().await?;
@@ -764,6 +826,8 @@ impl Store for PostgresStore {
     }
 
     async fn delete_engram(&self, domain: DomainId, path: &str) -> Result<()> {
+        // Deletes the engram's chunks, so the coverage snapshot is now stale.
+        self.invalidate_coverage();
         let mut conn = self.acquire().await?;
         let c = conn.as_mut();
         let id = sqlx::query("SELECT id FROM engram WHERE domain_id=$1 AND path=$2")
@@ -953,8 +1017,19 @@ impl Store for PostgresStore {
     }
 
     async fn search(&self, query: &SearchQuery) -> Result<Page<SearchHit>> {
+        // Compute the coverage snapshot for the semantic and hybrid modes (which
+        // gate on embedding staleness) BEFORE acquiring the search connection:
+        // embedding_coverage() acquires its own connection, and holding two
+        // acquisitions at once would relock the tx mutex on the pinned path. The
+        // cache makes this essentially free once effective_mode has warmed it, and
+        // folds the old second aggregate scan into the same shared snapshot. The
+        // lexical modes never touch embeddings, so they skip the snapshot.
+        let coverage = match query.mode {
+            SearchMode::Semantic | SearchMode::Hybrid => Some(self.embedding_coverage().await?),
+            _ => None,
+        };
         let mut conn = self.acquire().await?;
-        search::run_search(conn.as_mut(), query).await
+        search::run_search(conn.as_mut(), query, coverage.as_ref()).await
     }
 
     async fn neighbors(&self, ids: &[EngramId], depth: u8) -> Result<GraphSlice> {
@@ -1034,6 +1109,9 @@ impl Store for PostgresStore {
     }
 
     async fn replace_chunks(&self, engram_id: EngramId, chunks: &[NewChunk]) -> Result<()> {
+        // Deletes and reinserts this engram's chunks, so the coverage snapshot is
+        // now stale.
+        self.invalidate_coverage();
         let eid = engram_id.0;
         let mut conn = self.acquire().await?;
         let c = conn.as_mut();
@@ -1149,6 +1227,8 @@ impl Store for PostgresStore {
     }
 
     async fn store_embeddings(&self, batch: &[EmbeddingRow], model: &str) -> Result<()> {
+        // Writes embeddings, so the coverage snapshot is now stale.
+        self.invalidate_coverage();
         // Validate the whole batch before any write so a bad row never leaves
         // earlier rows committed.
         for row in batch {
@@ -1202,41 +1282,22 @@ impl Store for PostgresStore {
     }
 
     async fn embedding_coverage(&self) -> Result<EmbeddingCoverage> {
-        let mut conn = self.acquire().await?;
-        let c = conn.as_mut();
-        let total = scalar_i64(&mut *c, "SELECT count(*) FROM chunk", vec![])
-            .await?
-            .max(0) as usize;
-        let rows = query_all(
-            &mut *c,
-            "SELECT model, dims, count(*) FROM chunk WHERE embedding IS NOT NULL \
-             GROUP BY model, dims ORDER BY count(*) DESC",
-            vec![],
-        )
-        .await?;
-        let mut models = Vec::new();
-        let mut embedded = 0usize;
-        for r in &rows {
-            let count = cell_i64(r, 2).unwrap_or(0).max(0) as usize;
-            embedded += count;
-            let model = cell_text(r, 0).unwrap_or_default();
-            if model.is_empty() {
-                continue;
+        // Fast path in a tight scope so the std::sync guard is dropped before the
+        // recompute await below (clippy::await_holding_lock), tag_cache style.
+        {
+            let cached = self.coverage_cache.lock().unwrap();
+            if let Some(cov) = cached.as_ref() {
+                return Ok(cov.clone());
             }
-            models.push(ChunkModelCount {
-                model,
-                dims: cell_i64(r, 1).unwrap_or(0).max(0) as usize,
-                count,
-            });
         }
-        Ok(EmbeddingCoverage {
-            total_chunks: total,
-            embedded_chunks: embedded,
-            models,
-        })
+        let cov = self.compute_coverage().await?;
+        *self.coverage_cache.lock().unwrap() = Some(cov.clone());
+        Ok(cov)
     }
 
     async fn wipe(&self) -> Result<()> {
+        // Deletes every chunk, so the coverage snapshot is now stale.
+        self.invalidate_coverage();
         let mut conn = self.acquire().await?;
         let c = conn.as_mut();
         sqlx::query("BEGIN")
@@ -1450,6 +1511,9 @@ impl Store for PostgresStore {
         // A rolled-back tag insert leaves its cached id pointing at a row that no
         // longer exists, so drop the cache after a rollback.
         self.tag_cache.lock().unwrap().clear();
+        // A rollback also reverts any chunk mutation made in the transaction, so a
+        // snapshot recomputed mid-transaction must not survive it.
+        self.invalidate_coverage();
         Ok(())
     }
 }

--- a/crates/index/src/postgres/search.rs
+++ b/crates/index/src/postgres/search.rs
@@ -16,8 +16,8 @@ use sqlx::PgConnection;
 
 use crate::error::{IndexError, Result};
 use crate::store::{
-    EdgeKind, EngramId, FilterOp, GraphEdge, GraphNode, GraphSlice, HitKind, MetadataFilter, Page,
-    SearchHit, SearchMode, SearchQuery,
+    EdgeKind, EmbeddingCoverage, EngramId, FilterOp, GraphEdge, GraphNode, GraphSlice, HitKind,
+    MetadataFilter, Page, SearchHit, SearchMode, SearchQuery,
 };
 
 use super::{Param, cell_i64, cell_real, cell_text, query_all, query_first, scalar_i64};
@@ -39,16 +39,28 @@ const HYBRID_SEMANTIC_WEIGHT: f64 = 0.6;
 /// above it (a both-signal hit can reach 1.0, a single-signal hit at most 0.85).
 const SINGLE_SOURCE_PENALTY: f64 = 0.85;
 
-/// Run a search and return one page of hits plus the total match count.
+/// Run a search and return one page of hits plus the total match count. The
+/// `coverage` snapshot is supplied by the store for the semantic and hybrid modes
+/// (which gate on embedding staleness) and is `None` for the lexical modes.
 pub(super) async fn run_search(
     conn: &mut PgConnection,
     query: &SearchQuery,
+    coverage: Option<&EmbeddingCoverage>,
 ) -> Result<Page<SearchHit>> {
     match query.mode {
-        SearchMode::Semantic => run_semantic(conn, query).await,
-        SearchMode::Hybrid => run_hybrid(conn, query).await,
+        SearchMode::Semantic => run_semantic(conn, query, require_coverage(coverage)?).await,
+        SearchMode::Hybrid => run_hybrid(conn, query, require_coverage(coverage)?).await,
         _ => run_lexical(conn, query).await,
     }
+}
+
+/// The staleness gate for semantic and hybrid search needs the coverage snapshot,
+/// which the store computes for exactly those two modes. A missing snapshot here
+/// is an internal wiring break, never a user input error.
+fn require_coverage(coverage: Option<&EmbeddingCoverage>) -> Result<&EmbeddingCoverage> {
+    coverage.ok_or_else(|| {
+        IndexError::Db("semantic search dispatched without an embedding coverage snapshot".into())
+    })
 }
 
 /// The lexical modes: Text, Title and Permalink. A LIKE-candidate prefilter in
@@ -195,7 +207,11 @@ async fn filter_only(
 
 /// Semantic search over chunk embeddings. Requires the caller to have embedded
 /// the query and set the active model on the [`SearchQuery`].
-async fn run_semantic(conn: &mut PgConnection, query: &SearchQuery) -> Result<Page<SearchHit>> {
+async fn run_semantic(
+    conn: &mut PgConnection,
+    query: &SearchQuery,
+    coverage: &EmbeddingCoverage,
+) -> Result<Page<SearchHit>> {
     let qvec = query
         .query_embedding
         .as_deref()
@@ -209,7 +225,7 @@ async fn run_semantic(conn: &mut PgConnection, query: &SearchQuery) -> Result<Pa
     let page = query.page.max(1);
     let min_sim = query.min_similarity.unwrap_or(DEFAULT_MIN_SIMILARITY) as f64;
 
-    check_staleness(conn, active, dims).await?;
+    check_staleness(coverage, active, dims)?;
 
     let mut hits = semantic_candidates(conn, query, qvec, active, dims).await?;
     hits.retain(|(sim, _)| *sim >= min_sim);
@@ -241,7 +257,11 @@ async fn run_semantic(conn: &mut PgConnection, query: &SearchQuery) -> Result<Pa
 /// Hybrid search: a lexical candidate scan and a semantic top-k, each normalized
 /// to `[0, 1]`, then blended. See [`crate::turso::search`] for the normalization
 /// and blend rationale; this port reproduces it exactly.
-async fn run_hybrid(conn: &mut PgConnection, query: &SearchQuery) -> Result<Page<SearchHit>> {
+async fn run_hybrid(
+    conn: &mut PgConnection,
+    query: &SearchQuery,
+    coverage: &EmbeddingCoverage,
+) -> Result<Page<SearchHit>> {
     let qvec = query
         .query_embedding
         .as_deref()
@@ -255,7 +275,7 @@ async fn run_hybrid(conn: &mut PgConnection, query: &SearchQuery) -> Result<Page
     let page = query.page.max(1);
     let min_sim = query.min_similarity.unwrap_or(DEFAULT_MIN_SIMILARITY) as f64;
 
-    check_staleness(conn, active, dims).await?;
+    check_staleness(coverage, active, dims)?;
 
     let terms: Vec<String> = query.text.as_deref().map(terms_of).unwrap_or_default();
     let text_scored = if terms.is_empty() {
@@ -390,53 +410,36 @@ async fn semantic_candidates(
 }
 
 /// Refuse semantic search when the stored embeddings cannot be compared against
-/// the active provider's vector space. Ported verbatim from the Turso backend.
-async fn check_staleness(conn: &mut PgConnection, active_model: &str, dims: usize) -> Result<()> {
-    let rows = query_all(
-        conn,
-        "SELECT model, dims, count(*) FROM chunk WHERE embedding IS NOT NULL GROUP BY model, dims",
-        vec![],
-    )
-    .await?;
+/// the active provider's vector space. Ported verbatim from the Turso backend;
+/// see [`crate::turso::search`] for the byte-identical-fields reasoning. Consumes
+/// the shared coverage snapshot rather than issuing its own aggregate scan.
+fn check_staleness(coverage: &EmbeddingCoverage, active_model: &str, dims: usize) -> Result<()> {
     let mut active_embedded = 0usize;
-    let mut total_embedded = 0usize;
     let mut foreign_dims = false;
-    let mut other: Option<(String, usize)> = None;
-    for r in &rows {
-        let m = cell_text(r, 0).unwrap_or_default();
-        let d = cell_i64(r, 1).unwrap_or(0).max(0) as usize;
-        let c = cell_i64(r, 2).unwrap_or(0).max(0) as usize;
-        total_embedded += c;
-        if m == active_model && d == dims {
-            active_embedded += c;
+    let mut other: Option<(&str, usize)> = None;
+    for m in &coverage.models {
+        if m.model == active_model && m.dims == dims {
+            active_embedded += m.count;
             continue;
         }
-        if d != dims {
+        if m.dims != dims {
             foreign_dims = true;
         }
-        if other.as_ref().map(|(_, oc)| c > *oc).unwrap_or(true) {
-            let label = if m.is_empty() {
-                "unknown".to_string()
-            } else {
-                m
-            };
-            other = Some((label, c));
+        if other.as_ref().map(|(_, oc)| m.count > *oc).unwrap_or(true) {
+            other = Some((m.model.as_str(), m.count));
         }
     }
 
-    let stale = total_embedded > 0 && (foreign_dims || active_embedded == 0);
+    let stale = coverage.embedded_chunks > 0 && (foreign_dims || active_embedded == 0);
     if stale {
-        let total_chunks = scalar_i64(conn, "SELECT count(*) FROM chunk", vec![])
-            .await?
-            .max(0) as usize;
         let stored_model = other
-            .map(|(m, _)| m)
+            .map(|(m, _)| m.to_string())
             .unwrap_or_else(|| active_model.to_string());
         return Err(IndexError::StaleEmbeddings {
             stored_model,
             active_model: active_model.to_string(),
             embedded: active_embedded,
-            total: total_chunks,
+            total: coverage.total_chunks,
         });
     }
     Ok(())

--- a/crates/index/src/store.rs
+++ b/crates/index/src/store.rs
@@ -900,6 +900,16 @@ pub trait Store: Send + Sync {
     /// full-reindex path.
     async fn wipe(&self) -> Result<()>;
 
+    /// Best-effort WAL checkpoint in TRUNCATE mode, shrinking a local WAL file
+    /// back down after a bulk rewrite (a full reindex or a wipe). The default
+    /// is a no-op, which is correct for Postgres: it has no local WAL file to
+    /// truncate. Turso overrides this with a real `PRAGMA
+    /// wal_checkpoint(TRUNCATE)` (confirmed to work by a runtime probe; see
+    /// the doc comment on `TursoStore::build`).
+    async fn checkpoint_wal(&self) -> Result<()> {
+        Ok(())
+    }
+
     /// Record that a domain finished syncing at the given RFC 3339 instant.
     async fn record_sync(&self, domain: DomainId, when: &str) -> Result<()>;
 

--- a/crates/index/src/store.rs
+++ b/crates/index/src/store.rs
@@ -661,6 +661,12 @@ impl EmbeddingCoverage {
     pub fn has_active_embeddings(&self, model: &str) -> bool {
         self.embedded_for(model) > 0
     }
+
+    /// Chunks still awaiting embedding by the given model: the total minus what
+    /// that model has already embedded.
+    pub fn backlog_for(&self, model: &str) -> usize {
+        self.total_chunks.saturating_sub(self.embedded_for(model))
+    }
 }
 
 /// Which full-text path the store is using.

--- a/crates/index/src/sync.rs
+++ b/crates/index/src/sync.rs
@@ -23,7 +23,7 @@ use walkdir::WalkDir;
 
 use crate::embed::{ChunkParams, chunk_engram};
 use crate::error::{IndexError, Result};
-use crate::store::{EngramRecord, FileStamp, Store};
+use crate::store::{EngramRecord, FileStamp, NewChunk, Store};
 
 /// Maximum concurrent hashing or parsing tasks.
 const CONCURRENCY: usize = 8;
@@ -221,24 +221,16 @@ pub async fn sync_domain_with<S: Store + ?Sized>(
         }
     }
 
-    // Parse the changed files off-thread. Read failures and parse failures are
-    // reported, not fatal.
-    let parsed = parse_files(changed, &mut report).await;
+    // Parse the changed files off-thread, computing each engram's chunks in the
+    // same off-thread task so the write transaction never runs the chunker. Read
+    // failures and parse failures are reported, not fatal.
+    let parsed = parse_files(changed, chunk_params, &mut report).await;
 
     // Apply everything in one transaction. Duplicate-permalink upserts are
     // collected in `failed` and do not abort the batch (they are pre-checked so
     // no failing statement runs). Other errors roll the batch back.
     store.begin().await?;
-    let apply = apply_changes(
-        store,
-        domain,
-        moves,
-        deleted_remaining,
-        parsed,
-        chunk_params,
-        &mut report,
-    )
-    .await;
+    let apply = apply_changes(store, domain, moves, deleted_remaining, parsed, &mut report).await;
     match apply {
         Ok(()) => {}
         Err(e) => {
@@ -273,7 +265,6 @@ async fn apply_changes<S: Store + ?Sized>(
     moves: Vec<(String, String)>,
     deleted: std::collections::HashSet<String>,
     parsed: Vec<Parsed>,
-    chunk_params: &ChunkParams,
     report: &mut SyncReport,
 ) -> Result<()> {
     for (from, to) in moves {
@@ -288,16 +279,13 @@ async fn apply_changes<S: Store + ?Sized>(
         let existed = p.previously_indexed;
         match store.upsert_engram(domain, &p.record).await {
             Ok(id) => {
-                // Recompute the engram's chunk rows. replace_chunks keeps the
+                // Apply the chunk rows computed off-thread in parse_files, right
+                // after the upsert returns the id. replace_chunks keeps the
                 // embedding of any chunk whose fingerprint is unchanged, so an
-                // edit only re-embeds the paragraphs that changed.
-                let chunks = chunk_engram(
-                    &p.record.title,
-                    p.record.description.as_deref(),
-                    &p.record.content,
-                    chunk_params,
-                );
-                store.replace_chunks(id, &chunks).await?;
+                // edit only re-embeds the paragraphs that changed; the fingerprint
+                // folds in only the model id and text, so computing the chunks
+                // before the transaction changes nothing about the carry-over.
+                store.replace_chunks(id, &p.chunks).await?;
                 if existed {
                     report.updated += 1;
                 } else {
@@ -313,9 +301,11 @@ async fn apply_changes<S: Store + ?Sized>(
     Ok(())
 }
 
-/// A parsed change ready to upsert.
+/// A parsed change ready to upsert, with its embedding chunks already computed
+/// off-thread so the write transaction never runs the chunker.
 struct Parsed {
     record: EngramRecord,
+    chunks: Vec<NewChunk>,
     previously_indexed: bool,
 }
 
@@ -382,6 +372,7 @@ fn read_and_hash(path: &Path) -> std::io::Result<Hashed> {
 
 async fn parse_files(
     changed: Vec<(Scanned, Hashed, bool)>,
+    chunk_params: &ChunkParams,
     report: &mut SyncReport,
 ) -> Vec<Parsed> {
     let sem = Arc::new(Semaphore::new(CONCURRENCY));
@@ -393,6 +384,9 @@ async fn parse_files(
     for (scanned, hashed, previously_indexed) in changed {
         let sem = sem.clone();
         let rel = scanned.rel.clone();
+        // Chunking is two small fields, cloned per task so it moves into the
+        // blocking closure alongside the parse.
+        let chunk_params = chunk_params.clone();
         let handle = set.spawn(async move {
             let _permit = sem.acquire_owned().await.expect("semaphore open");
             let Some(content) = hashed.content else {
@@ -404,14 +398,28 @@ async fn parse_files(
                 size: scanned.size,
                 sha256: hashed.sha256,
             };
+            // Parse and chunk in one blocking task: both are pure CPU work, and
+            // computing the chunks here keeps the chunker out of the write
+            // transaction the apply phase holds.
             let parsed = tokio::task::spawn_blocking(move || {
                 crystalline_core::parse_engram(&content)
-                    .map(|engram| EngramRecord::from_engram(&engram, &rel, stamp))
+                    .map(|engram| {
+                        let record = EngramRecord::from_engram(&engram, &rel, stamp);
+                        let chunks = chunk_engram(
+                            &record.title,
+                            record.description.as_deref(),
+                            &record.content,
+                            &chunk_params,
+                        );
+                        (record, chunks)
+                    })
                     .map_err(|e| e.to_string())
             })
             .await;
             match parsed {
-                Ok(Ok(record)) => ParseOutcome::Ok(Box::new(record), previously_indexed),
+                Ok(Ok((record, chunks))) => {
+                    ParseOutcome::Ok(Box::new(record), chunks, previously_indexed)
+                }
                 Ok(Err(e)) => ParseOutcome::Failed(scanned.rel, e),
                 Err(e) => ParseOutcome::Failed(scanned.rel, e.to_string()),
             }
@@ -422,11 +430,12 @@ async fn parse_files(
     let mut out = Vec::new();
     while let Some(joined) = set.join_next_with_id().await {
         match joined {
-            Ok((id, ParseOutcome::Ok(record, previously_indexed))) => {
+            Ok((id, ParseOutcome::Ok(record, chunks, previously_indexed))) => {
                 ids.remove(&id);
                 out.push(Parsed {
                     previously_indexed,
                     record: *record,
+                    chunks,
                 });
             }
             Ok((id, ParseOutcome::Failed(path, err))) => {
@@ -447,7 +456,7 @@ async fn parse_files(
 }
 
 enum ParseOutcome {
-    Ok(Box<EngramRecord>, bool),
+    Ok(Box<EngramRecord>, Vec<NewChunk>, bool),
     Failed(String, String),
 }
 

--- a/crates/index/src/turso/migrations.rs
+++ b/crates/index/src/turso/migrations.rs
@@ -42,6 +42,11 @@ pub const MIGRATIONS: &[Migration] = &[
         label: "domain host lock",
         sql: SCHEMA_V4,
     },
+    Migration {
+        version: 5,
+        label: "title-lower expression index",
+        sql: SCHEMA_V5,
+    },
 ];
 
 const SCHEMA_V1: &str = r#"
@@ -196,6 +201,19 @@ CREATE TABLE domain_lock (
     acquired_at TEXT NOT NULL,
     heartbeat_at TEXT NOT NULL
 );
+"#;
+
+// A case-insensitive title index for forward-reference resolution. Relations
+// resolve their target with `lower(e.title) = lower(...)` scoped to a domain,
+// and the find/inbound paths share the pattern; without an index each match is
+// a full engram scan, once per unresolved reference on every sync. Turso 0.7.0
+// accepts expression indexes and its planner seeks this one for the resolve
+// subquery shape (`SEARCH e USING INDEX idx_engram_title_lower`), so the
+// existing queries are left untouched and only gain the index. The `lower()`
+// folded into the index is byte-identical to the one the queries already call,
+// so resolution results are unchanged; the index just makes the match a seek.
+const SCHEMA_V5: &str = r#"
+CREATE INDEX idx_engram_title_lower ON engram(domain_id, lower(title));
 "#;
 
 /// The tables cleared by `wipe()`, child rows first. `domain_lock` references

--- a/crates/index/src/turso/mod.rs
+++ b/crates/index/src/turso/mod.rs
@@ -26,7 +26,7 @@ use crate::store::{
     ChunkJob, ChunkModelCount, DomainHost, DomainId, DomainKind, DomainStats, EdgeKind,
     EmbeddingCoverage, EmbeddingRow, EngramDescriptor, EngramId, EngramRecord, EngramSummary,
     FileStamp, FtsMode, GraphSlice, HostClaim, InboundRef, NewChunk, Page, RecentFilter, SearchHit,
-    SearchQuery, Store, StoreInfo, StoredEngram,
+    SearchMode, SearchQuery, Store, StoreInfo, StoredEngram,
 };
 
 /// A Turso-backed store. Open one with [`TursoStore::open`].
@@ -39,6 +39,20 @@ pub struct TursoStore {
     fts_native: bool,
     // Tag name to id, to avoid re-interning tags during a sync.
     tag_cache: Mutex<HashMap<String, i64>>,
+    // The last computed embedding coverage snapshot, shared by effective_mode,
+    // the search staleness gate and CLI status so they issue one aggregate scan,
+    // not three. `None` means recompute on the next read. Interior mutability with
+    // the same std::sync discipline as tag_cache: the guard is taken in a tight
+    // scope and never held across an await (clippy::await_holding_lock).
+    //
+    // Invalidated (set to `None`) by exactly the Store methods that can change a
+    // chunk's embedding state, derived from the trait: store_embeddings (writes
+    // embeddings), replace_chunks (deletes and reinserts an engram's chunks),
+    // delete_engram (deletes an engram's chunks), clear_domain (deletes a domain's
+    // chunks), wipe (deletes every chunk) and rollback (reverts any of the above
+    // that ran inside the transaction). upsert_engram, upsert_engram_checked and
+    // rename_engram never touch the chunk table, so they are not invalidators.
+    coverage_cache: Mutex<Option<EmbeddingCoverage>>,
 }
 
 impl TursoStore {
@@ -91,6 +105,50 @@ impl TursoStore {
             schema_version,
             fts_native,
             tag_cache: Mutex::new(HashMap::new()),
+            coverage_cache: Mutex::new(None),
+        })
+    }
+
+    /// Drop the cached embedding coverage snapshot so the next read recomputes it.
+    /// Called by every mutator that can change a chunk's embedding state. Kept in a
+    /// tight scope with no await so the std::sync guard never crosses a suspension
+    /// point.
+    fn invalidate_coverage(&self) {
+        *self.coverage_cache.lock().unwrap() = None;
+    }
+
+    /// Recompute the embedding coverage snapshot from the chunk table. This is the
+    /// one aggregate scan the cached `embedding_coverage()` fills from on a miss.
+    async fn compute_coverage(&self) -> Result<EmbeddingCoverage> {
+        let total = scalar_i64(&self.conn, "SELECT count(*) FROM chunk", vec![])
+            .await?
+            .max(0) as usize;
+        let rows = query_all(
+            &self.conn,
+            "SELECT model, dims, count(*) FROM chunk WHERE embedding IS NOT NULL \
+             GROUP BY model, dims ORDER BY count(*) DESC",
+            vec![],
+        )
+        .await?;
+        let mut models = Vec::new();
+        let mut embedded = 0usize;
+        for r in &rows {
+            let count = cell_i64(r, 2).unwrap_or(0).max(0) as usize;
+            embedded += count;
+            let model = cell_text(r, 0).unwrap_or_default();
+            if model.is_empty() {
+                continue;
+            }
+            models.push(ChunkModelCount {
+                model,
+                dims: cell_i64(r, 1).unwrap_or(0).max(0) as usize,
+                count,
+            });
+        }
+        Ok(EmbeddingCoverage {
+            total_chunks: total,
+            embedded_chunks: embedded,
+            models,
         })
     }
 
@@ -584,6 +642,8 @@ impl Store for TursoStore {
     }
 
     async fn clear_domain(&self, domain: DomainId) -> Result<()> {
+        // Deletes this domain's chunks, so the coverage snapshot is now stale.
+        self.invalidate_coverage();
         // Delete a single domain's engram and child rows, keeping the domain
         // row. Child rows first, then chunks, then the engram rows themselves.
         let did = vec![Value::Integer(domain.0)];
@@ -603,6 +663,8 @@ impl Store for TursoStore {
     }
 
     async fn delete_engram(&self, domain: DomainId, path: &str) -> Result<()> {
+        // Deletes the engram's chunks, so the coverage snapshot is now stale.
+        self.invalidate_coverage();
         let id = query_first(
             &self.conn,
             "SELECT id FROM engram WHERE domain_id=?1 AND path=?2",
@@ -785,7 +847,16 @@ impl Store for TursoStore {
     }
 
     async fn search(&self, query: &SearchQuery) -> Result<Page<SearchHit>> {
-        search::run_search(&self.conn, query).await
+        // The semantic and hybrid modes gate on embedding staleness, which reads
+        // the coverage snapshot; the cache makes that essentially free once
+        // effective_mode has warmed it, and folds the old second aggregate scan
+        // into the same shared snapshot. The lexical modes never touch embeddings,
+        // so they skip the snapshot and pay nothing for it.
+        let coverage = match query.mode {
+            SearchMode::Semantic | SearchMode::Hybrid => Some(self.embedding_coverage().await?),
+            _ => None,
+        };
+        search::run_search(&self.conn, query, coverage.as_ref()).await
     }
 
     async fn neighbors(&self, ids: &[EngramId], depth: u8) -> Result<GraphSlice> {
@@ -863,6 +934,9 @@ impl Store for TursoStore {
     }
 
     async fn replace_chunks(&self, engram_id: EngramId, chunks: &[NewChunk]) -> Result<()> {
+        // Deletes and reinserts this engram's chunks, so the coverage snapshot is
+        // now stale.
+        self.invalidate_coverage();
         let eid = engram_id.0;
         // Carry over the embedding of any chunk whose fingerprint is unchanged so
         // an edit only re-embeds the paragraphs that actually changed. The
@@ -980,6 +1054,8 @@ impl Store for TursoStore {
     }
 
     async fn store_embeddings(&self, batch: &[EmbeddingRow], model: &str) -> Result<()> {
+        // Writes embeddings, so the coverage snapshot is now stale.
+        self.invalidate_coverage();
         // Validate the whole batch before opening the transaction so a bad row
         // never leaves earlier rows committed. The transaction then makes the
         // per-row updates all-or-nothing against a mid-batch database error,
@@ -1021,39 +1097,22 @@ impl Store for TursoStore {
     }
 
     async fn embedding_coverage(&self) -> Result<EmbeddingCoverage> {
-        let total = scalar_i64(&self.conn, "SELECT count(*) FROM chunk", vec![])
-            .await?
-            .max(0) as usize;
-        let rows = query_all(
-            &self.conn,
-            "SELECT model, dims, count(*) FROM chunk WHERE embedding IS NOT NULL \
-             GROUP BY model, dims ORDER BY count(*) DESC",
-            vec![],
-        )
-        .await?;
-        let mut models = Vec::new();
-        let mut embedded = 0usize;
-        for r in &rows {
-            let count = cell_i64(r, 2).unwrap_or(0).max(0) as usize;
-            embedded += count;
-            let model = cell_text(r, 0).unwrap_or_default();
-            if model.is_empty() {
-                continue;
+        // Fast path in a tight scope so the std::sync guard is dropped before the
+        // recompute await below (clippy::await_holding_lock), tag_cache style.
+        {
+            let cached = self.coverage_cache.lock().unwrap();
+            if let Some(cov) = cached.as_ref() {
+                return Ok(cov.clone());
             }
-            models.push(ChunkModelCount {
-                model,
-                dims: cell_i64(r, 1).unwrap_or(0).max(0) as usize,
-                count,
-            });
         }
-        Ok(EmbeddingCoverage {
-            total_chunks: total,
-            embedded_chunks: embedded,
-            models,
-        })
+        let cov = self.compute_coverage().await?;
+        *self.coverage_cache.lock().unwrap() = Some(cov.clone());
+        Ok(cov)
     }
 
     async fn wipe(&self) -> Result<()> {
+        // Deletes every chunk, so the coverage snapshot is now stale.
+        self.invalidate_coverage();
         self.conn.execute("BEGIN", ()).await?;
         for table in migrations::WIPE_TABLES {
             if let Err(e) = self.conn.execute(&format!("DELETE FROM {table}"), ()).await {
@@ -1225,6 +1284,9 @@ impl Store for TursoStore {
     }
 
     async fn rollback(&self) -> Result<()> {
+        // A rollback reverts any chunk mutation made in the transaction, so a
+        // snapshot recomputed mid-transaction must not survive it.
+        self.invalidate_coverage();
         self.conn.execute("ROLLBACK", ()).await?;
         Ok(())
     }

--- a/crates/index/src/turso/mod.rs
+++ b/crates/index/src/turso/mod.rs
@@ -96,6 +96,33 @@ impl TursoStore {
             .await
             .map_err(IndexError::from)?;
         let conn = db.connect().map_err(IndexError::from)?;
+
+        // PRAGMA probe against turso 0.7.0, verified two ways: reading
+        // turso_core's translate/pragma.rs (the PRAGMA setter dispatch) and a
+        // throwaway runtime test exercising each PRAGMA against a real
+        // connection. Findings:
+        // - busy_timeout: honored. `PRAGMA busy_timeout=5000` round-trips
+        //   through `PRAGMA busy_timeout` and drives a real retrying busy
+        //   handler (`Connection::set_busy_timeout`). Set below.
+        // - wal_checkpoint(TRUNCATE): honored. In the probe it shrank a
+        //   populated WAL file from over 1 MiB to 0 bytes. Used in `wipe()`
+        //   and by the CLI's `reindex --full` path (see
+        //   `Store::checkpoint_wal`), covering the same need the downstream
+        //   Docker image build met by shelling out to `sqlite3`.
+        // - synchronous: honored (round-tripped OFF and FULL in the probe)
+        //   but deliberately left at whatever `migrations::apply` and turso's
+        //   own default leave it at - not changed here, per plan.
+        // - wal_autocheckpoint: NOT honored. `turso_parser`'s `PragmaName`
+        //   enum has no `WalAutocheckpoint` variant, and turso_core's
+        //   `translate_pragma` silently ignores any unrecognized PRAGMA name
+        //   (SQLite's documented behavior for unknown pragmas): setting it
+        //   neither errors nor takes effect. The probe confirmed this -
+        //   `PRAGMA wal_autocheckpoint = 1000` returned `Ok`, but a
+        //   subsequent `PRAGMA wal_autocheckpoint` query returned no rows.
+        //   Not set here; wal_checkpoint(TRUNCATE) above is the mitigation for
+        //   WAL growth instead.
+        conn.execute("PRAGMA busy_timeout = 5000", ()).await?;
+
         let schema_version = migrations::apply(&conn).await?;
         let fts_native = probe_fts(&conn).await;
         Ok(TursoStore {
@@ -176,6 +203,15 @@ impl TursoStore {
     pub async fn explain_query_plan(&self, sql: &str) -> Result<Vec<String>> {
         let rows = query_all(&self.conn, &format!("EXPLAIN QUERY PLAN {sql}"), vec![]).await?;
         Ok(rows.iter().filter_map(|r| cell_text(r, 3)).collect())
+    }
+
+    /// Run `PRAGMA wal_checkpoint(TRUNCATE)`, shrinking the on-disk WAL file
+    /// back to (ideally) zero bytes. Confirmed to work by the runtime probe
+    /// documented on `build()`. The pragma returns one row (`busy`, `log`,
+    /// `checkpointed`) so it goes through the query path, not `execute`.
+    async fn truncate_wal(&self) -> Result<()> {
+        query_all(&self.conn, "PRAGMA wal_checkpoint(TRUNCATE)", vec![]).await?;
+        Ok(())
     }
 
     /// Delete the child rows recreated on every upsert. Chunk rows are NOT
@@ -1122,7 +1158,15 @@ impl Store for TursoStore {
         }
         self.conn.execute("COMMIT", ()).await?;
         self.tag_cache.lock().unwrap().clear();
+        // A wipe deletes every row, which is the biggest single write a store
+        // sees; truncate the WAL back down rather than leaving it to grow
+        // until the next natural checkpoint.
+        self.truncate_wal().await?;
         Ok(())
+    }
+
+    async fn checkpoint_wal(&self) -> Result<()> {
+        self.truncate_wal().await
     }
 
     async fn record_sync(&self, domain: DomainId, when: &str) -> Result<()> {

--- a/crates/index/src/turso/search.rs
+++ b/crates/index/src/turso/search.rs
@@ -13,8 +13,8 @@ use turso::{Connection, Row, Value};
 
 use crate::error::{IndexError, Result};
 use crate::store::{
-    EdgeKind, EngramId, FilterOp, GraphEdge, GraphNode, GraphSlice, HitKind, MetadataFilter, Page,
-    SearchHit, SearchMode, SearchQuery,
+    EdgeKind, EmbeddingCoverage, EngramId, FilterOp, GraphEdge, GraphNode, GraphSlice, HitKind,
+    MetadataFilter, Page, SearchHit, SearchMode, SearchQuery,
 };
 
 use super::{cell_i64, cell_real, cell_text, query_all, query_first, scalar_i64};
@@ -34,13 +34,28 @@ const HYBRID_SEMANTIC_WEIGHT: f64 = 0.6;
 /// above it (a both-signal hit can reach 1.0, a single-signal hit at most 0.85).
 const SINGLE_SOURCE_PENALTY: f64 = 0.85;
 
-/// Run a search and return one page of hits plus the total match count.
-pub(super) async fn run_search(conn: &Connection, query: &SearchQuery) -> Result<Page<SearchHit>> {
+/// Run a search and return one page of hits plus the total match count. The
+/// `coverage` snapshot is supplied by the store for the semantic and hybrid modes
+/// (which gate on embedding staleness) and is `None` for the lexical modes.
+pub(super) async fn run_search(
+    conn: &Connection,
+    query: &SearchQuery,
+    coverage: Option<&EmbeddingCoverage>,
+) -> Result<Page<SearchHit>> {
     match query.mode {
-        SearchMode::Semantic => run_semantic(conn, query).await,
-        SearchMode::Hybrid => run_hybrid(conn, query).await,
+        SearchMode::Semantic => run_semantic(conn, query, require_coverage(coverage)?).await,
+        SearchMode::Hybrid => run_hybrid(conn, query, require_coverage(coverage)?).await,
         _ => run_lexical(conn, query).await,
     }
+}
+
+/// The staleness gate for semantic and hybrid search needs the coverage snapshot,
+/// which the store computes for exactly those two modes. A missing snapshot here
+/// is an internal wiring break, never a user input error.
+fn require_coverage(coverage: Option<&EmbeddingCoverage>) -> Result<&EmbeddingCoverage> {
+    coverage.ok_or_else(|| {
+        IndexError::Db("semantic search dispatched without an embedding coverage snapshot".into())
+    })
 }
 
 /// The lexical modes: Text, Title and Permalink. A LIKE-candidate prefilter in
@@ -198,7 +213,11 @@ fn pack_vector(v: &[f32]) -> Vec<u8> {
 
 /// Semantic search over chunk embeddings. Requires the caller to have embedded
 /// the query and set the active model on the [`SearchQuery`].
-async fn run_semantic(conn: &Connection, query: &SearchQuery) -> Result<Page<SearchHit>> {
+async fn run_semantic(
+    conn: &Connection,
+    query: &SearchQuery,
+    coverage: &EmbeddingCoverage,
+) -> Result<Page<SearchHit>> {
     let qvec = query
         .query_embedding
         .as_deref()
@@ -212,7 +231,7 @@ async fn run_semantic(conn: &Connection, query: &SearchQuery) -> Result<Page<Sea
     let page = query.page.max(1);
     let min_sim = query.min_similarity.unwrap_or(DEFAULT_MIN_SIMILARITY) as f64;
 
-    check_staleness(conn, active, dims).await?;
+    check_staleness(coverage, active, dims)?;
 
     let mut hits = semantic_candidates(conn, query, qvec, active, dims).await?;
     hits.retain(|(sim, _)| *sim >= min_sim);
@@ -256,7 +275,11 @@ async fn run_semantic(conn: &Connection, query: &SearchQuery) -> Result<Page<Sea
 /// (up to `1.0`) can outrank an equally strong single-signal hit (up to `0.85`).
 /// Hits are deduplicated per engram, keeping the best score, and every filter is
 /// pushed into the SQL of both halves rather than dropped afterwards.
-async fn run_hybrid(conn: &Connection, query: &SearchQuery) -> Result<Page<SearchHit>> {
+async fn run_hybrid(
+    conn: &Connection,
+    query: &SearchQuery,
+    coverage: &EmbeddingCoverage,
+) -> Result<Page<SearchHit>> {
     let qvec = query
         .query_embedding
         .as_deref()
@@ -270,7 +293,7 @@ async fn run_hybrid(conn: &Connection, query: &SearchQuery) -> Result<Page<Searc
     let page = query.page.max(1);
     let min_sim = query.min_similarity.unwrap_or(DEFAULT_MIN_SIMILARITY) as f64;
 
-    check_staleness(conn, active, dims).await?;
+    check_staleness(coverage, active, dims)?;
 
     let terms: Vec<String> = query.text.as_deref().map(terms_of).unwrap_or_default();
     let text_scored = if terms.is_empty() {
@@ -409,52 +432,43 @@ async fn semantic_candidates(
 /// Either case surfaces as [`IndexError::StaleEmbeddings`] so callers report
 /// "reindex in progress"; text search never calls this. When nothing is embedded
 /// yet, this is not an error: the semantic scan simply returns no hits.
-async fn check_staleness(conn: &Connection, active_model: &str, dims: usize) -> Result<()> {
-    let rows = query_all(
-        conn,
-        "SELECT model, dims, count(*) FROM chunk WHERE embedding IS NOT NULL GROUP BY model, dims",
-        vec![],
-    )
-    .await?;
+///
+/// This consumes the shared coverage snapshot (the same one `effective_mode`
+/// reads) rather than issuing its own aggregate scan, so a semantic or hybrid
+/// search costs one cached snapshot, not a second `GROUP BY`. The snapshot's
+/// `models` omits the empty-model group, but `store_embeddings` always writes a
+/// non-empty model id and nothing else ever writes an embedding, so no embedded
+/// chunk can lack a model: the omitted group is unreachable, and `embedded_chunks`
+/// plus `total_chunks` still account for every chunk. The produced
+/// [`IndexError::StaleEmbeddings`] fields are therefore byte-identical to the old
+/// direct scan for every reachable database state.
+fn check_staleness(coverage: &EmbeddingCoverage, active_model: &str, dims: usize) -> Result<()> {
     let mut active_embedded = 0usize;
-    let mut total_embedded = 0usize;
     let mut foreign_dims = false;
-    let mut other: Option<(String, usize)> = None;
-    for r in &rows {
-        let m = cell_text(r, 0).unwrap_or_default();
-        let d = cell_i64(r, 1).unwrap_or(0).max(0) as usize;
-        let c = cell_i64(r, 2).unwrap_or(0).max(0) as usize;
-        total_embedded += c;
-        if m == active_model && d == dims {
-            active_embedded += c;
+    let mut other: Option<(&str, usize)> = None;
+    for m in &coverage.models {
+        if m.model == active_model && m.dims == dims {
+            active_embedded += m.count;
             continue;
         }
-        if d != dims {
+        if m.dims != dims {
             foreign_dims = true;
         }
-        if other.as_ref().map(|(_, oc)| c > *oc).unwrap_or(true) {
-            let label = if m.is_empty() {
-                "unknown".to_string()
-            } else {
-                m
-            };
-            other = Some((label, c));
+        if other.as_ref().map(|(_, oc)| m.count > *oc).unwrap_or(true) {
+            other = Some((m.model.as_str(), m.count));
         }
     }
 
-    let stale = total_embedded > 0 && (foreign_dims || active_embedded == 0);
+    let stale = coverage.embedded_chunks > 0 && (foreign_dims || active_embedded == 0);
     if stale {
-        let total_chunks = scalar_i64(conn, "SELECT count(*) FROM chunk", vec![])
-            .await?
-            .max(0) as usize;
         let stored_model = other
-            .map(|(m, _)| m)
+            .map(|(m, _)| m.to_string())
             .unwrap_or_else(|| active_model.to_string());
         return Err(IndexError::StaleEmbeddings {
             stored_model,
             active_model: active_model.to_string(),
             embedded: active_embedded,
-            total: total_chunks,
+            total: coverage.total_chunks,
         });
     }
     Ok(())

--- a/crates/index/tests/store.rs
+++ b/crates/index/tests/store.rs
@@ -12,8 +12,9 @@
 use std::path::Path;
 
 use crystalline_index::{
-    DomainKind, EmbeddingRow, EngramId, EngramRecord, FileStamp, FilterOp, HostClaim, IndexError,
-    MetadataFilter, RecentFilter, SearchMode, SearchQuery, Store, TursoStore, sync_domain,
+    DomainId, DomainKind, EmbeddingCoverage, EmbeddingRow, EngramId, EngramRecord, FileStamp,
+    FilterOp, HostClaim, IndexError, MetadataFilter, NewChunk, RecentFilter, SearchMode,
+    SearchQuery, Store, TursoStore, sync_domain,
 };
 
 fn write(dir: &Path, rel: &str, content: &str) {
@@ -1344,6 +1345,290 @@ async fn store_embeddings_mid_batch_mismatch_leaves_nothing(store: &dyn Store) {
 parity!(
     store_embeddings_is_atomic_on_mid_batch_dims_mismatch,
     store_embeddings_mid_batch_mismatch_leaves_nothing
+);
+
+// --- T1: embedding coverage cache invalidation -------------------------------
+//
+// The store caches the `EmbeddingCoverage` snapshot behind interior mutability
+// so `effective_mode` and the search staleness gate share one source of truth.
+// Every mutator that can change a chunk's embedding state must drop that
+// snapshot. The invalidation set derived from the `Store` trait is
+// `store_embeddings`, `replace_chunks`, `delete_engram`, `clear_domain`, `wipe`
+// and `rollback`. `upsert_engram`, `upsert_engram_checked` and `rename_engram`
+// never touch the chunk table, so they are deliberately not invalidators. Each
+// test warms the cache, mutates, then asserts the snapshot agrees with an
+// uncached recomputation, so a missing invalidation surfaces as a stale snapshot.
+
+/// The coverage facts recomputed WITHOUT the cache: `chunks_needing_embedding`
+/// never reads it. A model that embedded nothing needs every chunk, so its
+/// pending count is the total chunk count; the active model's pending count is
+/// the total minus the chunks it embedded, so total minus that pending count is
+/// the embedded count. Returns `(total_chunks, embedded_chunks)` as an
+/// independent ground truth for a store whose only embeddings use `model`.
+async fn recomputed_coverage(store: &dyn Store, model: &str) -> (usize, usize) {
+    let total = store
+        .chunks_needing_embedding("no-model-ever-embedded-this", None)
+        .await
+        .unwrap()
+        .len();
+    let pending = store
+        .chunks_needing_embedding(model, None)
+        .await
+        .unwrap()
+        .len();
+    (total, total - pending)
+}
+
+/// Assert the (possibly cached) coverage snapshot equals the uncached
+/// recomputation. Assumes every embedded chunk was embedded with `model`.
+async fn assert_snapshot_matches(store: &dyn Store, model: &str) {
+    let cov = store.embedding_coverage().await.unwrap();
+    let (total, embedded) = recomputed_coverage(store, model).await;
+    assert_eq!(
+        cov.total_chunks, total,
+        "total_chunks must match the uncached recount"
+    );
+    assert_eq!(
+        cov.embedded_chunks, embedded,
+        "embedded_chunks must match the uncached recount"
+    );
+}
+
+/// Seed a virtual domain with two engrams, one chunk each, nothing embedded.
+/// Returns the domain id for the mutators that address a domain directly.
+async fn seed_two_chunks(store: &dyn Store) -> DomainId {
+    let did = store
+        .upsert_domain("v", None, DomainKind::Virtual)
+        .await
+        .unwrap();
+    store
+        .upsert_engram(did, &record("a.md", "a", "alpha body", "sha-a"))
+        .await
+        .unwrap();
+    store
+        .upsert_engram(did, &record("b.md", "b", "beta body", "sha-b"))
+        .await
+        .unwrap();
+    let a = store.lookup_id("v", "a").await.unwrap().unwrap();
+    let b = store.lookup_id("v", "b").await.unwrap().unwrap();
+    store
+        .replace_chunks(
+            a,
+            &[NewChunk {
+                seq: 0,
+                text: "alpha body".into(),
+                text_hash: "hash-a".into(),
+            }],
+        )
+        .await
+        .unwrap();
+    store
+        .replace_chunks(
+            b,
+            &[NewChunk {
+                seq: 0,
+                text: "beta body".into(),
+                text_hash: "hash-b".into(),
+            }],
+        )
+        .await
+        .unwrap();
+    did
+}
+
+/// Embed every currently-pending chunk with `model` at width 8.
+async fn embed_all(store: &dyn Store, model: &str) {
+    let jobs = store.chunks_needing_embedding(model, None).await.unwrap();
+    let rows: Vec<EmbeddingRow> = jobs
+        .iter()
+        .map(|j| EmbeddingRow {
+            chunk_id: j.chunk_id,
+            embedding: vec![0.1f32; 8],
+            dims: 8,
+        })
+        .collect();
+    store.store_embeddings(&rows, model).await.unwrap();
+}
+
+async fn coverage_cache_invalidated_by_store_embeddings(store: &dyn Store) {
+    seed_two_chunks(store).await;
+    // Warm the snapshot while nothing is embedded.
+    let warm = store.embedding_coverage().await.unwrap();
+    assert_eq!(warm.total_chunks, 2);
+    assert_eq!(warm.embedded_chunks, 0, "nothing embedded yet");
+    // store_embeddings embeds every chunk; a surviving snapshot would still
+    // report zero embedded.
+    embed_all(store, "m8").await;
+    assert_snapshot_matches(store, "m8").await;
+    let cov = store.embedding_coverage().await.unwrap();
+    assert_eq!(
+        cov.embedded_chunks, 2,
+        "both chunks embedded after the mutator"
+    );
+}
+parity!(
+    coverage_cache_invalidates_on_store_embeddings,
+    coverage_cache_invalidated_by_store_embeddings
+);
+
+async fn coverage_cache_invalidated_by_replace_chunks(store: &dyn Store) {
+    seed_two_chunks(store).await;
+    embed_all(store, "m8").await;
+    let warm = store.embedding_coverage().await.unwrap();
+    assert_eq!(warm.embedded_chunks, 2);
+    // Replacing A's chunk with a differently fingerprinted one drops A's carried
+    // embedding, so one fewer chunk is embedded.
+    let a = store.lookup_id("v", "a").await.unwrap().unwrap();
+    store
+        .replace_chunks(
+            a,
+            &[NewChunk {
+                seq: 0,
+                text: "rewritten alpha".into(),
+                text_hash: "hash-a-v2".into(),
+            }],
+        )
+        .await
+        .unwrap();
+    assert_snapshot_matches(store, "m8").await;
+    let cov = store.embedding_coverage().await.unwrap();
+    assert_eq!(cov.embedded_chunks, 1, "A's embedding dropped, B's remains");
+    assert_eq!(cov.total_chunks, 2, "still two chunks total");
+}
+parity!(
+    coverage_cache_invalidates_on_replace_chunks,
+    coverage_cache_invalidated_by_replace_chunks
+);
+
+async fn coverage_cache_invalidated_by_delete_engram(store: &dyn Store) {
+    let did = seed_two_chunks(store).await;
+    embed_all(store, "m8").await;
+    let warm = store.embedding_coverage().await.unwrap();
+    assert_eq!(warm.total_chunks, 2);
+    assert_eq!(warm.embedded_chunks, 2);
+    store.delete_engram(did, "a.md").await.unwrap();
+    assert_snapshot_matches(store, "m8").await;
+    let cov = store.embedding_coverage().await.unwrap();
+    assert_eq!(cov.total_chunks, 1, "A's chunk removed");
+    assert_eq!(cov.embedded_chunks, 1);
+}
+parity!(
+    coverage_cache_invalidates_on_delete_engram,
+    coverage_cache_invalidated_by_delete_engram
+);
+
+async fn coverage_cache_invalidated_by_clear_domain(store: &dyn Store) {
+    let did = seed_two_chunks(store).await;
+    embed_all(store, "m8").await;
+    let warm = store.embedding_coverage().await.unwrap();
+    assert_eq!(warm.embedded_chunks, 2);
+    store.clear_domain(did).await.unwrap();
+    assert_snapshot_matches(store, "m8").await;
+    let cov = store.embedding_coverage().await.unwrap();
+    assert_eq!(
+        cov.total_chunks, 0,
+        "clearing the domain removed every chunk"
+    );
+    assert_eq!(cov.embedded_chunks, 0);
+    assert!(cov.models.is_empty());
+}
+parity!(
+    coverage_cache_invalidates_on_clear_domain,
+    coverage_cache_invalidated_by_clear_domain
+);
+
+async fn coverage_cache_invalidated_by_wipe(store: &dyn Store) {
+    seed_two_chunks(store).await;
+    embed_all(store, "m8").await;
+    let warm = store.embedding_coverage().await.unwrap();
+    assert_eq!(warm.embedded_chunks, 2);
+    store.wipe().await.unwrap();
+    assert_snapshot_matches(store, "m8").await;
+    let cov = store.embedding_coverage().await.unwrap();
+    assert_eq!(
+        cov,
+        EmbeddingCoverage::default(),
+        "wipe empties the snapshot"
+    );
+}
+parity!(
+    coverage_cache_invalidates_on_wipe,
+    coverage_cache_invalidated_by_wipe
+);
+
+async fn coverage_cache_invalidated_by_rollback(store: &dyn Store) {
+    let did = seed_two_chunks(store).await;
+    // Warm outside any transaction: two chunks, none embedded.
+    let base = store.embedding_coverage().await.unwrap();
+    assert_eq!(base.total_chunks, 2);
+    // Add a third chunk inside a transaction and observe it mid-transaction,
+    // which recomputes and re-caches the uncommitted count, then roll back.
+    store.begin().await.unwrap();
+    store
+        .upsert_engram(did, &record("c.md", "c", "gamma body", "sha-c"))
+        .await
+        .unwrap();
+    let c = store.lookup_id("v", "c").await.unwrap().unwrap();
+    store
+        .replace_chunks(
+            c,
+            &[NewChunk {
+                seq: 0,
+                text: "gamma body".into(),
+                text_hash: "hash-c".into(),
+            }],
+        )
+        .await
+        .unwrap();
+    let mid = store.embedding_coverage().await.unwrap();
+    assert_eq!(mid.total_chunks, 3, "sees its own uncommitted chunk");
+    store.rollback().await.unwrap();
+    // The uncommitted chunk is gone; the mid-transaction snapshot must not
+    // survive the rollback.
+    let after = store.embedding_coverage().await.unwrap();
+    assert_eq!(after.total_chunks, 2, "rollback dropped the stale snapshot");
+}
+parity!(
+    coverage_cache_invalidates_on_rollback,
+    coverage_cache_invalidated_by_rollback
+);
+
+/// The staleness label must stay byte-identical after the check consumes the
+/// cached coverage snapshot instead of its own aggregate scan: a same-width model
+/// swap names the stored model, reports zero embedded for the active model and
+/// counts every chunk. Mirrors `model_swap_returns_stale_embeddings_error` in
+/// `embed.rs` across both backends.
+async fn stale_embeddings_names_stored_model(store: &dyn Store) {
+    seed_two_chunks(store).await;
+    embed_all(store, "m8").await;
+    let query = SearchQuery {
+        text: Some("alpha".into()),
+        mode: SearchMode::Semantic,
+        query_embedding: Some(vec![0.1f32; 8]),
+        active_model: Some("other-model".into()),
+        limit: 10,
+        page: 1,
+        ..SearchQuery::default()
+    };
+    let err = store.search(&query).await.unwrap_err();
+    match err {
+        IndexError::StaleEmbeddings {
+            stored_model,
+            active_model,
+            embedded,
+            total,
+        } => {
+            assert_eq!(stored_model, "m8");
+            assert_eq!(active_model, "other-model");
+            assert_eq!(embedded, 0, "nothing embedded for the active model");
+            assert_eq!(total, 2, "every chunk counted");
+        }
+        other => panic!("expected StaleEmbeddings, got {other:?}"),
+    }
+}
+parity!(
+    stale_embeddings_reports_stored_model_on_swap,
+    stale_embeddings_names_stored_model
 );
 
 /// Models routinely double-encode nested tool arguments, sending the

--- a/crates/index/tests/store.rs
+++ b/crates/index/tests/store.rs
@@ -433,6 +433,50 @@ parity!(
     forward_reference_resolves
 );
 
+/// The twin of `forward_reference_resolves` for the title-match path: the
+/// reference names its target by title, not permalink, and must resolve on the
+/// later sync when the target appears. This exercises the `lower(e.title)`
+/// branch of `resolve_pending_relations` (and the index behind it), which the
+/// permalink case never touches.
+async fn forward_reference_resolves_by_title(store: &dyn Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // `[[Target Beta]]` matches neither a permalink nor anything present yet, so
+    // it stays unresolved until an engram whose title is "Target Beta" arrives.
+    write(
+        root,
+        "a.md",
+        &engram("A", "a", "engram", "", "- depends_on [[Target Beta]]\n"),
+    );
+    let first = sync_domain(store, "d", root).await.unwrap();
+    assert_eq!(first.relations_resolved, 0, "target absent, unresolved");
+    assert_eq!(
+        store.domain_stats().await.unwrap()[0].unresolved_relations,
+        1
+    );
+
+    // The target appears with a permalink that does NOT match the reference
+    // text, so only the title match can resolve it.
+    write(
+        root,
+        "b.md",
+        &engram("Target Beta", "beta-perma", "engram", "", "body b\n"),
+    );
+    let second = sync_domain(store, "d", root).await.unwrap();
+    assert_eq!(
+        second.relations_resolved, 1,
+        "resolved by title on the later sync"
+    );
+    assert_eq!(
+        store.domain_stats().await.unwrap()[0].unresolved_relations,
+        0
+    );
+}
+parity!(
+    forward_reference_resolves_by_title_on_later_sync,
+    forward_reference_resolves_by_title
+);
+
 async fn duplicate_permalink_fails(store: &dyn Store) {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();

--- a/crates/index/tests/turso_only.rs
+++ b/crates/index/tests/turso_only.rs
@@ -30,8 +30,41 @@ async fn store_info_reports_turso_schema_version() {
     let store = open().await;
     let info = store.store_info().await.unwrap();
     assert_eq!(info.fts_mode, crystalline_index::FtsMode::CandidateScan);
-    // v1 initial, v2 vector chunk storage, v3 domain kind, v4 domain host lock.
-    assert_eq!(info.schema_version, 4);
+    // v1 initial, v2 vector chunk storage, v3 domain kind, v4 domain host lock,
+    // v5 title-lower expression index.
+    assert_eq!(info.schema_version, 5);
+}
+
+#[tokio::test]
+async fn title_match_resolution_seeks_the_promoted_index() {
+    let store = open().await;
+    // Seed a domain so the query is over a real table.
+    let dir = tempfile::tempdir().unwrap();
+    write(
+        dir.path(),
+        "a.md",
+        &engram("Alpha", "a", "engram", "", "b\n"),
+    );
+    sync_domain(&store, "d", dir.path()).await.unwrap();
+
+    // The correlated title subquery shape `resolve_pending_relations` runs to
+    // match a relation target by lowercased title within a domain. Without the
+    // expression index this is a full engram scan per unresolved reference.
+    let plan = store
+        .explain_query_plan(
+            "SELECT e.id FROM engram e WHERE lower(e.title) = lower('Alpha') AND e.domain_id = 1 LIMIT 1",
+        )
+        .await
+        .unwrap();
+    let joined = plan.join(" | ");
+    assert!(
+        joined.contains("USING INDEX") && joined.contains("idx_engram_title_lower"),
+        "title match should seek the promoted index, plan was: {joined}"
+    );
+    assert!(
+        !joined.contains("SCAN engram") || joined.contains("USING INDEX"),
+        "title match should not be a bare full scan, plan was: {joined}"
+    );
 }
 
 #[tokio::test]

--- a/crates/service/src/daemon.rs
+++ b/crates/service/src/daemon.rs
@@ -348,6 +348,18 @@ pub async fn run_serve(
         });
     }
 
+    // The embed self-heal tick: re-fires the event-driven embed worker on a low
+    // cadence whenever a backlog is left outstanding, so a transient provider
+    // failure that consumed the worker's signal does not strand the backlog
+    // until the next write. Never embeds inline (see run_embed_tick).
+    {
+        let e = engine.clone();
+        let rx = shared.watch();
+        tokio::spawn(async move {
+            run_embed_tick(e, EMBED_TICK, rx).await;
+        });
+    }
+
     // The optional HTTP endpoint.
     if let Some(addr) = http_addr.clone() {
         let e = engine.clone();
@@ -676,6 +688,43 @@ async fn run_origin_poller(engine: Arc<Engine>, mut shutdown: watch::Receiver<bo
             _ = ticker.tick() => {
                 engine.origin_poll_tick(Instant::now(), chrono::Utc::now()).await;
             }
+        }
+    }
+}
+
+/// How often the embed self-heal tick wakes to re-fire the worker when a
+/// backlog remains. Low by design: the worker is event-driven and this only
+/// closes the gap a transient provider failure opens, so it never needs to run
+/// often.
+const EMBED_TICK: Duration = Duration::from_secs(300);
+
+/// Re-fire the event-driven embed worker whenever a backlog is left outstanding,
+/// until shutdown. The worker only runs when a write signals it; a transient
+/// provider failure consumes that signal and would strand the backlog until the
+/// next write. Every `cadence` this checks the engine's backlog probe and, only
+/// when it is non-empty, sends one more signal on the worker channel. It never
+/// falls back to an inline embed when no worker is wired (an inline pass on this
+/// timer would reintroduce the request-path stall the worker exists to
+/// prevent), so an unwired tick is a silent no-op. The cadence is a parameter so
+/// a test can drive it fast; production passes [`EMBED_TICK`]. The first tick is
+/// consumed so a self-heal never races the startup embed.
+pub async fn run_embed_tick(
+    engine: Arc<Engine>,
+    cadence: Duration,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    let mut ticker = tokio::time::interval(cadence);
+    ticker.tick().await;
+    loop {
+        tokio::select! {
+            _ = wait_true(&mut shutdown) => break,
+            _ = ticker.tick() => match engine.embedding_backlog().await {
+                Ok(0) => {}
+                Ok(_) => {
+                    engine.request_embed();
+                }
+                Err(err) => tracing::warn!("embed self-heal backlog probe failed: {err}"),
+            },
         }
     }
 }

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -2527,7 +2527,7 @@ impl Engine {
         if let Value::Object(map) = &mut activity {
             map.insert(
                 "embedding_backlog".to_string(),
-                json!(coverage.total_chunks.saturating_sub(active_embedded)),
+                json!(coverage.backlog_for(&self.model_id)),
             );
         }
         let mut result = json!({
@@ -2555,6 +2555,18 @@ impl Engine {
             map.insert("origins".to_string(), self.origins_status_block().await);
         }
         Ok(result)
+    }
+
+    /// Chunks awaiting embedding for the active model: the figure `status_report`
+    /// exposes as `embedding_backlog`. Reads the cached coverage snapshot, so it
+    /// is cheap enough for the daemon's self-heal tick to poll; no per-chunk
+    /// scan.
+    pub async fn embedding_backlog(&self) -> Result<usize> {
+        let coverage = {
+            let store = self.store.lock().await;
+            store.embedding_coverage().await?
+        };
+        Ok(coverage.backlog_for(&self.model_id))
     }
 
     /// The domain-id set this instance should embed, or `None` for "all domains".

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -1937,6 +1937,25 @@ impl Engine {
     /// default global config path. Staleness is bounded to one connection: the
     /// block is an initialize-time snapshot, and the virtual bullets are only as
     /// fresh as the last cache refresh.
+    ///
+    /// This re-read looks redundant with `self.config` (in-memory), and mostly
+    /// is: `configure`'s `Set`/`Unset` (Engine::configure), `domain_add`'s file
+    /// and virtual arms and `origin_add` all persist to disk and then write
+    /// `self.config` in the same call, under `file_config`-then-`config` lock
+    /// order, before returning - a concurrent reader sees the new value the
+    /// instant the write lock releases, no re-read needed. `domain remove`
+    /// (`cmd::domain_remove` in the CLI crate) is the one path that does not:
+    /// it is a free function with no `Engine` reference at all, so it mutates
+    /// the config file directly regardless of whether a daemon is live; the
+    /// only in-process signal a running daemon gets is the `forget_domain` ctl
+    /// call, and `Engine::forget_domain` only drops the name from
+    /// `discovered_domains` and tells the watcher to stop - it never touches
+    /// `self.config`. Serving from `self.config` alone would therefore keep a
+    /// removed domain in every connection's routing block until the daemon
+    /// restarts, not just for one racing connection - a real regression, not
+    /// the already-accepted bounded staleness this comment describes for the
+    /// `None` branch below. So the re-read stays for as long as `domain
+    /// remove` is the one mutation path that does not refresh `self.config`.
     pub fn routing_text(&self) -> String {
         // (1) The effective config, composed the same way a fresh load would
         // see it. With a config path this is a fresh file read plus the overlay;

--- a/crates/service/tests/embed_tick.rs
+++ b/crates/service/tests/embed_tick.rs
@@ -1,0 +1,112 @@
+//! The daemon's embed self-heal tick. The embed worker is event-driven: a
+//! transient provider failure consumes its signal and strands the backlog until
+//! the next write. This periodic tick re-fires the worker while a backlog
+//! remains and stays silent when there is none, and exits on shutdown.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crystalline_core::config::{DomainEntry, GlobalConfig};
+use crystalline_index::{Store, TursoStore};
+use crystalline_service::daemon::run_embed_tick;
+use crystalline_service::engine::Engine;
+use crystalline_service::params::*;
+use tokio::sync::Mutex;
+
+/// An engine over a config with a single virtual domain named `notes`.
+fn virtual_engine(store: Arc<Mutex<dyn Store>>) -> Engine {
+    let mut cfg = GlobalConfig::default();
+    cfg.domains
+        .insert("notes".to_string(), DomainEntry::virtual_domain());
+    Engine::new(store, cfg, None, None)
+}
+
+fn write_params(title: &str, content: &str) -> WriteParams {
+    WriteParams {
+        domain: "notes".to_string(),
+        title: title.to_string(),
+        content: content.to_string(),
+        folder: None,
+        engram_type: None,
+        tags: Vec::new(),
+        status: None,
+        metadata: None,
+        overwrite: false,
+    }
+}
+
+#[tokio::test]
+async fn tick_refires_the_worker_while_a_backlog_remains() {
+    let store = TursoStore::open_in_memory().await.unwrap();
+    let store: Arc<Mutex<dyn Store>> = Arc::new(Mutex::new(store));
+    let (embed_tx, mut embed_rx) = tokio::sync::mpsc::unbounded_channel();
+    let engine = Arc::new(virtual_engine(store).with_embed_channel(embed_tx));
+
+    // A written engram is chunked but, with no provider, never embedded, so the
+    // backlog is non-empty. The write itself schedules one pass on the wired
+    // channel; drain that so only a tick-driven signal is left to observe.
+    engine
+        .write_engram(&write_params(
+            "Note",
+            "the body of a note that produces a chunk",
+        ))
+        .await
+        .unwrap();
+    while embed_rx.try_recv().is_ok() {}
+    assert!(
+        engine.embedding_backlog().await.unwrap() > 0,
+        "the write left an unembedded backlog"
+    );
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let handle = tokio::spawn(run_embed_tick(
+        engine.clone(),
+        Duration::from_millis(25),
+        shutdown_rx,
+    ));
+
+    // The tick must re-fire the worker within the window.
+    let signal = tokio::time::timeout(Duration::from_secs(1), embed_rx.recv()).await;
+    assert!(
+        signal.is_ok_and(|v| v.is_some()),
+        "a tick re-fires the worker while a backlog remains"
+    );
+
+    // Shutdown mirrors the other periodic tasks: the task exits promptly.
+    shutdown_tx.send(true).unwrap();
+    tokio::time::timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("the tick task exits when shutdown is signaled")
+        .unwrap();
+}
+
+#[tokio::test]
+async fn tick_stays_silent_with_no_backlog() {
+    let store = TursoStore::open_in_memory().await.unwrap();
+    let store: Arc<Mutex<dyn Store>> = Arc::new(Mutex::new(store));
+    let (embed_tx, mut embed_rx) = tokio::sync::mpsc::unbounded_channel();
+    // Nothing is written, so nothing is chunked and the backlog is empty.
+    let engine = Arc::new(virtual_engine(store).with_embed_channel(embed_tx));
+    assert_eq!(
+        engine.embedding_backlog().await.unwrap(),
+        0,
+        "an empty index has an empty backlog"
+    );
+
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let handle = tokio::spawn(run_embed_tick(
+        engine.clone(),
+        Duration::from_millis(25),
+        shutdown_rx,
+    ));
+
+    // Several tick periods pass with an empty backlog; the worker is never fired.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(
+        embed_rx.try_recv().is_err(),
+        "an empty backlog fires no tick signal"
+    );
+
+    shutdown_tx.send(true).unwrap();
+    let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
+}


### PR DESCRIPTION
The four medium-risk batches deferred from the audit (PR #8), each probe-verified where the design depended on unconfirmed behavior.

- Coverage cache: both backends keep one embedding-coverage snapshot invalidated by exactly the six chunk-mutating store methods (including rollback); the search staleness gate consumes it, so a hybrid search costs one cached read instead of two full chunk-table scans. Invalidation matrix test per mutator.
- Embed resilience: the remote provider retries transient failures (429, 5xx, connect, timeout) with capped doubling backoff honoring Retry-After; a five-minute daemon tick re-fires the embed worker while a backlog remains, so a transient failure no longer strands chunks until the next write.
- Sync scalability: turso 0.7.0 accepts and seeks expression indexes (probe-confirmed), so both backends gain an append-only (domain_id, lower(title)) index that turns per-reference full scans in relation resolution into seeks; chunking moved out of the sync write transaction. Perf corpus: cold sync ~1030 ms to ~440 ms, warm steady at 3 ms.
- Probe-driven singles: busy_timeout set at open and wal_checkpoint(TRUNCATE) after wipe/full reindex (wal_autocheckpoint is silently ignored by turso, documented); atomic import writes; verify tokenizes each body once; read-only CLI verbs on a current-thread runtime. The routing-text config re-read stays - the probe found domain remove mutates the file with no engine reference, so the re-read is load-bearing; documented in code.

Gates green after every milestone: 1117 tests, doctests, clippy -D warnings (incl. the postgres feature), fmt and style-lint. The postgres-parity CI leg validates the twin-backend changes; windows validates the runtime split.