### PR TITLE
Checkpoint the WAL after every sync and reindex

### DIFF
--- a/crates/cli/src/cmd.rs
+++ b/crates/cli/src/cmd.rs
@@ -883,6 +883,16 @@ pub async fn sync(
         let store = store.lock().await;
         embed_pass(&*store, &cfg).await?;
     }
+
+    // Any sync, not just a full reindex, is a snapshot-preparation verb: a
+    // downstream pipeline may ship index.db as a single file (sidecars
+    // deleted), so the delta this sync just wrote must not sit stranded in
+    // the WAL. Merge and shrink it now rather than waiting for a natural
+    // checkpoint. A no-op on Postgres (no local WAL file).
+    {
+        let store = store.lock().await;
+        store.checkpoint_wal().await?;
+    }
     Ok(())
 }
 
@@ -969,12 +979,15 @@ pub async fn reindex(
         embed_pass(&*store, &cfg).await?;
     }
 
-    if full {
-        // A full reindex is the biggest single rewrite the database sees;
-        // shrink the WAL back down rather than leaving it to grow until the
-        // next natural checkpoint. A no-op on Postgres (no local WAL file);
-        // on Turso this replaces the downstream Docker image build's shell-out
-        // to `sqlite3` for the same purpose.
+    // Any reindex, full or incremental, is a snapshot-preparation verb: a
+    // downstream pipeline may ship index.db as a single file (sidecars
+    // deleted), so whatever this reindex (and the optional embed pass above)
+    // just wrote must not sit stranded in the WAL. Merge and shrink it now
+    // rather than leaving it to grow until the next natural checkpoint. A
+    // no-op on Postgres (no local WAL file); on Turso this replaces the
+    // downstream Docker image build's shell-out to `sqlite3` for the same
+    // purpose.
+    {
         let store = store.lock().await;
         store.checkpoint_wal().await?;
     }

--- a/crates/cli/tests/data.rs
+++ b/crates/cli/tests/data.rs
@@ -653,6 +653,85 @@ fn delete_force_deletes_without_prompting() {
     );
 }
 
+/// The WAL sidecar path turso writes next to a local db file.
+fn wal_path(db: &Path) -> PathBuf {
+    let mut s = db.as_os_str().to_os_string();
+    s.push("-wal");
+    PathBuf::from(s)
+}
+
+/// True when the WAL sidecar is either absent or truncated to 0 bytes - the
+/// two shapes `PRAGMA wal_checkpoint(TRUNCATE)` can leave behind.
+fn wal_is_truncated(db: &Path) -> bool {
+    match std::fs::metadata(wal_path(db)) {
+        Ok(meta) => meta.len() == 0,
+        Err(_) => true,
+    }
+}
+
+#[test]
+fn incremental_reindex_truncates_the_wal() {
+    let work = tempfile::tempdir().unwrap();
+    let (config, db) = seed_two_engrams(work.path());
+
+    // seed_two_engrams already ran `domain add`, which syncs; the WAL sidecar
+    // should reflect that write. A plain `sync` afterward covers change 2:
+    // the direct sync path checkpoints too, even with nothing new to index.
+    bin()
+        .args(["sync", "--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .assert()
+        .success();
+    assert!(
+        wal_is_truncated(&db),
+        "sync (direct, non-daemon path) truncates the WAL: {:?}",
+        std::fs::metadata(wal_path(&db)).map(|m| m.len())
+    );
+
+    // Add a third engram so the incremental reindex below has a real delta to
+    // merge, not a no-op scan.
+    write(
+        &work.path().join("kb"),
+        "gamma.md",
+        "---\ntype: engram\ntitle: Gamma\npermalink: gamma\ntags:\n  - t\nstatus: current\nrecorded_at: 2026-01-01\n---\n\nGamma body mentions zephyrtoken too.\n",
+    );
+
+    // reindex with NO --full: the incremental path. Before the fix this never
+    // calls checkpoint_wal, so a snapshot pipeline shipping index.db alone
+    // (sidecars deleted) would ship a stale database missing this delta.
+    bin()
+        .args(["reindex", "--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .assert()
+        .success();
+    assert!(
+        wal_is_truncated(&db),
+        "incremental reindex (no --full) truncates the WAL: {:?}",
+        std::fs::metadata(wal_path(&db)).map(|m| m.len())
+    );
+
+    // The delta the WAL held is not lost: it was merged into the db file, not
+    // discarded, before the truncate.
+    let out = bin()
+        .args(["--json", "search", "zephyrtoken", "--config"])
+        .arg(&config)
+        .args(["--db"])
+        .arg(&db)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let search: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(
+        search["total"].as_u64().unwrap(),
+        3,
+        "the incremental delta survived the WAL truncate: {search}"
+    );
+}
+
 #[test]
 fn domain_add_without_a_path_registers_at_the_default_domains_root() {
     let work = tempfile::tempdir().unwrap();

--- a/crates/index/src/store.rs
+++ b/crates/index/src/store.rs
@@ -901,11 +901,13 @@ pub trait Store: Send + Sync {
     async fn wipe(&self) -> Result<()>;
 
     /// Best-effort WAL checkpoint in TRUNCATE mode, shrinking a local WAL file
-    /// back down after a bulk rewrite (a full reindex or a wipe). The default
-    /// is a no-op, which is correct for Postgres: it has no local WAL file to
-    /// truncate. Turso overrides this with a real `PRAGMA
-    /// wal_checkpoint(TRUNCATE)` (confirmed to work by a runtime probe; see
-    /// the doc comment on `TursoStore::build`).
+    /// back down after a sync or reindex, full or incremental, or a wipe. Any
+    /// of these may precede a caller shipping the database file as a
+    /// single-file snapshot (sidecars deleted), so the WAL must not be left
+    /// holding an un-merged delta. The default is a no-op, which is correct
+    /// for Postgres: it has no local WAL file to truncate. Turso overrides
+    /// this with a real `PRAGMA wal_checkpoint(TRUNCATE)` (confirmed to work
+    /// by a runtime probe; see the doc comment on `TursoStore::build`).
     async fn checkpoint_wal(&self) -> Result<()> {
         Ok(())
     }


### PR DESCRIPTION
Downstream feedback: checkpoint_wal only fired on reindex --full, so an incremental reindex - the common snapshot-pipeline case - left its delta stranded in the WAL sidecar, and shipping index.db without sidecars would ship a stale database (empirically a 560 KB WAL after one small sync). The direct sync path and every reindex now merge and truncate the WAL at the end; a CLI test pins the empty sidecar plus post-truncate search results on both verbs.