### PR TITLE
Lock-phased sync and path-targeted watcher syncs

### DIFF
--- a/crates/cli/src/cmd.rs
+++ b/crates/cli/src/cmd.rs
@@ -13,8 +13,8 @@ use crystalline_core::config::{
     self, DatabaseBackend, DomainEntry, EmbeddingsConfig, GlobalConfig,
 };
 use crystalline_index::{
-    ChunkParams, DomainKind, Store, configured_model_id, download_local_model,
-    provider_from_config, run_embedding_pass, sync_domain_with,
+    ChunkParams, DomainKind, Store, apply_scan, configured_model_id, download_local_model,
+    provider_from_config, run_embedding_pass, scan_domain,
 };
 use tokio::sync::Mutex as TokioMutex;
 
@@ -314,9 +314,20 @@ pub(crate) async fn sync_domain_direct(
 ) -> Result<crystalline_index::SyncReport> {
     let cfg = load(config_override)?.effective;
     let store = open_backend(&cfg, db_override, false).await?;
-    let store = store.lock().await;
     let params = chunk_params(&cfg);
-    sync_domain_with(&*store, name, root, &params)
+    // First lock window: resolve the domain id and snapshot its stamps. The scan
+    // then runs with no lock held; the second window applies transactionally.
+    let (domain, snapshot) = {
+        let store = store.lock().await;
+        let domain = store
+            .upsert_domain(name, Some(&root.to_string_lossy()), DomainKind::File)
+            .await?;
+        let snapshot = store.file_stamps(domain).await?;
+        (domain, snapshot)
+    };
+    let scan = scan_domain(name, root, snapshot, &params).await;
+    let store = store.lock().await;
+    apply_scan(&*store, domain, scan)
         .await
         .map_err(|e| anyhow!("sync of '{name}' failed: {e}"))
 }
