### PR TITLE
Expose schema drift through validate_engrams

### DIFF
--- a/crates/core/src/schema.rs
+++ b/crates/core/src/schema.rs
@@ -781,3 +781,28 @@ pub fn diff(schema: &Schema, engrams: &[Engram]) -> SchemaDrift {
         unused_relations: declared_rel.difference(&observed_rel).cloned().collect(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse::parse_engram;
+
+    /// `diff` pins the four drift lists: an observation category and a relation
+    /// type in use but undeclared land in the `undeclared_*` lists, a declared
+    /// category never used lands in `unused_observations` and a declared
+    /// relation that is used stays out of `unused_relations`.
+    #[test]
+    fn diff_reports_the_four_drift_lists() {
+        let schema_md = "---\ntype: schema\ntitle: Note Schema\npermalink: note-schema\nstatus: current\nentity: note\nversion: 1\nschema:\n  decision: string\n  pattern: string\n  depends_on: Note\nsettings:\n  validation: warn\n---\n\n# Note Schema\n";
+        let schema = Schema::from_engram(&parse_engram(schema_md).unwrap()).unwrap();
+
+        let note_md = "---\ntype: note\ntitle: Drifter\npermalink: drifter\nstatus: current\n---\n\n- [decision] chose it\n\n- [insight] noticed something\n\n- depends_on [[Foo]]\n\n- relates_to [[Bar]]\n";
+        let note = parse_engram(note_md).unwrap();
+
+        let drift = diff(&schema, std::slice::from_ref(&note));
+        assert_eq!(drift.undeclared_observations, vec!["insight".to_string()]);
+        assert_eq!(drift.undeclared_relations, vec!["relates_to".to_string()]);
+        assert_eq!(drift.unused_observations, vec!["pattern".to_string()]);
+        assert!(drift.unused_relations.is_empty());
+    }
+}

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -2342,13 +2342,17 @@ impl Engine {
 
         let mut issues = Vec::new();
         let mut checked = 0usize;
+        // When drift is requested, target engrams are grouped by their selected
+        // schema so `schema::diff` runs once per schema over its own group.
+        let mut drift_groups: Vec<(Schema, Vec<Engram>)> = Vec::new();
         for d in &targets {
             let Some(engram) = self.load_engram(&source, d.domain_id, &d.path).await else {
                 continue;
             };
             checked += 1;
-            if let Some(schema) = schema::select_schema(&engram, &schemas) {
-                for issue in schema::validate(&engram, &schema) {
+            let selected = schema::select_schema(&engram, &schemas);
+            if let Some(schema) = &selected {
+                for issue in schema::validate(&engram, schema) {
                     issues.push(json!({
                         "permalink": d.permalink,
                         "path": d.path,
@@ -2375,15 +2379,40 @@ impl Engine {
                     "line": issue.line,
                 }));
             }
+            if p.drift
+                && let Some(schema) = selected
+            {
+                match drift_groups.iter_mut().find(|(s, _)| *s == schema) {
+                    Some((_, group)) => group.push(engram),
+                    None => drift_groups.push((schema, vec![engram])),
+                }
+            }
         }
 
-        Ok(json!({
+        let mut response = json!({
             "domain": p.domain,
             "checked": checked,
             "schemas": schemas.len(),
             "issue_count": issues.len(),
             "issues": issues,
-        }))
+        });
+        if p.drift {
+            let drift: Vec<Value> = drift_groups
+                .iter()
+                .map(|(schema, engrams)| {
+                    let d = schema::diff(schema, engrams);
+                    json!({
+                        "schema": schema.entity,
+                        "undeclared_observations": d.undeclared_observations,
+                        "undeclared_relations": d.undeclared_relations,
+                        "unused_observations": d.unused_observations,
+                        "unused_relations": d.unused_relations,
+                    })
+                })
+                .collect();
+            response["drift"] = Value::Array(drift);
+        }
+        Ok(response)
     }
 
     // --- infer schema --------------------------------------------------------

--- a/crates/service/src/mcp.rs
+++ b/crates/service/src/mcp.rs
@@ -355,7 +355,7 @@ impl McpServer {
     #[tool(
         name = "validate_engrams",
         title = "Validate engrams",
-        description = "Check a domain's engrams against its schema engrams to keep captured knowledge well-formed. Optionally narrow to one engram by identifier or to one type. Also runs the temporal checks so malformed dates, inverted validity windows and sentinel far-future dates are reported.",
+        description = "Check a domain's engrams against its schema engrams to keep captured knowledge well-formed. Optionally narrow to one engram by identifier or to one type. Also runs the temporal checks so malformed dates, inverted validity windows and sentinel far-future dates are reported. Set drift to also report observation categories and relation types that drift from the schema - in use but undeclared or declared but unused.",
         annotations(read_only_hint = true, open_world_hint = false)
     )]
     async fn validate_engrams(

--- a/crates/service/src/params.rs
+++ b/crates/service/src/params.rs
@@ -246,6 +246,10 @@ pub struct ValidateParams {
     /// Validate only engrams of this `type`.
     #[serde(rename = "type", default)]
     pub engram_type: Option<String>,
+    /// Also report schema drift: observation categories and relation types
+    /// in use but undeclared by the schema, and declared but unused.
+    #[serde(default)]
+    pub drift: bool,
 }
 
 /// Parameters for `infer_schema`.

--- a/crates/service/tests/mcp_tools.rs
+++ b/crates/service/tests/mcp_tools.rs
@@ -1004,6 +1004,93 @@ async fn validate_and_infer_schema() {
     assert!(inferred["count"].as_u64().unwrap() >= 2);
 }
 
+/// The opt-in `drift` flag reports observation categories and relation types
+/// that drift from the schema: in use but undeclared, and declared but unused.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn validate_engrams_reports_schema_drift() {
+    // `bare` has no schema engram: the zero-schema drift shape is checked there.
+    let h = Harness::new(&["eng", "bare"]).await;
+
+    // A schema for `note` engrams declaring two observation categories
+    // (`decision`, `pattern`) and one relation type (`depends_on`).
+    let schema_md = "---\ntype: schema\ntitle: Note Schema\npermalink: note-schema\ntags:\n  - schema\nstatus: current\nrecorded_at: 2026-01-01\nentity: note\nversion: 1\nschema:\n  decision: string\n  pattern: string\n  depends_on: Note\nsettings:\n  validation: warn\n---\n\n# Note Schema\n";
+    std::fs::write(h.root.join("eng/note-schema.md"), schema_md).unwrap();
+    h.engine.sync(None).await.unwrap();
+
+    let (client, _server) = h.connect().await;
+    let peer = client.peer();
+
+    // A note that uses `decision` (declared) and `insight` (undeclared), and
+    // relates via `depends_on` (declared) and `relates_to` (undeclared). The
+    // declared `pattern` category is left unused.
+    call(
+        peer,
+        "write_engram",
+        json!({
+            "domain": "eng",
+            "title": "Drifter",
+            "type": "note",
+            "content": "- [decision] chose it\n\n- [insight] noticed something\n\n- depends_on [[Foo]]\n\n- relates_to [[Bar]]",
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Flag on: the drift block reports each of the four lists precisely.
+    let out = call(
+        peer,
+        "validate_engrams",
+        json!({ "domain": "eng", "type": "note", "drift": true }),
+    )
+    .await
+    .unwrap();
+    let drift = out["drift"].as_array().unwrap();
+    assert_eq!(
+        drift.len(),
+        1,
+        "one entry per schema with a target: {drift:?}"
+    );
+    let entry = &drift[0];
+    assert_eq!(entry["schema"], json!("note"));
+    assert_eq!(entry["undeclared_observations"], json!(["insight"]));
+    assert_eq!(entry["undeclared_relations"], json!(["relates_to"]));
+    assert_eq!(entry["unused_observations"], json!(["pattern"]));
+    assert_eq!(entry["unused_relations"], json!([]));
+
+    // Flag off (the default): the drift key is absent, leaving existing callers
+    // untouched.
+    let off = call(
+        peer,
+        "validate_engrams",
+        json!({ "domain": "eng", "type": "note" }),
+    )
+    .await
+    .unwrap();
+    assert!(
+        off.get("drift").is_none(),
+        "drift key absent when the flag is off: {off}"
+    );
+
+    // Flag on with no schema in the domain: `schemas` is zero and `drift` is an
+    // honest empty array, not absent.
+    call(
+        peer,
+        "write_engram",
+        json!({ "domain": "bare", "title": "Loose", "type": "note", "content": "- [decision] whatever" }),
+    )
+    .await
+    .unwrap();
+    let bare = call(
+        peer,
+        "validate_engrams",
+        json!({ "domain": "bare", "drift": true }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(bare["schemas"], json!(0));
+    assert_eq!(bare["drift"], json!([]));
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn vocabulary_lists_tags_categories_and_relation_types() {
     let h = Harness::new(&["eng"]).await;


### PR DESCRIPTION
Follow-up to #15, completing the knowledge organization gap analysis: core's schema::diff drift analysis is now reachable through an opt-in drift flag on validate_engrams.

- ValidateParams gains drift (default false). When set, the response carries a drift array with one entry per schema that had target engrams: observation categories and relation types in use but undeclared plus declared but unused, keyed by the schema's entity.
- Flag-off responses are byte-identical to before; no new tool, no CLI change, no store change.
- New service test pins all four drift lists plus the flag-off and zero-schema shapes; new core unit test pins diff's semantics.