### PR TITLE
Reclaim the WAL high-water mark after embed passes and at shutdown

### DIFF
--- a/crates/index/src/turso/mod.rs
+++ b/crates/index/src/turso/mod.rs
@@ -119,8 +119,20 @@ impl TursoStore {
         //   neither errors nor takes effect. The probe confirmed this -
         //   `PRAGMA wal_autocheckpoint = 1000` returned `Ok`, but a
         //   subsequent `PRAGMA wal_autocheckpoint` query returned no rows.
-        //   Not set here; wal_checkpoint(TRUNCATE) above is the mitigation for
-        //   WAL growth instead.
+        //   Not set here, and not needed: a source read of vendored
+        //   turso_core 0.7.0 (storage/wal.rs, storage/pager.rs) confirms the
+        //   engine passive-checkpoints on every commit once un-backfilled
+        //   frames pass a hardcoded threshold of 1000, and separately
+        //   restarts the WAL file from the start once fully backfilled, both
+        //   default-on for the plain local-database path this store uses. So
+        //   the WAL never grows unbounded on its own; it is bounded near
+        //   whatever burst set its high-water mark. What the engine does not
+        //   do is zero the file: passive checkpoints backfill without
+        //   truncating, and its own last-connection shutdown truncate never
+        //   fires here because these bindings' `Connection` has no
+        //   Drop-close and this store never calls `close()`. wal_checkpoint
+        //   (TRUNCATE) above is reclamation of that high-water mark, not a
+        //   substitute for growth control the engine already provides.
         conn.execute("PRAGMA busy_timeout = 5000", ()).await?;
 
         let schema_version = migrations::apply(&conn).await?;

--- a/crates/service/src/daemon.rs
+++ b/crates/service/src/daemon.rs
@@ -386,6 +386,11 @@ pub async fn run_serve(
     // instance hosts nothing.
     engine.release_hosts().await;
 
+    // Best-effort WAL checkpoint so a stopped daemon's state dir holds a clean
+    // single-file db, backup and copy friendly. Never blocks or fails
+    // shutdown: checkpoint_wal logs and swallows any error itself.
+    engine.checkpoint_wal().await;
+
     // Dropping ownership releases the lock and removes the socket and lock files.
     drop(ownership);
     if !daemon_flag {

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -2674,6 +2674,22 @@ impl Engine {
         Ok(coverage.backlog_for(&self.model_id))
     }
 
+    /// Best-effort WAL checkpoint: reclaims disk after a burst of writes (a
+    /// bulk embed pass, daemon shutdown) by merging the WAL back into the main
+    /// db file and truncating it. The engine already bounds WAL growth on its
+    /// own (a passive checkpoint fires past a hardcoded un-backfilled-frame
+    /// threshold, see the PRAGMA probe comment on `TursoStore::build`), so
+    /// this call is disk hygiene, never growth control - callers must not
+    /// depend on it for correctness. Errors are logged and swallowed: never
+    /// let a checkpoint block or fail the caller. A no-op on Postgres via the
+    /// `Store::checkpoint_wal` trait default.
+    pub async fn checkpoint_wal(&self) {
+        let store = self.store.lock().await;
+        if let Err(e) = store.checkpoint_wal().await {
+            tracing::warn!("WAL checkpoint failed: {e}");
+        }
+    }
+
     /// The domain-id set this instance should embed, or `None` for "all domains".
     /// Outside collaboration mode it is `None` (embed everything). In
     /// collaboration mode it is the file domains this instance hosts plus every
@@ -4933,8 +4949,15 @@ pub async fn run_embed_worker(
 ) {
     while rx.recv().await.is_some() {
         while rx.try_recv().is_ok() {}
-        if let Err(e) = engine.embed_pending().await {
-            tracing::warn!("background embed failed: {e}");
+        match engine.embed_pending().await {
+            Ok(0) => {}
+            Ok(_) => {
+                // The engine passive-checkpoints on its own past a hardcoded
+                // un-backfilled-frame threshold, so this is disk reclamation
+                // of the post-bulk-embed high-water mark, not growth control.
+                engine.checkpoint_wal().await;
+            }
+            Err(e) => tracing::warn!("background embed failed: {e}"),
         }
     }
 }

--- a/crates/service/tests/embed_tick.rs
+++ b/crates/service/tests/embed_tick.rs
@@ -3,6 +3,9 @@
 //! the next write. This periodic tick re-fires the worker while a backlog
 //! remains and stays silent when there is none, and exits on shutdown.
 
+mod support;
+
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -11,6 +14,7 @@ use crystalline_index::{Store, TursoStore};
 use crystalline_service::daemon::run_embed_tick;
 use crystalline_service::engine::Engine;
 use crystalline_service::params::*;
+use support::CountingEmbedder;
 use tokio::sync::Mutex;
 
 /// An engine over a config with a single virtual domain named `notes`.
@@ -109,4 +113,104 @@ async fn tick_stays_silent_with_no_backlog() {
 
     shutdown_tx.send(true).unwrap();
     let _ = tokio::time::timeout(Duration::from_secs(1), handle).await;
+}
+
+// --- WAL hygiene -------------------------------------------------------------
+
+/// The WAL sidecar path turso writes next to a local db file. Mirrors the CLI
+/// test helpers in crates/cli/tests/data.rs.
+fn wal_path(db: &Path) -> PathBuf {
+    let mut s = db.as_os_str().to_os_string();
+    s.push("-wal");
+    PathBuf::from(s)
+}
+
+/// True when the WAL sidecar is either absent or truncated to 0 bytes - the
+/// two shapes `PRAGMA wal_checkpoint(TRUNCATE)` can leave behind.
+fn wal_is_truncated(db: &Path) -> bool {
+    match std::fs::metadata(wal_path(db)) {
+        Ok(meta) => meta.len() == 0,
+        Err(_) => true,
+    }
+}
+
+#[tokio::test]
+async fn checkpoint_wal_truncates_the_sidecar() {
+    // A real file-backed db: the sidecar this test asserts on does not exist
+    // for an in-memory store.
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("index.db");
+    let store = TursoStore::open(&db).await.unwrap();
+    let store: Arc<Mutex<dyn Store>> = Arc::new(Mutex::new(store));
+    let engine = virtual_engine(store);
+
+    engine
+        .write_engram(&write_params(
+            "Note",
+            "a body long enough to leave a non-empty WAL sidecar before the checkpoint",
+        ))
+        .await
+        .unwrap();
+    assert!(
+        !wal_is_truncated(&db),
+        "the write left the WAL non-empty: {:?}",
+        std::fs::metadata(wal_path(&db)).map(|m| m.len())
+    );
+
+    engine.checkpoint_wal().await;
+    assert!(
+        wal_is_truncated(&db),
+        "checkpoint_wal truncates the sidecar: {:?}",
+        std::fs::metadata(wal_path(&db)).map(|m| m.len())
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn embed_worker_checkpoints_the_wal_after_a_pass() {
+    // A real file-backed db, driven through the same run_embed_worker loop the
+    // daemon spawns, so this exercises the post-embed-pass checkpoint call
+    // site, not just Engine::checkpoint_wal in isolation.
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("index.db");
+    let store = TursoStore::open(&db).await.unwrap();
+    let store: Arc<Mutex<dyn Store>> = Arc::new(Mutex::new(store));
+    let (embed_tx, embed_rx) = tokio::sync::mpsc::unbounded_channel();
+    let engine = Arc::new(virtual_engine(store).with_embed_channel(embed_tx));
+    let embedder = Arc::new(CountingEmbedder::new());
+    engine.set_provider(embedder.clone());
+
+    tokio::spawn(crystalline_service::engine::run_embed_worker(
+        engine.clone(),
+        embed_rx,
+    ));
+
+    // write_engram indexes and chunks synchronously but, like the real MCP
+    // and watcher paths, does not itself request a background pass; that is
+    // the self-heal tick's job (daemon::run_embed_tick) or, here, an explicit
+    // request mirroring it. The spawned worker consumes the signal, embeds
+    // via the provider and, per the change under test, checkpoints the WAL
+    // once the pass embeds a non-zero count.
+    engine
+        .write_engram(&write_params(
+            "Note",
+            "the body of a note that produces a chunk for the worker to embed",
+        ))
+        .await
+        .unwrap();
+    assert!(
+        engine.request_embed(),
+        "the wired channel accepts the request"
+    );
+
+    for _ in 0..200 {
+        if embedder.calls.load(std::sync::atomic::Ordering::SeqCst) > 0 && wal_is_truncated(&db) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!(
+        "the embed worker never checkpointed the WAL after its pass: embed calls={}, wal={:?}",
+        embedder.calls.load(std::sync::atomic::Ordering::SeqCst),
+        std::fs::metadata(wal_path(&db)).map(|m| m.len())
+    );
 }


### PR DESCRIPTION
Source probe of vendored turso_core 0.7.0: the engine passive-checkpoints past a hardcoded 1000 un-backfilled frames and restarts the WAL when fully backfilled, both default-on, so daemon WAL growth is bounded and no periodic checkpoint is warranted. The file is just never zeroed (no Drop-close in the bindings, so the engine's shutdown truncate never fires). The daemon now truncates best-effort after any background embed pass that wrote embeddings and on graceful shutdown; the probe comment in TursoStore::build records the confirmed engine behavior.