@@ -825,7 +836,6 @@ pub async fn sync(
     let cfg = load(config_override)?.effective;
     let targets = select_domains(&cfg, only)?;
     let store = open_backend(&cfg, db_override, false).await?;
-    let store = store.lock().await;
     let params = chunk_params(&cfg);
 
     let mut reports = Vec::new();
@@ -840,9 +850,24 @@ pub async fn sync(
         if !json {
             eprintln!("syncing {name}...");
         }
-        let report = sync_domain_with(&*store, &name, &path, &params)
-            .await
-            .map_err(|e| anyhow!("sync of '{name}' failed: {e}"))?;
+        // First lock window: snapshot the stamps; scan with no lock held so the
+        // walk-hash-parse pass does not block concurrent readers; second window:
+        // apply transactionally with the TOCTOU guards.
+        let (domain, snapshot) = {
+            let store = store.lock().await;
+            let domain = store
+                .upsert_domain(&name, Some(&path.to_string_lossy()), DomainKind::File)
+                .await?;
+            let snapshot = store.file_stamps(domain).await?;
+            (domain, snapshot)
+        };
+        let scan = scan_domain(&name, &path, snapshot, &params).await;
+        let report = {
+            let store = store.lock().await;
+            apply_scan(&*store, domain, scan)
+                .await
+                .map_err(|e| anyhow!("sync of '{name}' failed: {e}"))?
+        };
         reports.push(report);
     }
 
@@ -855,6 +880,7 @@ pub async fn sync(
     }
 
     if embed {
+        let store = store.lock().await;
         embed_pass(&*store, &cfg).await?;
     }
     Ok(())
@@ -880,13 +906,16 @@ pub async fn reindex(
     // domain's rows per-domain and resyncs, so virtual-domain rows, whose only
     // source of truth is the database, survive the reindex.
     let store = open_backend(&cfg, db_override, full).await?;
-    let store = store.lock().await;
     // Only the file domains have files to (re)index.
     let file_targets: Vec<(String, PathBuf)> = targets
         .into_iter()
         .filter_map(|(name, entry)| resolve_domain_path(&entry).map(|p| (name, p)))
         .collect();
+    // Clear every file domain up front, before any resync, so cross-domain
+    // forward references resolve in the same order as before the lock split (a
+    // source domain sees the cleared, not the stale, target while resolving).
     if full {
+        let store = store.lock().await;
         for (name, path) in &file_targets {
             let domain_id = store
                 .upsert_domain(name, Some(&path.to_string_lossy()), DomainKind::File)
@@ -901,9 +930,22 @@ pub async fn reindex(
 
     let mut reports = Vec::new();
     for (name, path) in &file_targets {
-        let report = sync_domain_with(&*store, name, path, &params)
-            .await
-            .map_err(|e| anyhow!("reindex of '{name}' failed: {e}"))?;
+        // First lock window: snapshot; scan with no lock held; second: apply.
+        let (domain, snapshot) = {
+            let store = store.lock().await;
+            let domain = store
+                .upsert_domain(name, Some(&path.to_string_lossy()), DomainKind::File)
+                .await?;
+            let snapshot = store.file_stamps(domain).await?;
+            (domain, snapshot)
+        };
+        let scan = scan_domain(name, path, snapshot, &params).await;
+        let report = {
+            let store = store.lock().await;
+            apply_scan(&*store, domain, scan)
+                .await
+                .map_err(|e| anyhow!("reindex of '{name}' failed: {e}"))?
+        };
         reports.push(report);
     }
 
@@ -923,6 +965,7 @@ pub async fn reindex(
     }
 
     if embed {
+        let store = store.lock().await;
         embed_pass(&*store, &cfg).await?;
     }
 
@@ -932,6 +975,7 @@ pub async fn reindex(
         // next natural checkpoint. A no-op on Postgres (no local WAL file);
         // on Turso this replaces the downstream Docker image build's shell-out
         // to `sqlite3` for the same purpose.
+        let store = store.lock().await;
         store.checkpoint_wal().await?;
     }
     Ok(())
@@ -1588,14 +1632,22 @@ fn select_domains(cfg: &GlobalConfig, only: Option<&str>) -> Result<Vec<(String,
 }
 
 fn print_report(r: &crystalline_index::SyncReport) {
+    // The deferred count only prints when non-zero, so a quiet uncontended sync
+    // reads the same as before and a busy one surfaces the skipped changes.
+    let deferred = if r.deferred > 0 {
+        format!(", {} deferred", r.deferred)
+    } else {
+        String::new()
+    };
     println!(
-        "{}: {} added, {} updated, {} deleted, {} moved, {} unchanged, {} resolved ({} ms)",
+        "{}: {} added, {} updated, {} deleted, {} moved, {} unchanged{}, {} resolved ({} ms)",
         r.domain,
         r.added,
         r.updated,
         r.deleted,
         r.moved,
         r.unchanged,
+        deferred,
         r.relations_resolved,
         r.duration_ms
     );

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -36,7 +36,7 @@ pub use store::{
     MetadataFilter, NewChunk, Page, RecentFilter, SearchHit, SearchMode, SearchQuery, Store,
     StoreInfo, StoredEngram, parse_metadata_filters,
 };
-pub use sync::{SyncReport, sync_domain, sync_domain_with};
+pub use sync::{DomainScan, SyncReport, apply_scan, scan_domain, sync_domain, sync_domain_with};
 pub use turso::TursoStore;
 
 #[cfg(feature = "postgres")]

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -36,7 +36,9 @@ pub use store::{
     MetadataFilter, NewChunk, Page, RecentFilter, SearchHit, SearchMode, SearchQuery, Store,
     StoreInfo, StoredEngram, parse_metadata_filters,
 };
-pub use sync::{DomainScan, SyncReport, apply_scan, scan_domain, sync_domain, sync_domain_with};
+pub use sync::{
+    DomainScan, SyncReport, apply_scan, scan_domain, scan_paths, sync_domain, sync_domain_with,
+};
 pub use turso::TursoStore;
 
 #[cfg(feature = "postgres")]

--- a/crates/index/src/sync.rs
+++ b/crates/index/src/sync.rs
@@ -20,6 +20,14 @@
 //! the two for callers that do not manage the lock. Splitting them keeps the
 //! store mutex off the long walk-hash-parse pass of a large domain.
 //!
+//! [`scan_paths`] is a second front on the same classification machinery for the
+//! file watcher: its candidates come from a given list of relative paths instead
+//! of a full walk, so a one-file edit in a large domain costs one stat and one
+//! hash rather than walking every entry. Both fronts feed the identical
+//! [`apply_scan`], so the targeted pass inherits every TOCTOU guard unchanged.
+//! The watcher's full fallback, the startup sync and manual sync all reconcile
+//! any gap, so the targeted front only has to be convergent, never perfect.
+//!
 //! # Convergence under a concurrent writer
 //!
 //! Between the snapshot and the apply another writer (an MCP edit or a second
@@ -36,7 +44,7 @@
 //! the prefilter keeps re-selecting a diverged path until an uncontended pass
 //! applies it.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant, UNIX_EPOCH};
@@ -223,6 +231,145 @@ pub async fn scan_domain(
         );
     }
 
+    // Deleted candidates: recorded files no longer present on disk. A full walk
+    // sees every recorded path, so deletion detection is domain-wide here.
+    let deleted_paths: Vec<String> = stamps
+        .keys()
+        .filter(|p| !current.contains_key(*p))
+        .cloned()
+        .collect();
+
+    classify_and_parse(
+        name,
+        root,
+        stamps,
+        current,
+        deleted_paths,
+        chunk_params,
+        started,
+    )
+    .await
+}
+
+/// Scan a specific list of relative paths against a stamp snapshot, the
+/// path-targeted counterpart of [`scan_domain`] for the file watcher.
+///
+/// The classification, hashing, move detection and parsing are the identical
+/// shared machinery [`scan_domain`] uses; only the candidate set differs. Each
+/// given path is classified in isolation: a path that exists and is a markdown
+/// file (and passes the same walk filters - not hidden, not inside a provisioned
+/// artifact folder) is a change candidate, still prefiltered against `stamps`; a
+/// path absent on disk but present in `stamps` is a delete candidate; a path that
+/// is neither on disk nor recorded is ignored. Deletion detection is scoped to
+/// `paths` - no directory is walked anywhere - so a one-file edit in a large
+/// domain costs one stat and one hash, not a full walk of every entry.
+///
+/// Move detection stays within this one batch, exactly as the full scan: a delete
+/// candidate whose stored checksum matches a new candidate's hash is a rename in
+/// place rather than a delete plus an add. A rename whose two ends land in
+/// different debounce windows cannot be paired here and degrades to a delete plus
+/// an add - index-correct, but the rename-in-place optimization is lost and,
+/// because `replace_chunks` carries an embedding over only within one engram, the
+/// new path's chunks re-embed. That degradation is acceptable: the watcher's full
+/// fallback, the startup sync and manual sync all reconcile, so the targeted
+/// front only has to be convergent, never perfect.
+///
+/// The result flows through [`apply_scan`] with the identical TOCTOU guards, so a
+/// concurrent writer landing between the snapshot and the apply is deferred and
+/// reconciled just as it is for a full scan.
+pub async fn scan_paths(
+    name: &str,
+    root: &Path,
+    stamps: HashMap<String, FileStamp>,
+    paths: Vec<String>,
+    chunk_params: &ChunkParams,
+) -> DomainScan {
+    let started = Instant::now();
+
+    // The same artifact folders the full walk prunes: a targeted scan must index
+    // exactly what a full scan would, never a file the walk would have skipped.
+    let excluded = crystalline_core::in_root_artifact_dirs(root);
+
+    let mut current: HashMap<String, Scanned> = HashMap::new();
+    let mut deleted_paths: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for rel in paths {
+        // The same path can arrive twice in one debounce batch; classify it once.
+        if !seen.insert(rel.clone()) {
+            continue;
+        }
+        let abs = root.join(&rel);
+        let hidden = rel.split('/').any(is_hidden);
+        let is_md = rel.to_lowercase().ends_with(".md");
+        match std::fs::metadata(&abs) {
+            // An existing markdown file, filtered exactly as the walk filters:
+            // a change candidate, prefiltered against the stamps downstream.
+            Ok(meta) if meta.is_file() && is_md && !hidden && !is_excluded(&abs, &excluded) => {
+                let mtime = meta
+                    .modified()
+                    .ok()
+                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or(0);
+                let size = meta.len();
+                current.insert(
+                    rel.clone(),
+                    Scanned {
+                        rel,
+                        abs,
+                        mtime,
+                        size,
+                    },
+                );
+            }
+            // Exists but is not an indexable markdown file (a directory, a
+            // non-markdown file, a hidden or artifact path): ignore it, matching
+            // the walk which never indexes it either.
+            Ok(_) => {}
+            // Absent on disk: a recorded path is a delete candidate (scoped to
+            // the given paths, no walk), an unrecorded one is a no-op.
+            Err(_) => {
+                if stamps.contains_key(&rel) {
+                    deleted_paths.push(rel);
+                }
+            }
+        }
+    }
+
+    classify_and_parse(
+        name,
+        root,
+        stamps,
+        current,
+        deleted_paths,
+        chunk_params,
+        started,
+    )
+    .await
+}
+
+/// The classification and parse core shared by [`scan_domain`] and [`scan_paths`].
+///
+/// Given the markdown files found on disk (`current`, keyed by relative path) and
+/// the recorded paths whose file is gone (`deleted_paths`), it prefilters against
+/// `stamps`, hashes the survivors, detects moves within this batch (a vanished
+/// path whose stored checksum matches a new file's hash is a rename, not a delete
+/// plus an add), parses the genuinely changed files off-thread and assembles the
+/// [`DomainScan`]. The walk front and the path-list front differ only in how they
+/// build `current` and `deleted_paths`; everything from here is identical, so the
+/// two stay in step by construction. `report.unchanged` counts only paths
+/// actually examined - the whole domain for a walk, only the given paths for a
+/// targeted scan - because it is only ever bumped for an entry in `current`.
+#[allow(clippy::too_many_arguments)]
+async fn classify_and_parse(
+    name: &str,
+    root: &Path,
+    stamps: HashMap<String, FileStamp>,
+    current: HashMap<String, Scanned>,
+    deleted_paths: Vec<String>,
+    chunk_params: &ChunkParams,
+    started: Instant,
+) -> DomainScan {
     // Prefilter: unchanged files (same mtime and size) are skipped entirely.
     let mut report = SyncReport {
         domain: name.to_string(),
@@ -246,12 +393,6 @@ pub async fn scan_domain(
     // Hash (and read) the survivors off-thread with bounded concurrency.
     let hashed = hash_files(to_hash, &mut report).await;
 
-    // Deleted candidates: recorded files no longer present on disk.
-    let deleted_paths: Vec<String> = stamps
-        .keys()
-        .filter(|p| !current.contains_key(*p))
-        .cloned()
-        .collect();
     // Index deleted files by checksum for move detection.
     let mut deleted_by_hash: HashMap<String, Vec<String>> = HashMap::new();
     for p in &deleted_paths {
@@ -262,8 +403,7 @@ pub async fn scan_domain(
                 .push(p.clone());
         }
     }
-    let mut deleted_remaining: std::collections::HashSet<String> =
-        deleted_paths.iter().cloned().collect();
+    let mut deleted_remaining: HashSet<String> = deleted_paths.iter().cloned().collect();
 
     // Classify each hashed file. The bool records whether the engram was
     // already indexed, so the apply phase can tell added from updated.

--- a/crates/index/src/sync.rs
+++ b/crates/index/src/sync.rs
@@ -10,6 +10,31 @@
 //!
 //! Hashing and parsing run off-thread with bounded concurrency; all database
 //! writes stay on the calling task and commit together.
+//!
+//! # Two phases, so the store lock only covers database work
+//!
+//! A sync is two phases: [`scan_domain`] is pure filesystem and CPU (walk, hash,
+//! parse, chunk) and takes the stamp snapshot as input rather than reading the
+//! store, so a caller runs it with no store lock held; [`apply_scan`] is the
+//! transactional apply and touches the store only. [`sync_domain_with`] composes
+//! the two for callers that do not manage the lock. Splitting them keeps the
+//! store mutex off the long walk-hash-parse pass of a large domain.
+//!
+//! # Convergence under a concurrent writer
+//!
+//! Between the snapshot and the apply another writer (an MCP edit or a second
+//! instance in collaboration mode) can change both the index and the files.
+//! [`apply_scan`] re-reads the live stamps inside its transaction and skips any
+//! classified change whose live db stamp no longer matches the snapshot it was
+//! classified against (a delete additionally skips when its file reappeared on
+//! disk), counting each skip in [`SyncReport::deferred`]. Every skip is safe
+//! because it leaves the system in a state a later pass reconciles: a skip on a
+//! changed db stamp leaves an index state newer than the scan, and a skip on a
+//! reappeared file leaves a watcher event already queued for that write. In both
+//! cases the next sync sees the divergence through the stamp prefilter. No skip
+//! can wedge permanently, because a stamp only changes when content changes, so
+//! the prefilter keeps re-selecting a diverged path until an uncontended pass
+//! applies it.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -23,7 +48,7 @@ use walkdir::WalkDir;
 
 use crate::embed::{ChunkParams, chunk_engram};
 use crate::error::{IndexError, Result};
-use crate::store::{EngramRecord, FileStamp, NewChunk, Store};
+use crate::store::{DomainId, EngramRecord, FileStamp, NewChunk, Store};
 
 /// Maximum concurrent hashing or parsing tasks.
 const CONCURRENCY: usize = 8;
@@ -43,6 +68,11 @@ pub struct SyncReport {
     pub moved: usize,
     /// Files unchanged since the last sync.
     pub unchanged: usize,
+    /// Classified changes the apply skipped because a concurrent writer moved
+    /// the db stamp (or recreated the file) between the snapshot and the apply.
+    /// A later pass reconciles each one, so a non-zero count marks a busy system,
+    /// not a failure.
+    pub deferred: usize,
     /// Files that could not be read, parsed or upserted, with the reason.
     pub failed: Vec<(String, String)>,
     /// Forward references resolved at the end of this sync.
@@ -90,7 +120,6 @@ pub async fn sync_domain_with<S: Store + ?Sized>(
     root: &Path,
     chunk_params: &ChunkParams,
 ) -> Result<SyncReport> {
-    let started = Instant::now();
     let domain = store
         .upsert_domain(
             name,
@@ -98,7 +127,53 @@ pub async fn sync_domain_with<S: Store + ?Sized>(
             crate::store::DomainKind::File,
         )
         .await?;
-    let existing = store.file_stamps(domain).await?;
+    let stamps = store.file_stamps(domain).await?;
+    let scan = scan_domain(name, root, stamps, chunk_params).await;
+    apply_scan(store, domain, scan).await
+}
+
+/// The filesystem side of a sync, ready to apply against a store.
+///
+/// [`scan_domain`] produces this with no store access at all. It carries the
+/// classified moves, deletes and parsed-with-chunks changes, the stamp snapshot
+/// they were classified against (so the apply can detect a concurrent writer),
+/// the walk root (so a delete can re-stat its file) and the partial report
+/// (`unchanged` and `failed` counts). [`apply_scan`] consumes it inside one
+/// transaction and fills in the remaining report fields.
+pub struct DomainScan {
+    /// Renames: `(from, to)`, identical content moved to a new path in place.
+    moves: Vec<(String, String)>,
+    /// Recorded paths whose file vanished from disk, to delete from the index.
+    deletes: std::collections::HashSet<String>,
+    /// Parsed new and modified engrams with their chunks computed off-thread.
+    parsed: Vec<Parsed>,
+    /// The stamp snapshot the scan classified against, keyed by relative path.
+    /// The apply compares the live db stamps against these to spot a concurrent
+    /// write and defer the stale change.
+    snapshot: HashMap<String, FileStamp>,
+    /// The walk root, so the apply can re-stat a delete candidate on disk.
+    root: PathBuf,
+    /// `unchanged` and `failed` from the scan; the apply fills in the rest.
+    report: SyncReport,
+    /// When the scan began, so the apply can report the total duration.
+    started: Instant,
+}
+
+/// Scan one domain against a stamp snapshot: walk, prefilter, hash, classify and
+/// parse, with no store access at all.
+///
+/// `stamps` is the recorded [`FileStamp`] per relative path the caller read from
+/// the store before releasing its lock; the scan classifies every file against
+/// it and hands it back inside the [`DomainScan`] so the apply can re-check it.
+/// The walk, hash and parse phases run off-thread and never fail fatally: a file
+/// that cannot be read or parsed lands in `report.failed`, not an error.
+pub async fn scan_domain(
+    name: &str,
+    root: &Path,
+    stamps: HashMap<String, FileStamp>,
+    chunk_params: &ChunkParams,
+) -> DomainScan {
+    let started = Instant::now();
 
     // Folders the MANIFEST provisions from inside this root hold deployable
     // artifacts, not engrams, so they are pruned from the walk. Empty whenever
@@ -155,7 +230,7 @@ pub async fn sync_domain_with<S: Store + ?Sized>(
     };
     let mut to_hash: Vec<Scanned> = Vec::new();
     for (rel, scanned) in &current {
-        match existing.get(rel) {
+        match stamps.get(rel) {
             Some(stamp) if stamp.mtime == scanned.mtime && stamp.size == scanned.size => {
                 report.unchanged += 1;
             }
@@ -172,7 +247,7 @@ pub async fn sync_domain_with<S: Store + ?Sized>(
     let hashed = hash_files(to_hash, &mut report).await;
 
     // Deleted candidates: recorded files no longer present on disk.
-    let deleted_paths: Vec<String> = existing
+    let deleted_paths: Vec<String> = stamps
         .keys()
         .filter(|p| !current.contains_key(*p))
         .cloned()
@@ -180,7 +255,7 @@ pub async fn sync_domain_with<S: Store + ?Sized>(
     // Index deleted files by checksum for move detection.
     let mut deleted_by_hash: HashMap<String, Vec<String>> = HashMap::new();
     for p in &deleted_paths {
-        if let Some(stamp) = existing.get(p) {
+        if let Some(stamp) = stamps.get(p) {
             deleted_by_hash
                 .entry(stamp.sha256.clone())
                 .or_default()
@@ -195,7 +270,7 @@ pub async fn sync_domain_with<S: Store + ?Sized>(
     let mut moves: Vec<(String, String)> = Vec::new();
     let mut changed: Vec<(Scanned, Hashed, bool)> = Vec::new();
     for (scanned, hashed) in hashed {
-        let is_new = !existing.contains_key(&scanned.rel);
+        let is_new = !stamps.contains_key(&scanned.rel);
         if is_new {
             // A new file whose checksum matches a vanished file is a move.
             if let Some(candidates) = deleted_by_hash.get_mut(&hashed.sha256)
@@ -210,7 +285,7 @@ pub async fn sync_domain_with<S: Store + ?Sized>(
             }
             changed.push((scanned, hashed, false));
         } else {
-            let stamp = existing.get(&scanned.rel);
+            let stamp = stamps.get(&scanned.rel);
             let same = stamp.map(|s| s.sha256 == hashed.sha256).unwrap_or(false);
             if same {
                 // Touched but identical content: nothing to reindex.
@@ -226,17 +301,58 @@ pub async fn sync_domain_with<S: Store + ?Sized>(
     // failures and parse failures are reported, not fatal.
     let parsed = parse_files(changed, chunk_params, &mut report).await;
 
-    // Apply everything in one transaction. Duplicate-permalink upserts are
-    // collected in `failed` and do not abort the batch (they are pre-checked so
-    // no failing statement runs). Other errors roll the batch back.
+    DomainScan {
+        moves,
+        deletes: deleted_remaining,
+        parsed,
+        snapshot: stamps,
+        root: root.to_path_buf(),
+        report,
+        started,
+    }
+}
+
+/// Apply a [`DomainScan`] to the store in one transaction: moves, deletes,
+/// upserts with their chunks, forward-reference resolution and the sync stamp.
+///
+/// The whole batch commits together. Duplicate-permalink upserts are collected in
+/// `failed` and do not abort the batch (they are pre-checked so no failing
+/// statement runs); any other error rolls the batch back.
+///
+/// A concurrent writer can move the index between the scan's snapshot and this
+/// apply. The apply re-reads the live stamps once, inside the transaction, and
+/// defers any classified change whose live db stamp no longer matches the
+/// snapshot it was classified against - see the module-level convergence note.
+pub async fn apply_scan<S: Store + ?Sized>(
+    store: &S,
+    domain: DomainId,
+    scan: DomainScan,
+) -> Result<SyncReport> {
+    let DomainScan {
+        moves,
+        deletes,
+        parsed,
+        snapshot,
+        root,
+        mut report,
+        started,
+    } = scan;
+
     store.begin().await?;
-    let apply = apply_changes(store, domain, moves, deleted_remaining, parsed, &mut report).await;
-    match apply {
-        Ok(()) => {}
-        Err(e) => {
-            let _ = store.rollback().await;
-            return Err(e);
-        }
+    let apply = apply_changes(
+        store,
+        domain,
+        moves,
+        deletes,
+        parsed,
+        &snapshot,
+        &root,
+        &mut report,
+    )
+    .await;
+    if let Err(e) = apply {
+        let _ = store.rollback().await;
+        return Err(e);
     }
 
     let resolved = match store.resolve_pending_relations(domain).await {
@@ -259,23 +375,66 @@ pub async fn sync_domain_with<S: Store + ?Sized>(
     Ok(report)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn apply_changes<S: Store + ?Sized>(
     store: &S,
-    domain: crate::store::DomainId,
+    domain: DomainId,
     moves: Vec<(String, String)>,
-    deleted: std::collections::HashSet<String>,
+    deletes: std::collections::HashSet<String>,
     parsed: Vec<Parsed>,
+    snapshot: &HashMap<String, FileStamp>,
+    root: &Path,
     report: &mut SyncReport,
 ) -> Result<()> {
+    // The live stamps guard against a writer that moved the index between the
+    // scan's snapshot and now. Read them once, inside the transaction and only
+    // when there is something to apply, so the warm no-change pass adds no query.
+    let live = if moves.is_empty() && deletes.is_empty() && parsed.is_empty() {
+        HashMap::new()
+    } else {
+        store.file_stamps(domain).await?
+    };
+
     for (from, to) in moves {
+        // A move is a delete of `from` plus an add of `to`; if either end's db
+        // stamp moved since the snapshot the classification is stale, so leave
+        // both ends for the next pass rather than renaming over a fresh write.
+        if live.get(&from) != snapshot.get(&from) || live.get(&to) != snapshot.get(&to) {
+            report.deferred += 1;
+            tracing::debug!(from = %from, to = %to, "sync: deferring a move whose db stamp moved mid-scan");
+            continue;
+        }
         store.rename_engram(domain, &from, &to).await?;
         report.moved += 1;
     }
-    for path in deleted {
+    for path in deletes {
+        // The row was rewritten mid-scan: someone indexed newer state at this
+        // path, so dropping it would discard their write.
+        if live.get(&path) != snapshot.get(&path) {
+            report.deferred += 1;
+            tracing::debug!(path = %path, "sync: deferring a delete whose db stamp moved mid-scan");
+            continue;
+        }
+        // The file vanished during the scan but is back on disk now; the watcher
+        // event for that recreation is already queued, so leave the row for it.
+        if root.join(&path).exists() {
+            report.deferred += 1;
+            tracing::debug!(path = %path, "sync: deferring a delete whose file reappeared on disk");
+            continue;
+        }
         store.delete_engram(domain, &path).await?;
         report.deleted += 1;
     }
     for p in parsed {
+        // The db stamp for this path moved since the snapshot: a concurrent
+        // writer indexed newer state, so the parsed content is stale. Applying it
+        // would clobber the newer state, so defer and let the next pass reconcile.
+        let path = p.record.path.as_str();
+        if live.get(path) != snapshot.get(path) {
+            report.deferred += 1;
+            tracing::debug!(path = %path, "sync: deferring a change whose db stamp moved mid-scan");
+            continue;
+        }
         let existed = p.previously_indexed;
         match store.upsert_engram(domain, &p.record).await {
             Ok(id) => {

--- a/crates/index/tests/perf.rs
+++ b/crates/index/tests/perf.rs
@@ -7,7 +7,9 @@
 
 use std::path::Path;
 
-use crystalline_index::{TursoStore, sync_domain};
+use crystalline_index::{
+    ChunkParams, DomainKind, Store, TursoStore, apply_scan, scan_paths, sync_domain,
+};
 
 fn write(dir: &Path, rel: &str, content: &str) {
     let path = dir.join(rel);
@@ -63,5 +65,94 @@ async fn thousand_engram_warm_sync_under_two_seconds() {
     assert!(
         warm_ms < 2000,
         "warm sync must be under 2s, was {warm_ms} ms"
+    );
+}
+
+fn synthetic(i: usize, body: &str) -> String {
+    format!(
+        "---\ntype: engram\ntitle: Engram {i}\npermalink: engram-{i}\ntags:\n  - synthetic\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# Engram {i}\n\n{body}\n"
+    )
+}
+
+/// The relative path engram `i` is seeded at in the 5k corpus.
+fn corpus_rel(i: usize) -> String {
+    format!("dir{}/engram_{i}.md", i % 50)
+}
+
+/// Perf evidence for the path-targeted watcher pass: a one-file targeted sync
+/// versus a full warm sync over a 5000-file domain. Not asserted (numbers vary
+/// by machine), just recorded. Run with
+/// `cargo test -p crystalline-index --test perf --release -- --ignored --nocapture`.
+#[tokio::test]
+#[ignore = "perf evidence: run manually with --ignored --nocapture"]
+async fn targeted_one_file_versus_full_warm_sync_at_5k() {
+    let corpus = tempfile::tempdir().unwrap();
+    let root = corpus.path();
+    const N: usize = 5000;
+    for i in 0..N {
+        write(
+            root,
+            &corpus_rel(i),
+            &synthetic(
+                i,
+                &format!("Body text for engram {i} with searchable words."),
+            ),
+        );
+    }
+
+    let db_dir = tempfile::tempdir().unwrap();
+    let store = TursoStore::open(&db_dir.path().join("index.db"))
+        .await
+        .unwrap();
+
+    let cold = std::time::Instant::now();
+    let report = sync_domain(&store, "big", root).await.unwrap();
+    let cold_ms = cold.elapsed().as_millis();
+    assert_eq!(report.added, N, "all engrams indexed");
+
+    let domain = store
+        .upsert_domain("big", Some(&root.to_string_lossy()), DomainKind::File)
+        .await
+        .unwrap();
+
+    // Apples to apples: both routes apply exactly one edit, so the only
+    // difference is how they find it - a full walk of all 5000 files versus a
+    // single stat of the one dirty path. Editing one file and running a FULL
+    // sync is what the watcher does today for a one-file change.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    let file_a = corpus_rel(7);
+    write(root, &file_a, &synthetic(7, "Edit A body."));
+    let full = std::time::Instant::now();
+    let full_report = sync_domain(&store, "big", root).await.unwrap();
+    let full_us = full.elapsed().as_micros();
+    assert_eq!(full_report.updated, 1, "full sync applied the one edit");
+    assert_eq!(full_report.unchanged, N - 1, "full sync walked all 5000");
+
+    // Edit a second file and run a TARGETED sync of just its path - the
+    // walk-free route the watcher now takes for a small debounce batch.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    let file_b = corpus_rel(11);
+    write(root, &file_b, &synthetic(11, "Edit B body."));
+    let targeted = std::time::Instant::now();
+    let snapshot = store.file_stamps(domain).await.unwrap();
+    let scan = scan_paths(
+        "big",
+        root,
+        snapshot,
+        vec![file_b.clone()],
+        &ChunkParams::default(),
+    )
+    .await;
+    let treport = apply_scan(&store, domain, scan).await.unwrap();
+    let targeted_us = targeted.elapsed().as_micros();
+    assert_eq!(treport.updated, 1, "the one edited file reindexed");
+    assert_eq!(
+        treport.unchanged, 0,
+        "the other 4999 files were never visited"
+    );
+
+    eprintln!(
+        "PERF 5k engrams, one-file edit: cold sync {cold_ms} ms | full sync {full_us} us | targeted pass {targeted_us} us | speedup {:.1}x",
+        full_us as f64 / targeted_us.max(1) as f64
     );
 }

--- a/crates/index/tests/sync_phases.rs
+++ b/crates/index/tests/sync_phases.rs
@@ -1,0 +1,344 @@
+//! The lock-phased sync: `scan_domain` (filesystem, no store) then `apply_scan`
+//! (transactional, store only), and the TOCTOU guards that make a concurrent
+//! writer between the two deterministic to test without timing games.
+//!
+//! The guard tests drive the two phases by hand: snapshot the stamps, scan,
+//! mutate the store as a stand-in for a concurrent writer (an MCP edit or a
+//! second collaboration-mode instance), then apply. Every guard test asserts the
+//! stale change is deferred, the concurrent state survives and the next full sync
+//! converges. Every body is a pure function of a `&dyn Store` so it runs on both
+//! backends; Turso (in-memory) always runs, Postgres runs when
+//! `CRYSTALLINE_TEST_POSTGRES_URL` is set.
+
+use std::path::Path;
+
+use crystalline_index::{
+    ChunkParams, DomainKind, EngramRecord, FileStamp, SearchQuery, Store, TursoStore, apply_scan,
+    scan_domain, sync_domain_with,
+};
+
+fn write(dir: &Path, rel: &str, content: &str) {
+    let path = dir.join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, content).unwrap();
+}
+
+/// A minimal engram markdown block with a searchable body token.
+fn engram(title: &str, permalink: &str, body: &str) -> String {
+    format!(
+        "---\ntype: engram\ntitle: {title}\npermalink: {permalink}\ntags:\n  - t\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# {title}\n\n{body}\n"
+    )
+}
+
+/// A minimal engram record with explicit content and checksum, built without
+/// parsing so a test can write it straight through the store as a stand-in for a
+/// concurrent writer. `sha` becomes the stamp checksum, so passing a fresh value
+/// moves the db stamp exactly as a real mid-scan write would.
+fn record(path: &str, permalink: &str, content: &str, sha: &str) -> EngramRecord {
+    EngramRecord {
+        path: path.to_string(),
+        permalink: permalink.to_string(),
+        title: "Title".to_string(),
+        engram_type: "engram".to_string(),
+        status: "current".to_string(),
+        recorded_at: Some("2026-01-01".to_string()),
+        valid_from: None,
+        valid_to: None,
+        timestamp: None,
+        description: None,
+        content: content.to_string(),
+        metadata: serde_json::json!({}),
+        tags: Vec::new(),
+        observations: Vec::new(),
+        relations: Vec::new(),
+        links: Vec::new(),
+        stamp: FileStamp {
+            mtime: 0,
+            size: content.len() as u64,
+            sha256: sha.to_string(),
+        },
+    }
+}
+
+// --- backend runner ----------------------------------------------------------
+
+#[cfg(feature = "postgres")]
+fn pg_url() -> Option<String> {
+    use std::sync::Once;
+    static NOTE: Once = Once::new();
+    match std::env::var("CRYSTALLINE_TEST_POSTGRES_URL") {
+        Ok(u) if !u.is_empty() => Some(u),
+        _ => {
+            NOTE.call_once(|| {
+                eprintln!(
+                    "note: skipping the postgres parity leg (CRYSTALLINE_TEST_POSTGRES_URL is unset); turso only"
+                )
+            });
+            None
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn unique_schema() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("cp_{}_{}", std::process::id(), n)
+}
+
+/// Run a parity body against Turso (always) and Postgres (when configured).
+macro_rules! parity {
+    ($name:ident, $body:path) => {
+        #[tokio::test]
+        async fn $name() {
+            {
+                let store = TursoStore::open_in_memory().await.unwrap();
+                $body(&store).await;
+            }
+            #[cfg(feature = "postgres")]
+            {
+                if let Some(url) = pg_url() {
+                    let schema = unique_schema();
+                    let store = crystalline_index::PostgresStore::open_in_schema(&url, &schema)
+                        .await
+                        .expect("open the postgres test schema");
+                    $body(&store).await;
+                    store
+                        .drop_schema()
+                        .await
+                        .expect("drop the postgres test schema");
+                }
+            }
+        }
+    };
+}
+
+fn params() -> ChunkParams {
+    ChunkParams::default()
+}
+
+async fn upsert_domain(store: &dyn Store, name: &str, root: &Path) -> crystalline_index::DomainId {
+    store
+        .upsert_domain(name, Some(&root.to_string_lossy()), DomainKind::File)
+        .await
+        .unwrap()
+}
+
+// --- parity bodies -----------------------------------------------------------
+
+/// A change the scan classified against a stale snapshot is deferred when a
+/// concurrent writer indexed the same path first; the concurrent content wins
+/// and the next full sync brings the file on disk back.
+async fn concurrent_write_defers(store: &dyn Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // A file on disk the scan classifies as new against the empty snapshot.
+    write(root, "a.md", &engram("A", "a", "diskwins body"));
+
+    let domain = upsert_domain(store, "d", root).await;
+    let snapshot = store.file_stamps(domain).await.unwrap();
+    assert!(snapshot.is_empty(), "nothing indexed yet");
+    let scan = scan_domain("d", root, snapshot, &params()).await;
+
+    // A concurrent writer indexes the same path with different content between
+    // the snapshot and the apply.
+    store
+        .upsert_engram(
+            domain,
+            &record("a.md", "a", "concurrentwins body", "sha-conc"),
+        )
+        .await
+        .unwrap();
+
+    let report = apply_scan(store, domain, scan).await.unwrap();
+    assert_eq!(report.deferred, 1, "the stale add was deferred: {report:?}");
+    assert_eq!(report.added, 0, "the stale add did not land");
+
+    // The concurrent writer's content survives; the scan's stale content did not
+    // overwrite it.
+    let live = store
+        .search(&SearchQuery::text("concurrentwins"))
+        .await
+        .unwrap();
+    assert_eq!(live.total, 1, "the concurrent write survives");
+    let stale = store.search(&SearchQuery::text("diskwins")).await.unwrap();
+    assert_eq!(stale.total, 0, "the scan's stale content did not land");
+
+    // The next full sync converges: the file on disk wins again.
+    let converge = sync_domain_with(store, "d", root, &params()).await.unwrap();
+    assert_eq!(converge.deferred, 0, "the converging pass is uncontended");
+    let now = store.search(&SearchQuery::text("diskwins")).await.unwrap();
+    assert_eq!(now.total, 1, "the file on disk wins on the next pass");
+}
+parity!(
+    concurrent_write_defers_the_stale_scan_result,
+    concurrent_write_defers
+);
+
+/// A delete the scan classified is skipped when the row was rewritten in the db
+/// between the snapshot and the apply.
+async fn concurrent_rewrite_skips_delete(store: &dyn Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(root, "a.md", &engram("A", "a", "original body"));
+    sync_domain_with(store, "d", root, &params()).await.unwrap();
+    let domain = upsert_domain(store, "d", root).await;
+
+    // The file vanishes from disk, so a scan classifies it as a delete.
+    std::fs::remove_file(root.join("a.md")).unwrap();
+    let snapshot = store.file_stamps(domain).await.unwrap();
+    assert!(snapshot.contains_key("a.md"), "a.md still recorded");
+    let scan = scan_domain("d", root, snapshot, &params()).await;
+
+    // A concurrent writer rewrites the row (a new stamp) mid-window.
+    store
+        .upsert_engram(domain, &record("a.md", "a", "rewrittenrow body", "sha-new"))
+        .await
+        .unwrap();
+
+    let report = apply_scan(store, domain, scan).await.unwrap();
+    assert_eq!(
+        report.deferred, 1,
+        "the stale delete was deferred: {report:?}"
+    );
+    assert_eq!(report.deleted, 0, "the row was not deleted");
+    let live = store
+        .search(&SearchQuery::text("rewrittenrow"))
+        .await
+        .unwrap();
+    assert_eq!(live.total, 1, "the rewritten row survives");
+}
+parity!(
+    concurrent_rewrite_skips_the_scan_delete,
+    concurrent_rewrite_skips_delete
+);
+
+/// A delete the scan classified is skipped when the file reappeared on disk
+/// before the apply, even though the db stamp never moved: the disk-side guard.
+async fn recreated_file_skips_delete(store: &dyn Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(root, "a.md", &engram("A", "a", "recreated body"));
+    sync_domain_with(store, "d", root, &params()).await.unwrap();
+    let domain = upsert_domain(store, "d", root).await;
+
+    // The file vanishes, the scan classifies the delete, then it reappears on
+    // disk before the apply. The db is never touched, so only the disk re-stat
+    // can catch this.
+    std::fs::remove_file(root.join("a.md")).unwrap();
+    let snapshot = store.file_stamps(domain).await.unwrap();
+    let scan = scan_domain("d", root, snapshot, &params()).await;
+    write(root, "a.md", &engram("A", "a", "recreated body"));
+
+    let report = apply_scan(store, domain, scan).await.unwrap();
+    assert_eq!(
+        report.deferred, 1,
+        "the delete was deferred because the file reappeared: {report:?}"
+    );
+    assert_eq!(report.deleted, 0, "the row was not deleted");
+    let live = store.search(&SearchQuery::text("recreated")).await.unwrap();
+    assert_eq!(live.total, 1, "the row survives the reappearance");
+}
+parity!(
+    recreated_file_on_disk_skips_the_delete,
+    recreated_file_skips_delete
+);
+
+/// A move the scan classified is skipped when either end's db stamp moved
+/// mid-window; both ends are left for the next pass, which converges.
+async fn move_with_moved_end_defers(store: &dyn Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(root, "old.md", &engram("Mover", "mover", "moveme body"));
+    sync_domain_with(store, "d", root, &params()).await.unwrap();
+    let domain = upsert_domain(store, "d", root).await;
+
+    // Rename on disk: identical bytes at a new path, so the scan classifies a
+    // move.
+    std::fs::rename(root.join("old.md"), root.join("new.md")).unwrap();
+    let snapshot = store.file_stamps(domain).await.unwrap();
+    let scan = scan_domain("d", root, snapshot, &params()).await;
+
+    // A concurrent writer mutates the move's `from` end mid-window.
+    store
+        .upsert_engram(
+            domain,
+            &record("old.md", "mover", "mutatedend body", "sha-mut"),
+        )
+        .await
+        .unwrap();
+
+    let report = apply_scan(store, domain, scan).await.unwrap();
+    assert_eq!(report.deferred, 1, "the move was deferred: {report:?}");
+    assert_eq!(report.moved, 0, "the move did not land");
+
+    // The next full sync converges on the file on disk: the original content is
+    // present once, the concurrent mutation is gone and only one engram remains.
+    let converge = sync_domain_with(store, "d", root, &params()).await.unwrap();
+    assert_eq!(converge.deferred, 0, "the converging pass is uncontended");
+    assert!(
+        store.lookup_id("d", "mover").await.unwrap().is_some(),
+        "the engram survives under its permalink"
+    );
+    let moved = store.search(&SearchQuery::text("moveme")).await.unwrap();
+    assert_eq!(moved.total, 1, "the moved content is present once");
+    let stale = store
+        .search(&SearchQuery::text("mutatedend"))
+        .await
+        .unwrap();
+    assert_eq!(stale.total, 0, "the stale concurrent mutation is gone");
+    assert_eq!(
+        store.domain_stats().await.unwrap()[0].engrams,
+        1,
+        "exactly one engram after convergence"
+    );
+}
+parity!(
+    move_with_a_moved_end_is_deferred,
+    move_with_moved_end_defers
+);
+
+/// The composition path defers nothing when uncontended: a fresh add, a warm
+/// no-change pass, an edit, a delete and a move each report their usual counts
+/// with `deferred == 0`.
+async fn composition_identical_uncontended(store: &dyn Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(root, "a.md", &engram("A", "a", "alpha body"));
+    write(root, "b.md", &engram("B", "b", "beta body"));
+
+    let added = sync_domain_with(store, "d", root, &params()).await.unwrap();
+    assert_eq!(added.added, 2);
+    assert_eq!(added.deferred, 0);
+
+    let warm = sync_domain_with(store, "d", root, &params()).await.unwrap();
+    assert_eq!(warm.unchanged, 2);
+    assert_eq!(warm.added, 0);
+    assert_eq!(warm.deferred, 0);
+
+    // Edit a.md; bump the mtime past the prefilter.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    write(root, "a.md", &engram("A", "a", "revised body"));
+    let edited = sync_domain_with(store, "d", root, &params()).await.unwrap();
+    assert_eq!(edited.updated, 1);
+    assert_eq!(edited.deferred, 0);
+
+    // Delete b.md.
+    std::fs::remove_file(root.join("b.md")).unwrap();
+    let deleted = sync_domain_with(store, "d", root, &params()).await.unwrap();
+    assert_eq!(deleted.deleted, 1);
+    assert_eq!(deleted.deferred, 0);
+
+    // Move a.md to c.md.
+    std::fs::rename(root.join("a.md"), root.join("c.md")).unwrap();
+    let moved = sync_domain_with(store, "d", root, &params()).await.unwrap();
+    assert_eq!(moved.moved, 1);
+    assert_eq!(moved.deferred, 0);
+}
+parity!(
+    the_composition_is_identical_when_uncontended,
+    composition_identical_uncontended
+);

--- a/crates/index/tests/sync_targeted.rs
+++ b/crates/index/tests/sync_targeted.rs
@@ -1,0 +1,316 @@
+//! The path-targeted scan: `scan_paths` classifies exactly the given relative
+//! paths against a stamp snapshot, with no walk anywhere, then applies through
+//! the same `apply_scan` the full scan uses.
+//!
+//! These pin the scoping guarantee the watcher relies on: a one-file edit in an
+//! N-file domain touches exactly that file, the other N-1 rows are never even
+//! visited (so `report.unchanged` counts only the given paths, never the whole
+//! domain) and stay byte-for-byte in the index after the apply. Every body is a
+//! pure function of a `&dyn Store` so it runs on both backends; Turso
+//! (in-memory) always runs, Postgres runs when `CRYSTALLINE_TEST_POSTGRES_URL`
+//! is set.
+
+use std::path::Path;
+
+use crystalline_index::{
+    ChunkParams, DomainKind, SearchQuery, Store, TursoStore, apply_scan, scan_paths,
+    sync_domain_with,
+};
+
+fn write(dir: &Path, rel: &str, content: &str) {
+    let path = dir.join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, content).unwrap();
+}
+
+/// A minimal engram markdown block with a searchable body token.
+fn engram(title: &str, permalink: &str, body: &str) -> String {
+    format!(
+        "---\ntype: engram\ntitle: {title}\npermalink: {permalink}\ntags:\n  - t\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# {title}\n\n{body}\n"
+    )
+}
+
+#[cfg(feature = "postgres")]
+fn pg_url() -> Option<String> {
+    use std::sync::Once;
+    static NOTE: Once = Once::new();
+    match std::env::var("CRYSTALLINE_TEST_POSTGRES_URL") {
+        Ok(u) if !u.is_empty() => Some(u),
+        _ => {
+            NOTE.call_once(|| {
+                eprintln!(
+                    "note: skipping the postgres parity leg (CRYSTALLINE_TEST_POSTGRES_URL is unset); turso only"
+                )
+            });
+            None
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+fn unique_schema() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("ct_{}_{}", std::process::id(), n)
+}
+
+/// Run a parity body against Turso (always) and Postgres (when configured).
+macro_rules! parity {
+    ($name:ident, $body:path) => {
+        #[tokio::test]
+        async fn $name() {
+            {
+                let store = TursoStore::open_in_memory().await.unwrap();
+                $body(&store).await;
+            }
+            #[cfg(feature = "postgres")]
+            {
+                if let Some(url) = pg_url() {
+                    let schema = unique_schema();
+                    let store = crystalline_index::PostgresStore::open_in_schema(&url, &schema)
+                        .await
+                        .expect("open the postgres test schema");
+                    $body(&store).await;
+                    store
+                        .drop_schema()
+                        .await
+                        .expect("drop the postgres test schema");
+                }
+            }
+        }
+    };
+}
+
+fn params() -> ChunkParams {
+    ChunkParams::default()
+}
+
+async fn upsert_domain(store: &dyn Store, name: &str, root: &Path) -> crystalline_index::DomainId {
+    store
+        .upsert_domain(name, Some(&root.to_string_lossy()), DomainKind::File)
+        .await
+        .unwrap()
+}
+
+/// Seed `n` engrams `f0.md..f{n-1}.md` on disk and in the index, returning the
+/// tempdir so the caller keeps the files alive.
+async fn seed(store: &dyn Store, n: usize) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    for i in 0..n {
+        write(
+            dir.path(),
+            &format!("f{i}.md"),
+            &engram(
+                &format!("F{i}"),
+                &format!("f{i}"),
+                &format!("body{i} token"),
+            ),
+        );
+    }
+    let report = sync_domain_with(store, "d", dir.path(), &params())
+        .await
+        .unwrap();
+    assert_eq!(report.added, n, "seed indexed every file");
+    dir
+}
+
+/// Run one targeted pass over `paths` and return the report.
+async fn target(store: &dyn Store, root: &Path, paths: &[&str]) -> crystalline_index::SyncReport {
+    let domain = upsert_domain(store, "d", root).await;
+    let snapshot = store.file_stamps(domain).await.unwrap();
+    let scan = scan_paths(
+        "d",
+        root,
+        snapshot,
+        paths.iter().map(|s| s.to_string()).collect(),
+        &params(),
+    )
+    .await;
+    apply_scan(store, domain, scan).await.unwrap()
+}
+
+// --- parity bodies -----------------------------------------------------------
+
+/// Editing one of N files and targeting just that path reindexes exactly it: the
+/// other N-1 are never visited, so `unchanged` is 0, not N-1, and every other row
+/// survives untouched in the index.
+async fn edit_one_of_many_touches_only_it(store: &dyn Store) {
+    let dir = seed(store, 5).await;
+    let root = dir.path();
+
+    // Edit f2.md; bump the mtime past the prefilter.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    write(root, "f2.md", &engram("F2", "f2", "revised token"));
+
+    let report = target(store, root, &["f2.md"]).await;
+    assert_eq!(report.updated, 1, "exactly the edited file reindexed");
+    assert_eq!(report.added, 0);
+    assert_eq!(report.deleted, 0);
+    assert_eq!(report.moved, 0);
+    // The walk-free marker: a full scan would report unchanged == 4 here; the
+    // targeted scan visited only the one given path, so it reports 0.
+    assert_eq!(
+        report.unchanged, 0,
+        "unchanged counts only the given paths, never the unvisited N-1"
+    );
+
+    // The edit landed and the other four rows are intact.
+    let revised = store.search(&SearchQuery::text("revised")).await.unwrap();
+    assert_eq!(revised.total, 1, "the edit is in the index");
+    for i in [0usize, 1, 3, 4] {
+        let hit = store
+            .search(&SearchQuery::text(&format!("body{i}")))
+            .await
+            .unwrap();
+        assert_eq!(hit.total, 1, "the untouched f{i}.md row survives verbatim");
+    }
+    assert_eq!(
+        store.domain_stats().await.unwrap()[0].engrams,
+        5,
+        "still exactly five engrams"
+    );
+}
+parity!(
+    editing_one_of_many_targets_only_that_file,
+    edit_one_of_many_touches_only_it
+);
+
+/// Targeting an unchanged path counts it as unchanged - proving `unchanged` does
+/// count a given path, but only a given one.
+async fn unchanged_given_path_counts_one(store: &dyn Store) {
+    let dir = seed(store, 3).await;
+    let root = dir.path();
+
+    // f1.md is not edited; targeting it sees it unchanged.
+    let report = target(store, root, &["f1.md"]).await;
+    assert_eq!(
+        report.unchanged, 1,
+        "the one given unchanged path counts one"
+    );
+    assert_eq!(report.updated, 0);
+    assert_eq!(report.added, 0);
+}
+parity!(
+    an_unchanged_given_path_counts_as_one_unchanged,
+    unchanged_given_path_counts_one
+);
+
+/// A brand-new file targeted by its path is added; nothing else is walked.
+async fn add_one_targeted(store: &dyn Store) {
+    let dir = seed(store, 2).await;
+    let root = dir.path();
+
+    write(root, "new.md", &engram("New", "new", "fresh token"));
+    let report = target(store, root, &["new.md"]).await;
+    assert_eq!(report.added, 1, "the new file is added");
+    assert_eq!(report.unchanged, 0, "no other path was visited");
+    let hit = store.search(&SearchQuery::text("fresh")).await.unwrap();
+    assert_eq!(hit.total, 1, "the new engram is searchable");
+    assert_eq!(store.domain_stats().await.unwrap()[0].engrams, 3);
+}
+parity!(a_new_file_is_added_by_its_path, add_one_targeted);
+
+/// A vanished file targeted by its path is deleted; deletion detection is scoped
+/// to the given path, so the other rows are untouched.
+async fn delete_one_targeted(store: &dyn Store) {
+    let dir = seed(store, 3).await;
+    let root = dir.path();
+
+    std::fs::remove_file(root.join("f1.md")).unwrap();
+    let report = target(store, root, &["f1.md"]).await;
+    assert_eq!(report.deleted, 1, "the vanished file is deleted");
+    assert_eq!(report.unchanged, 0);
+    let gone = store.search(&SearchQuery::text("body1")).await.unwrap();
+    assert_eq!(gone.total, 0, "the deleted engram is gone");
+    assert_eq!(
+        store.domain_stats().await.unwrap()[0].engrams,
+        2,
+        "the other two survive"
+    );
+}
+parity!(a_vanished_file_is_deleted_by_its_path, delete_one_targeted);
+
+/// Both ends of a rename in one batch are classified as a move, not a delete plus
+/// an add, so the engram is renamed in place.
+async fn move_pair_in_one_batch(store: &dyn Store) {
+    let dir = seed(store, 1).await;
+    let root = dir.path();
+
+    std::fs::rename(root.join("f0.md"), root.join("moved.md")).unwrap();
+    let report = target(store, root, &["f0.md", "moved.md"]).await;
+    // moved == 1 with deleted == 0 and added == 0 is the whole point: both ends
+    // in one batch are paired as a rename in place, not a delete plus an add.
+    assert_eq!(report.moved, 1, "the rename is a move, not delete+add");
+    assert_eq!(report.deleted, 0, "no delete when both ends are given");
+    assert_eq!(report.added, 0, "no add when both ends are given");
+    // The content survived the in-place move as a single engram (a delete+add
+    // would also end at one row, but would have reported deleted == 1/added == 1
+    // above, so the counts plus this survival together pin the move).
+    let survived = store.search(&SearchQuery::text("body0")).await.unwrap();
+    assert_eq!(survived.total, 1, "the moved content survives once");
+    assert_eq!(store.domain_stats().await.unwrap()[0].engrams, 1);
+}
+parity!(a_rename_pair_in_one_batch_is_a_move, move_pair_in_one_batch);
+
+/// A path that is neither on disk nor in the stamps is a no-op: it becomes no
+/// change candidate and no delete candidate.
+async fn ghost_path_is_a_noop(store: &dyn Store) {
+    let dir = seed(store, 2).await;
+    let root = dir.path();
+
+    let report = target(store, root, &["ghost.md"]).await;
+    assert_eq!(report.added, 0);
+    assert_eq!(report.updated, 0);
+    assert_eq!(report.deleted, 0);
+    assert_eq!(report.moved, 0);
+    assert_eq!(report.unchanged, 0);
+    assert_eq!(
+        store.domain_stats().await.unwrap()[0].engrams,
+        2,
+        "the domain is untouched"
+    );
+}
+parity!(
+    a_path_neither_on_disk_nor_recorded_is_a_noop,
+    ghost_path_is_a_noop
+);
+
+/// Seeding N and targeting exactly one leaves the other N-1 rows present and
+/// byte-for-byte unmodified in the index after the apply.
+async fn outside_batch_untouched(store: &dyn Store) {
+    let dir = seed(store, 6).await;
+    let root = dir.path();
+
+    // Target one addition; assert the six seeded rows are all present before and
+    // still present and unmodified after, none rewritten.
+    for i in 0..6 {
+        let hit = store
+            .search(&SearchQuery::text(&format!("body{i}")))
+            .await
+            .unwrap();
+        assert_eq!(hit.total, 1, "f{i}.md present before the targeted add");
+    }
+
+    write(root, "seven.md", &engram("Seven", "seven", "seventh token"));
+    let report = target(store, root, &["seven.md"]).await;
+    assert_eq!(report.added, 1);
+
+    for i in 0..6 {
+        let hit = store
+            .search(&SearchQuery::text(&format!("body{i}")))
+            .await
+            .unwrap();
+        assert_eq!(
+            hit.total, 1,
+            "the outside-batch row f{i}.md is still present and unmodified"
+        );
+    }
+    assert_eq!(store.domain_stats().await.unwrap()[0].engrams, 7);
+}
+parity!(
+    rows_outside_the_targeted_batch_are_untouched,
+    outside_batch_untouched
+);

--- a/crates/service/src/daemon.rs
+++ b/crates/service/src/daemon.rs
@@ -449,6 +449,14 @@ async fn handle_conn(mut stream: IpcStream, shared: Arc<Shared>) {
     }
 }
 
+/// One item on the watcher's debounce channel: a concrete filesystem path from
+/// a notify event, or a rescan/overflow signal meaning events were dropped and
+/// every watched domain must fall back to a full rescan this flush.
+enum WatchTick {
+    Path(PathBuf),
+    Rescan,
+}
+
 /// Watch every domain root, debounce bursts by ~300ms and sync the touched
 /// domains, then schedule an embedding pass on the worker (falling back to an
 /// inline pass only if the worker channel is unwired or its receiver already
@@ -456,6 +464,16 @@ async fn handle_conn(mut stream: IpcStream, shared: Arc<Shared>) {
 /// on-disk stamp already matches
 /// any file a mutating tool just wrote, so those files are classified
 /// unchanged here.
+///
+/// A debounce flush accumulates dirty relative PATHS per domain (see
+/// [`DirtyPaths`]), not just dirty domain names: a small batch runs a
+/// path-targeted [`Engine::sync_paths`] over exactly those paths, so a one-file
+/// edit in a large domain no longer walks every entry. A batch that cannot be
+/// reduced to clean markdown paths - a rescan/overflow notice, a directory
+/// event, an ambiguous deletion or more than [`MAX_DIRTY_PATHS`] paths -
+/// escalates that domain to today's full [`Engine::sync`] rescan. That full
+/// fallback, plus the startup sync and manual `crystalline sync`, cover every
+/// watcher gap, so the targeted path only has to be convergent, never perfect.
 ///
 /// `new_roots` carries domains discovered after startup (see
 /// `Engine::domain_root`'s fresh-config fallback): a `domain add` while this
@@ -479,11 +497,17 @@ async fn run_watcher(
     mut new_roots: tokio::sync::mpsc::UnboundedReceiver<WatchEvent>,
     watches_ready: tokio::sync::oneshot::Sender<()>,
 ) -> anyhow::Result<()> {
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<PathBuf>();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<WatchTick>();
     let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
         if let Ok(event) = res {
+            // A rescan/overflow notice (an inotify IN_Q_OVERFLOW, an fsevents
+            // rescan) means events were dropped, so which paths changed is
+            // unknown: signal a full rescan rather than trust a partial stream.
+            if event.need_rescan() {
+                let _ = tx.send(WatchTick::Rescan);
+            }
             for path in event.paths {
-                let _ = tx.send(path);
+                let _ = tx.send(WatchTick::Path(path));
             }
         }
     })?;
@@ -585,19 +609,34 @@ async fn run_watcher(
             }
             first = rx.recv() => {
                 let Some(first) = first else { break };
-                let mut dirty: HashSet<String> =
-                    domains_for(&first, &domains).into_iter().collect();
-                while let Ok(Some(path)) =
+                // Accumulate dirty relative paths per domain over the debounce
+                // window, escalating a domain to a full rescan whenever a batch
+                // cannot be reduced to clean markdown paths (see DirtyPaths).
+                let mut dirty: HashMap<String, DirtyPaths> = HashMap::new();
+                accumulate_tick(&mut dirty, first, &domains);
+                while let Ok(Some(tick)) =
                     tokio::time::timeout(Duration::from_millis(300), rx.recv()).await
                 {
-                    dirty.extend(domains_for(&path, &domains));
+                    accumulate_tick(&mut dirty, tick, &domains);
                 }
-                for name in &dirty {
-                    if let Err(err) = engine.sync(Some(name)).await {
-                        tracing::warn!("watch sync of '{name}' failed: {err}");
+                let touched = !dirty.is_empty();
+                for (name, work) in dirty {
+                    // full: today's walk-based rescan; otherwise a targeted pass
+                    // over just the dirty paths. The full fallback plus the
+                    // startup and manual syncs cover any gap, so the targeted
+                    // pass only has to be convergent, never perfect.
+                    if work.full {
+                        if let Err(err) = engine.sync(Some(&name)).await {
+                            tracing::warn!("watch sync of '{name}' failed: {err}");
+                        }
+                    } else if !work.paths.is_empty() {
+                        let paths: Vec<String> = work.paths.into_iter().collect();
+                        if let Err(err) = engine.sync_paths(&name, paths).await {
+                            tracing::warn!("targeted watch sync of '{name}' failed: {err}");
+                        }
                     }
                 }
-                if !dirty.is_empty()
+                if touched
                     && !engine.request_embed()
                     && let Err(err) = engine.embed_pending().await
                 {
@@ -779,27 +818,181 @@ fn domain_roots(config: &GlobalConfig) -> Vec<(String, PathBuf)> {
         .collect()
 }
 
-/// The domain names whose root is a prefix of the event path.
+/// Cap on targeted dirty paths per domain per debounce flush before the batch
+/// escalates to a full rescan: past this many distinct paths a full walk is the
+/// cheaper way to reconcile, and the cap also bounds the memory one burst holds.
+const MAX_DIRTY_PATHS: usize = 256;
+
+/// One domain's pending watcher work for a single debounce flush: a set of dirty
+/// relative markdown paths, or `full` when the batch must fall back to a full
+/// rescan.
 ///
-/// `domains` roots are already canonical (see [`domain_roots`]), so a raw
-/// prefix match against the event path is tried first and needs no syscall.
-/// Only when that finds nothing is the event path itself canonicalized and
-/// retried, which still matches a root reached through a symlink.
-fn domains_for(path: &Path, domains: &[(String, PathBuf)]) -> Vec<String> {
-    let raw_hits: Vec<String> = domains
+/// `full` is the safety valve. The startup sync, a manual `crystalline sync` and
+/// this full fallback all cover any watcher gap, so targeted mode only has to be
+/// convergent, never perfect: anything the watcher cannot reduce to a clean
+/// markdown path escalates here rather than risk a missed or wrong targeted
+/// change. Once `full` is set the individual paths no longer matter, so they are
+/// dropped to keep the set bounded.
+#[derive(Debug, Default)]
+struct DirtyPaths {
+    paths: HashSet<String>,
+    full: bool,
+}
+
+impl DirtyPaths {
+    /// Escalate this domain to a full rescan for this flush.
+    fn mark_full(&mut self) {
+        self.full = true;
+        self.paths.clear();
+    }
+
+    /// Add one dirty relative path, escalating to a full rescan once the batch
+    /// grows past the cap.
+    fn add(&mut self, rel: String) {
+        if self.full {
+            return;
+        }
+        self.paths.insert(rel);
+        if self.paths.len() > MAX_DIRTY_PATHS {
+            self.mark_full();
+        }
+    }
+}
+
+/// How one watcher event maps onto a domain: a clean relative markdown path to
+/// target, a signal to escalate the whole domain to a full rescan, or nothing.
+enum DirtyKind {
+    /// A clean domain-relative markdown path to sync in the targeted pass.
+    Path(String),
+    /// Fall back to a full rescan of the domain (a directory event, an
+    /// unresolvable relative path or an ambiguous deletion).
+    Escalate,
+    /// Not index-relevant (a hidden path or a live non-markdown file); ignore.
+    Ignore,
+}
+
+/// Fold one debounce tick into the per-domain dirty map.
+fn accumulate_tick(
+    dirty: &mut HashMap<String, DirtyPaths>,
+    tick: WatchTick,
+    domains: &[(String, PathBuf)],
+) {
+    match tick {
+        // A dropped-event / overflow signal: which paths were lost is unknown,
+        // so reconcile every watched domain with a full rescan.
+        WatchTick::Rescan => {
+            for (name, _) in domains {
+                dirty.entry(name.clone()).or_default().mark_full();
+            }
+        }
+        WatchTick::Path(path) => {
+            for (name, kind) in classify_event(&path, domains) {
+                let entry = dirty.entry(name).or_default();
+                match kind {
+                    DirtyKind::Path(rel) => entry.add(rel),
+                    DirtyKind::Escalate => entry.mark_full(),
+                    DirtyKind::Ignore => {}
+                }
+            }
+        }
+    }
+}
+
+/// Classify one event path against the watched domains, then reduce the event to
+/// a [`DirtyKind`] per matched domain. A path under no root yields nothing.
+///
+/// `domains` roots are already canonical (see [`domain_roots`]), so a raw prefix
+/// match against the event path is tried first and needs no syscall. Only when
+/// that finds nothing is the event path itself canonicalized and retried, which
+/// still matches a root reached through a symlink.
+fn classify_event(path: &Path, domains: &[(String, PathBuf)]) -> Vec<(String, DirtyKind)> {
+    // Raw prefix match first (no syscall).
+    let raw: Vec<(String, PathBuf)> = domains
         .iter()
         .filter(|(_, root)| path.starts_with(root))
-        .map(|(name, _)| name.clone())
+        .map(|(name, root)| (name.clone(), root.clone()))
         .collect();
-    if !raw_hits.is_empty() {
-        return raw_hits;
-    }
-    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-    domains
-        .iter()
-        .filter(|(_, root)| canonical.starts_with(root))
-        .map(|(name, _)| name.clone())
+    let canonical;
+    let (match_path, hits): (&Path, Vec<(String, PathBuf)>) = if !raw.is_empty() {
+        (path, raw)
+    } else {
+        // Only when the raw check finds nothing is the event path canonicalized
+        // and retried, which still matches a root reached through a symlink.
+        canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        let hits = domains
+            .iter()
+            .filter(|(_, root)| canonical.starts_with(root))
+            .map(|(name, root)| (name.clone(), root.clone()))
+            .collect();
+        (canonical.as_path(), hits)
+    };
+    hits.into_iter()
+        .map(|(name, root)| (name, classify_in_root(match_path, &root)))
         .collect()
+}
+
+/// Reduce one event path, already known to sit under `root`, to a [`DirtyKind`].
+fn classify_in_root(path: &Path, root: &Path) -> DirtyKind {
+    // A directory event (a create, a rename, a bulk delete) can hide markdown
+    // children notify never reports individually, so fall back to a full rescan
+    // rather than guess at the children.
+    if path.is_dir() {
+        return DirtyKind::Escalate;
+    }
+    let Some(rel) = clean_rel(root, path) else {
+        // Not cleanly under this root (a `..` component or a non-UTF8 name once
+        // the prefix matched): the safe side is a full rescan.
+        return DirtyKind::Escalate;
+    };
+    // Hidden paths (dotfiles, anything under a dot-directory) are pruned by the
+    // scan walk, so they never map to an engram: ignore them, matching the walk.
+    if rel.split('/').any(is_hidden) {
+        return DirtyKind::Ignore;
+    }
+    let is_md = rel.to_lowercase().ends_with(".md");
+    if path.exists() {
+        // An existing non-markdown regular file is never indexed (directories
+        // were escalated above), so ignore it; a markdown file is a targeted
+        // candidate, resolved against the stamps by scan_paths.
+        if is_md {
+            DirtyKind::Path(rel)
+        } else {
+            DirtyKind::Ignore
+        }
+    } else if is_md {
+        // A vanished markdown file is a targeted delete candidate.
+        DirtyKind::Path(rel)
+    } else {
+        // A vanished non-markdown path is ambiguous - it may have been a
+        // directory whose markdown children notify never reported - so escalate
+        // to a full rescan, the convergent safe side.
+        DirtyKind::Escalate
+    }
+}
+
+/// The domain-relative path of `path` under `root`, joined with `/` to match the
+/// stamp keys, or `None` when the path is the root itself or holds any non-normal
+/// component (`..`, a prefix), which must escalate instead.
+fn clean_rel(root: &Path, path: &Path) -> Option<String> {
+    let rel = path.strip_prefix(root).ok()?;
+    let mut parts = Vec::new();
+    for comp in rel.components() {
+        match comp {
+            std::path::Component::Normal(s) => parts.push(s.to_string_lossy().into_owned()),
+            _ => return None,
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("/"))
+    }
+}
+
+/// Whether a single path component is hidden (a dotfile or dot-directory),
+/// mirroring the scan walk's own pruning.
+fn is_hidden(name: &str) -> bool {
+    name.starts_with('.') && name != "." && name != ".."
 }
 
 // --- config + path resolution -----------------------------------------------
@@ -1000,34 +1193,43 @@ mod tests {
         );
     }
 
-    // domains_for: the raw prefix match must short-circuit before any
-    // canonicalize syscall, and the canonicalize fallback must still resolve
-    // an event path reached through a symlinked root.
+    // classify_event: the raw prefix match must short-circuit before any
+    // canonicalize syscall and the canonicalize fallback must still resolve an
+    // event path reached through a symlinked root - the same matching the old
+    // domains_for had - and each matched event reduces to the right DirtyKind.
 
-    #[test]
-    fn domains_for_matches_via_raw_prefix_without_canonicalizing() {
-        // A path that does not exist on disk still matches through the raw
-        // check, proving the fallback canonicalize call is never reached.
-        let root = PathBuf::from("/some/canonical/root");
-        let domains = vec![("domain".to_string(), root.clone())];
-        let event_path = root.join("sub/does-not-exist.md");
-        assert_eq!(
-            domains_for(&event_path, &domains),
-            vec!["domain".to_string()]
-        );
+    fn as_path(kind: &DirtyKind) -> Option<&str> {
+        match kind {
+            DirtyKind::Path(p) => Some(p.as_str()),
+            _ => None,
+        }
     }
 
     #[test]
-    fn domains_for_returns_empty_when_no_root_matches() {
+    fn classify_event_matches_via_raw_prefix_without_canonicalizing() {
+        // A path that does not exist on disk still matches through the raw
+        // check, proving the fallback canonicalize call is never reached; a
+        // vanished markdown path is a targeted delete candidate.
+        let root = PathBuf::from("/some/canonical/root");
+        let domains = vec![("domain".to_string(), root.clone())];
+        let event_path = root.join("sub/does-not-exist.md");
+        let hits = classify_event(&event_path, &domains);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].0, "domain");
+        assert_eq!(as_path(&hits[0].1), Some("sub/does-not-exist.md"));
+    }
+
+    #[test]
+    fn classify_event_returns_empty_when_no_root_matches() {
         let root = PathBuf::from("/some/canonical/root");
         let domains = vec![("domain".to_string(), root)];
         let event_path = PathBuf::from("/completely/unrelated/path/file.md");
-        assert!(domains_for(&event_path, &domains).is_empty());
+        assert!(classify_event(&event_path, &domains).is_empty());
     }
 
     #[cfg(unix)]
     #[test]
-    fn domains_for_matches_a_symlinked_event_path_via_canonicalize_fallback() {
+    fn classify_event_matches_a_symlinked_event_path_via_canonicalize_fallback() {
         let base = tempfile::tempdir().unwrap();
         let real_root = base.path().join("real");
         std::fs::create_dir(&real_root).unwrap();
@@ -1040,14 +1242,120 @@ mod tests {
         std::os::unix::fs::symlink(&real_root, &link).unwrap();
 
         let domains = vec![("domain".to_string(), canonical_root)];
-        // The event path travels through the symlink, so it does not
-        // textually start with the canonical root: only the canonicalize
-        // fallback resolves it.
+        // The event path travels through the symlink, so it does not textually
+        // start with the canonical root: only the canonicalize fallback resolves
+        // it, and the resolved markdown file is a targeted path.
         let event_path = link.join("note.md");
 
-        assert_eq!(
-            domains_for(&event_path, &domains),
-            vec!["domain".to_string()]
+        let hits = classify_event(&event_path, &domains);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].0, "domain");
+        assert_eq!(as_path(&hits[0].1), Some("note.md"));
+    }
+
+    #[test]
+    fn classify_event_escalates_on_a_directory() {
+        // A directory event can hide markdown children notify never reports
+        // individually, so it must fall back to a full rescan.
+        let dir = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+        let subdir = root.join("sub");
+        std::fs::create_dir(&subdir).unwrap();
+        let domains = vec![("domain".to_string(), root)];
+        let hits = classify_event(&subdir, &domains);
+        assert_eq!(hits.len(), 1);
+        assert!(matches!(hits[0].1, DirtyKind::Escalate));
+    }
+
+    #[test]
+    fn classify_event_ignores_a_live_non_markdown_file_and_hidden_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(dir.path()).unwrap();
+        std::fs::write(root.join("scratch.txt"), "x").unwrap();
+        std::fs::write(root.join(".hidden.md"), "x").unwrap();
+        let domains = vec![("domain".to_string(), root.clone())];
+
+        // A live non-markdown file is never indexed, so it is ignored.
+        let txt = classify_event(&root.join("scratch.txt"), &domains);
+        assert_eq!(txt.len(), 1);
+        assert!(matches!(txt[0].1, DirtyKind::Ignore));
+
+        // A hidden markdown file is pruned by the scan walk, so it is ignored.
+        let hidden = classify_event(&root.join(".hidden.md"), &domains);
+        assert_eq!(hidden.len(), 1);
+        assert!(matches!(hidden[0].1, DirtyKind::Ignore));
+    }
+
+    #[test]
+    fn classify_event_escalates_on_a_vanished_non_markdown_path() {
+        // A vanished non-markdown path is ambiguous - it may have been a
+        // directory whose markdown children notify never reported - so it
+        // escalates to a full rescan, the convergent safe side.
+        let root = PathBuf::from("/some/canonical/root");
+        let domains = vec![("domain".to_string(), root.clone())];
+        let hits = classify_event(&root.join("was-a-dir"), &domains);
+        assert_eq!(hits.len(), 1);
+        assert!(matches!(hits[0].1, DirtyKind::Escalate));
+    }
+
+    // DirtyPaths: distinct paths accumulate until the cap, an overflow escalates
+    // to a full rescan and full is sticky (a later path never un-escalates it).
+
+    #[test]
+    fn dirty_paths_accumulates_distinct_paths_under_the_cap() {
+        let mut d = DirtyPaths::default();
+        d.add("a.md".to_string());
+        d.add("b.md".to_string());
+        d.add("a.md".to_string()); // a duplicate does not double-count
+        assert!(!d.full);
+        assert_eq!(d.paths.len(), 2);
+    }
+
+    #[test]
+    fn dirty_paths_overflow_past_the_cap_escalates_to_full() {
+        let mut d = DirtyPaths::default();
+        for i in 0..=MAX_DIRTY_PATHS {
+            d.add(format!("f{i}.md"));
+        }
+        assert!(
+            d.full,
+            "past {MAX_DIRTY_PATHS} distinct paths the batch is full"
         );
+        assert!(d.paths.is_empty(), "the paths are dropped once full");
+    }
+
+    #[test]
+    fn dirty_paths_full_is_sticky() {
+        let mut d = DirtyPaths::default();
+        d.mark_full();
+        d.add("a.md".to_string());
+        assert!(d.full, "a later path never un-escalates a full batch");
+        assert!(d.paths.is_empty());
+    }
+
+    // accumulate_tick: a rescan/overflow signal marks every watched domain full;
+    // a single markdown event targets exactly that path.
+
+    #[test]
+    fn accumulate_tick_rescan_marks_every_watched_domain_full() {
+        let domains = vec![
+            ("a".to_string(), PathBuf::from("/roots/a")),
+            ("b".to_string(), PathBuf::from("/roots/b")),
+        ];
+        let mut dirty: HashMap<String, DirtyPaths> = HashMap::new();
+        accumulate_tick(&mut dirty, WatchTick::Rescan, &domains);
+        assert!(dirty["a"].full);
+        assert!(dirty["b"].full);
+    }
+
+    #[test]
+    fn accumulate_tick_a_single_markdown_event_targets_that_path() {
+        let root = PathBuf::from("/roots/a");
+        let domains = vec![("a".to_string(), root.clone())];
+        let mut dirty: HashMap<String, DirtyPaths> = HashMap::new();
+        // A vanished markdown path (delete candidate) is targeted, not full.
+        accumulate_tick(&mut dirty, WatchTick::Path(root.join("note.md")), &domains);
+        assert!(!dirty["a"].full);
+        assert!(dirty["a"].paths.contains("note.md"));
     }
 }

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -32,9 +32,9 @@ use crystalline_core::{
 };
 use crystalline_index::{
     ChunkParams, DomainHost, DomainId, DomainKind, EmbeddingProvider, EngramDescriptor, EngramId,
-    EngramRecord, FileStamp, HostClaim, RecentFilter, SearchMode, SearchQuery, Store, apply_scan,
-    chunk_engram, configured_model_id, order_jobs_for_batching, parse_metadata_filters,
-    provider_from_config, scan_domain,
+    EngramRecord, FileStamp, HostClaim, RecentFilter, SearchMode, SearchQuery, Store, SyncReport,
+    apply_scan, chunk_engram, configured_model_id, order_jobs_for_batching, parse_metadata_filters,
+    provider_from_config, scan_domain, scan_paths,
 };
 use crystalline_remote::ops;
 use crystalline_remote::{
@@ -2446,6 +2446,64 @@ impl Engine {
             "reports": serde_json::to_value(&reports).unwrap_or(Value::Null),
             "skipped": skipped,
         }))
+    }
+
+    /// Sync only the given relative paths of one file domain: the targeted path
+    /// the daemon's watcher takes for a small debounced batch instead of a full
+    /// rescan, so a one-file edit in a large domain costs one stat and one hash,
+    /// not a walk of every entry.
+    ///
+    /// The two-lock-window shape mirrors [`Engine::sync_take_over`]'s per-domain
+    /// body - claim the host, snapshot the stamps and release the lock, run the
+    /// lock-free path scan, then re-lock to apply through the same [`apply_scan`]
+    /// with its TOCTOU guards - so a targeted pass never holds the store mutex
+    /// across the scan either. Only the watcher calls this; it is intentionally
+    /// not exposed over MCP or the control socket, where a full sync is always
+    /// wanted. A domain hosted by another live instance in collaboration mode is
+    /// skipped silently, exactly as the watcher's full-sync path skips it today,
+    /// so a non-host never writes the host's rows. A missed or mis-targeted event
+    /// is caught by the full fallback, the startup sync or a manual sync, so the
+    /// targeted pass only has to be convergent, never perfect.
+    pub async fn sync_paths(&self, name: &str, paths: Vec<String>) -> Result<SyncReport> {
+        let ContentSource::File { root } = self.content_source(name)? else {
+            // A virtual domain has no files on disk; there is nothing to scan.
+            return Ok(SyncReport {
+                domain: name.to_string(),
+                ..SyncReport::default()
+            });
+        };
+        let collab = !self.instance_id.is_empty();
+        let (domain, snapshot) = {
+            let store = self.store.lock().await;
+            if collab {
+                match self.claim_file_host(&*store, name, &root, false).await? {
+                    HostClaim::Acquired => {}
+                    HostClaim::HeldByOther(host) => {
+                        tracing::info!(
+                            "targeted sync skipped: domain '{name}' is hosted by instance {}",
+                            host.instance_id
+                        );
+                        return Ok(SyncReport {
+                            domain: name.to_string(),
+                            ..SyncReport::default()
+                        });
+                    }
+                }
+            }
+            let domain = store
+                .upsert_domain(name, Some(&root.to_string_lossy()), DomainKind::File)
+                .await?;
+            let snapshot = store.file_stamps(domain).await?;
+            (domain, snapshot)
+        };
+        let scan = scan_paths(name, &root, snapshot, paths, &self.chunk_params).await;
+        let report = {
+            let store = self.store.lock().await;
+            apply_scan(&*store, domain, scan).await.map_err(|e| {
+                EngineError::Internal(format!("targeted sync of '{name}' failed: {e}"))
+            })?
+        };
+        Ok(report)
     }
 
     /// Reindex all file domains. `full` clears each file domain's rows first

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -32,9 +32,9 @@ use crystalline_core::{
 };
 use crystalline_index::{
     ChunkParams, DomainHost, DomainId, DomainKind, EmbeddingProvider, EngramDescriptor, EngramId,
-    EngramRecord, FileStamp, HostClaim, RecentFilter, SearchMode, SearchQuery, Store, chunk_engram,
-    configured_model_id, order_jobs_for_batching, parse_metadata_filters, provider_from_config,
-    sync_domain_with,
+    EngramRecord, FileStamp, HostClaim, RecentFilter, SearchMode, SearchQuery, Store, apply_scan,
+    chunk_engram, configured_model_id, order_jobs_for_batching, parse_metadata_filters,
+    provider_from_config, scan_domain,
 };
 use crystalline_remote::ops;
 use crystalline_remote::{
@@ -2393,35 +2393,53 @@ impl Engine {
         let collab = !self.instance_id.is_empty();
         let mut reports = Vec::new();
         let mut skipped = Vec::new();
-        // Acquire the store lock per domain so the guard drops between domains
-        // instead of spanning the whole run; a domain's claim and sync stay
-        // under one acquisition, keeping per-domain single-writer semantics.
+        // Two short store-lock windows per domain with the scan in between, so the
+        // walk-hash-parse pass of a large domain no longer blocks every concurrent
+        // read behind the mutex. The first window claims the host, resolves the
+        // domain id and snapshots its stamps; the second applies transactionally
+        // with the TOCTOU guards. The claim stays live across the lock-free scan:
+        // the heartbeat timer renews it on its own task (30 s cadence, 90 s stale
+        // threshold), and unlike the old single-lock sync that scan no longer holds
+        // the store lock the timer needs, so a long scan cannot starve the
+        // heartbeat into staleness. The apply window is bounded db work, so no
+        // extra renew before it is needed.
         for (name, root) in &targets {
-            let store = self.store.lock().await;
-            if collab {
-                match self.claim_file_host(&*store, name, root, take_over).await? {
-                    HostClaim::Acquired => {}
-                    HostClaim::HeldByOther(host) => {
-                        if only.is_some() {
-                            return Err(EngineError::Conflict(host_refusal(name, &host)));
+            let (domain, snapshot) = {
+                let store = self.store.lock().await;
+                if collab {
+                    match self.claim_file_host(&*store, name, root, take_over).await? {
+                        HostClaim::Acquired => {}
+                        HostClaim::HeldByOther(host) => {
+                            if only.is_some() {
+                                return Err(EngineError::Conflict(host_refusal(name, &host)));
+                            }
+                            tracing::info!(
+                                "domain '{name}' is hosted by instance {} (last heartbeat {}); serving it read-from-database only",
+                                host.instance_id,
+                                host.heartbeat_at
+                            );
+                            skipped.push(json!({
+                                "domain": name,
+                                "hosted_by": host.instance_id,
+                                "heartbeat_at": host.heartbeat_at,
+                            }));
+                            continue;
                         }
-                        tracing::info!(
-                            "domain '{name}' is hosted by instance {} (last heartbeat {}); serving it read-from-database only",
-                            host.instance_id,
-                            host.heartbeat_at
-                        );
-                        skipped.push(json!({
-                            "domain": name,
-                            "hosted_by": host.instance_id,
-                            "heartbeat_at": host.heartbeat_at,
-                        }));
-                        continue;
                     }
                 }
-            }
-            let report = sync_domain_with(&*store, name, root, &self.chunk_params)
-                .await
-                .map_err(|e| EngineError::Internal(format!("sync of '{name}' failed: {e}")))?;
+                let domain = store
+                    .upsert_domain(name, Some(&root.to_string_lossy()), DomainKind::File)
+                    .await?;
+                let snapshot = store.file_stamps(domain).await?;
+                (domain, snapshot)
+            };
+            let scan = scan_domain(name, root, snapshot, &self.chunk_params).await;
+            let report = {
+                let store = self.store.lock().await;
+                apply_scan(&*store, domain, scan)
+                    .await
+                    .map_err(|e| EngineError::Internal(format!("sync of '{name}' failed: {e}")))?
+            };
             reports.push(report);
         }
         Ok(json!({
@@ -2441,34 +2459,44 @@ impl Engine {
         let targets = self.sync_targets(None)?;
         let collab = !self.instance_id.is_empty();
         let mut reports = Vec::new();
-        // Acquire the store lock per domain so the guard drops between domains.
-        // Claim, clear-if-full and sync interleave per domain under one
-        // acquisition rather than claiming every domain up front; per-domain
-        // single-writer semantics are unchanged. In collaboration mode a domain
-        // hosted by another live instance is left untouched.
+        // Two short store-lock windows per domain with the scan in between, the
+        // same shape as `sync_take_over`, so a large domain's walk-hash-parse pass
+        // no longer holds the mutex. The first window claims the host, clears the
+        // domain when `full` and snapshots the stamps; the snapshot is taken AFTER
+        // the clear so the scan classifies every file as new against empty stamps -
+        // the correct full-rebuild semantics. In collaboration mode a domain hosted
+        // by another live instance is left untouched (neither cleared nor scanned).
         for (name, root) in targets {
-            let store = self.store.lock().await;
-            if collab {
-                match self.claim_file_host(&*store, &name, &root, false).await? {
-                    HostClaim::Acquired => {}
-                    HostClaim::HeldByOther(host) => {
-                        tracing::info!(
-                            "skipping reindex of '{name}' hosted by instance {}",
-                            host.instance_id
-                        );
-                        continue;
+            let (domain, snapshot) = {
+                let store = self.store.lock().await;
+                if collab {
+                    match self.claim_file_host(&*store, &name, &root, false).await? {
+                        HostClaim::Acquired => {}
+                        HostClaim::HeldByOther(host) => {
+                            tracing::info!(
+                                "skipping reindex of '{name}' hosted by instance {}",
+                                host.instance_id
+                            );
+                            continue;
+                        }
                     }
                 }
-            }
-            if full {
-                let domain_id = store
+                let domain = store
                     .upsert_domain(&name, Some(&root.to_string_lossy()), DomainKind::File)
                     .await?;
-                store.clear_domain(domain_id).await?;
-            }
-            let report = sync_domain_with(&*store, &name, &root, &self.chunk_params)
-                .await
-                .map_err(|e| EngineError::Internal(format!("reindex of '{name}' failed: {e}")))?;
+                if full {
+                    store.clear_domain(domain).await?;
+                }
+                let snapshot = store.file_stamps(domain).await?;
+                (domain, snapshot)
+            };
+            let scan = scan_domain(&name, &root, snapshot, &self.chunk_params).await;
+            let report = {
+                let store = self.store.lock().await;
+                apply_scan(&*store, domain, scan).await.map_err(|e| {
+                    EngineError::Internal(format!("reindex of '{name}' failed: {e}"))
+                })?
+            };
             reports.push(report);
         }
         Ok(json!({

--- a/crates/service/tests/watch_targeted.rs
+++ b/crates/service/tests/watch_targeted.rs
@@ -1,0 +1,175 @@
+//! Engine-level coverage for the watcher's path-targeted sync,
+//! [`Engine::sync_paths`]: the pass the debounce flush runs over just the dirty
+//! paths of a domain instead of a full rescan.
+//!
+//! The watcher's own accumulation and escalation decision (DirtyPaths, the 256
+//! cap, classify_event, the rescan fallback) is unit-tested in the daemon module
+//! directly, because driving the live notify loop against real filesystem events
+//! is not deterministic in a harness. What these tests pin is the other half:
+//! that `sync_paths` over one path reindexes exactly that path and leaves every
+//! other row untouched, while a full `sync` remains the fallback the watcher
+//! escalates to.
+
+use std::sync::Arc;
+
+use crystalline_core::config::{DomainEntry, GlobalConfig};
+use crystalline_index::TursoStore;
+use crystalline_service::Engine;
+use crystalline_service::params::SearchParams;
+use tokio::sync::Mutex;
+
+fn manifest() -> String {
+    "---\ntype: manifest\ntitle: Notes\npermalink: manifest\ntags:\n  - manifest\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# Notes\n\n## Scope\n\n- notes\n\n## When to Use\n\n- always\n".to_string()
+}
+
+fn engram(title: &str, permalink: &str, body: &str) -> String {
+    format!(
+        "---\ntype: engram\ntitle: {title}\npermalink: {permalink}\ntags:\n  - t\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# {title}\n\n{body}\n"
+    )
+}
+
+async fn search_total(engine: &Engine, query: &str) -> u64 {
+    let hits = engine
+        .search_engrams(&SearchParams {
+            query: Some(query.to_string()),
+            ..SearchParams::default()
+        })
+        .await
+        .unwrap();
+    hits["total"].as_u64().unwrap()
+}
+
+/// A one-file edit synced through `sync_paths` reindexes exactly that file: the
+/// report counts one update and zero unchanged (the walk-free marker - a full
+/// scan would count the untouched files as unchanged), and every other engram
+/// survives verbatim in the index.
+#[tokio::test]
+async fn sync_paths_reindexes_only_the_targeted_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("MANIFEST.md"), manifest()).unwrap();
+    for i in 0..5 {
+        std::fs::write(
+            root.join(format!("f{i}.md")),
+            engram(
+                &format!("F{i}"),
+                &format!("f{i}"),
+                &format!("body{i} token"),
+            ),
+        )
+        .unwrap();
+    }
+
+    let mut cfg = GlobalConfig::default();
+    cfg.domains
+        .insert("notes".to_string(), DomainEntry::file(root.to_path_buf()));
+    let engine = Engine::new(
+        Arc::new(Mutex::new(TursoStore::open_in_memory().await.unwrap())),
+        cfg,
+        None,
+        None,
+    );
+
+    // Full sync seeds every engram.
+    engine.sync(None).await.unwrap();
+    assert_eq!(search_total(&engine, "body2").await, 1);
+
+    // Edit f2.md on disk; bump the mtime past the prefilter.
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+    std::fs::write(root.join("f2.md"), engram("F2", "f2", "revised token")).unwrap();
+
+    // Targeted pass over just that path.
+    let report = engine
+        .sync_paths("notes", vec!["f2.md".to_string()])
+        .await
+        .unwrap();
+    assert_eq!(report.domain, "notes");
+    assert_eq!(report.updated, 1, "exactly the edited file reindexed");
+    assert_eq!(report.added, 0);
+    assert_eq!(report.deleted, 0);
+    assert_eq!(
+        report.unchanged, 0,
+        "unchanged counts only the given path, never the unvisited others"
+    );
+
+    // The edit landed and the other four engrams survive untouched.
+    assert_eq!(search_total(&engine, "revised").await, 1);
+    for i in [0u32, 1, 3, 4] {
+        assert_eq!(
+            search_total(&engine, &format!("body{i}")).await,
+            1,
+            "the untouched f{i}.md row survives"
+        );
+    }
+}
+
+/// A new file and a deleted file, each synced through `sync_paths` by its own
+/// path, are added and removed without walking the rest of the domain.
+#[tokio::test]
+async fn sync_paths_handles_a_targeted_add_and_delete() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    std::fs::write(root.join("MANIFEST.md"), manifest()).unwrap();
+    std::fs::write(root.join("keep.md"), engram("Keep", "keep", "keep token")).unwrap();
+    std::fs::write(root.join("drop.md"), engram("Drop", "drop", "drop token")).unwrap();
+
+    let mut cfg = GlobalConfig::default();
+    cfg.domains
+        .insert("notes".to_string(), DomainEntry::file(root.to_path_buf()));
+    let engine = Engine::new(
+        Arc::new(Mutex::new(TursoStore::open_in_memory().await.unwrap())),
+        cfg,
+        None,
+        None,
+    );
+    engine.sync(None).await.unwrap();
+
+    // Add fresh.md and target it.
+    std::fs::write(
+        root.join("fresh.md"),
+        engram("Fresh", "fresh", "fresh token"),
+    )
+    .unwrap();
+    let added = engine
+        .sync_paths("notes", vec!["fresh.md".to_string()])
+        .await
+        .unwrap();
+    assert_eq!(added.added, 1);
+    assert_eq!(search_total(&engine, "fresh").await, 1);
+
+    // Delete drop.md and target it.
+    std::fs::remove_file(root.join("drop.md")).unwrap();
+    let deleted = engine
+        .sync_paths("notes", vec!["drop.md".to_string()])
+        .await
+        .unwrap();
+    assert_eq!(deleted.deleted, 1);
+    assert_eq!(search_total(&engine, "drop").await, 0);
+
+    // keep.md was never a target and is still there.
+    assert_eq!(search_total(&engine, "keep").await, 1);
+}
+
+/// A targeted sync of an unknown or virtual domain is a clean no-op rather than
+/// an error, so a stray watcher event never fails the flush.
+#[tokio::test]
+async fn sync_paths_on_a_virtual_domain_is_a_noop() {
+    let mut cfg = GlobalConfig::default();
+    cfg.domains
+        .insert("v".to_string(), DomainEntry::virtual_domain());
+    let engine = Engine::new(
+        Arc::new(Mutex::new(TursoStore::open_in_memory().await.unwrap())),
+        cfg,
+        None,
+        None,
+    );
+
+    let report = engine
+        .sync_paths("v", vec!["anything.md".to_string()])
+        .await
+        .unwrap();
+    assert_eq!(report.added, 0);
+    assert_eq!(report.updated, 0);
+    assert_eq!(report.deleted, 0);
+    assert_eq!(report.unchanged, 0);
+}


### PR DESCRIPTION
The two remaining redesigns deferred by the audit. (The third - a turso vector index - stays blocked upstream: 0.7.0 ships only a toy sparse-IVF index method behind an experimental flag.)

- Lock-phased sync: scan_domain is now pure filesystem work taking the stamp snapshot as input and apply_scan is the guarded transactional apply, so every lock-holding caller runs the walk-hash-parse pass of a large domain with no store lock held. A concurrent writer landing between snapshot and apply is deferred via in-transaction stamp guards (plus a disk re-stat for deletes), counted in the report's new deferred field and reconciled by a later pass; the guards are pinned by deterministic phase-split tests. This also removes a latent collaboration-mode risk: the old whole-sync lock could starve the heartbeat task past the 90 s stale threshold.
- Path-targeted watcher syncs: a debounce flush accumulates dirty relative markdown paths per domain and syncs exactly those paths through the same shared machinery and guarded apply; anything ambiguous (rescan or overflow notices, directory events, ambiguous deletions, over 256 paths) escalates that domain to the full rescan. One-file pass on a 5k-file corpus: ~15-31 ms vs ~38-47 ms full walk, gap growing with file count, and daemon-side tool writes no longer trigger a redundant full walk.

Includes the merge of the cached-plan fix from PR #10. Validated locally against a live Postgres with pgvector: parity suite green three consecutive runs; 1141 tests, clippy both feature sets, fmt and style-lint green.