### PR TITLE
Restructure the playbook around use-cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ crystalline status
 
 Engrams written through Crystalline are indexed immediately; `crystalline sync` only picks up files created outside it (an editor, a `git pull`) when no daemon is watching them. Edit the domain's `MANIFEST.md` `## Scope` and `## When to Use` sections so routing describes it accurately - that file is what the session prompt and an agent's routing decisions read (see [Session onboarding](#session-onboarding)).
 
-[The Crystalline Playbook](docs/playbook.md) teaches the whole workflow by example, as a short mission-based course from your first domain through ingestion, reconciliation, retirement and team sharing.
+[The Crystalline Playbook](docs/playbook.md) teaches the whole workflow by example, a use-case course over one running dataset through recording, querying, ingesting, reconciling, retiring and sharing knowledge.
 
 ## Session onboarding
 

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -53,7 +53,7 @@ the docking gear, the coolant loop, the vent drivers.
 (`~/Documents/Crystalline` by default), scaffolds its `MANIFEST.md` and registers
 it, confirming the location before it writes anything. Naming the domain yourself
 keeps the outcome predictable; leave the name out and the agent will propose one
-and ask.* The scaffold is a stub you fill in -
+and ask.* The scaffold arrives as a stub -
 its routing sections are what an agent reads each session to decide whether a task
 belongs here:
 
@@ -83,9 +83,30 @@ recorded_at: 2026-07-19
 - Add guidance for agents working in this domain
 ```
 
-Replace the placeholders with the ship's real scope - docking, coolant, the vent
-drivers and the hull - so the `When to Use` bullets route clamp and coolant
-questions straight here. From then on every session opens with the agent reading
+The placeholders are not yours to type either - describe the domain and let the
+agent write its own routing:
+
+```text
+Fill in the ship-ops manifest: this domain covers the ship's hardware and
+operations - docking gear, coolant loop, vent drivers and hull - and any
+question about those systems should route here.
+```
+
+*The agent rewrites the placeholder sections in place:*
+
+```markdown
+## Scope
+
+- Hardware and operations of the ship: docking gear, coolant loop, vent
+  drivers and hull
+
+## When to Use
+
+- Route questions about docking, clamps, coolant or vents here
+- Check here before touching hardware the ship has already complained about
+```
+
+From then on every session opens with the agent reading
 those bullets as a routing brief, so it knows `ship-ops` owns them without being
 told. A healthy archive keeps its sync ratio: what the agent sees and what is on
 disk track one to one, and everything below drifts them apart then back.

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -3,336 +3,524 @@
               ▄▄▄████▄▄▄
             ▟███▓▒░░▒▓███▙            T H E   C R Y S T A L L I N E
              ▜███▓▒░▒▓███▛                · ·  P L A Y B O O K  · ·
-        *      ▀▜███▛▀                    a field manual, in missions
+        *      ▀▜███▛▀                    a field manual, in use-cases
                   ▀
 ```
 
 # The Crystalline Playbook
 
 You are the new knowledge officer aboard the SS Kobayashi Delorean, a small
-freighter whose transponder still answers to three older names. Your crew
-includes an AI agent that starts every shift a stranger and forgets the last one,
-unless you teach it to remember. Eight missions below, each runnable start to
-finish: work through them and the ship keeps its own log, the agent reads it
-before acting and neither of you re-derives the docking procedure from scratch
-again.
+freighter that hauls whatever pays - flux capacitors one run, live cargo from an
+island job the next. Your crew includes an AI agent that starts every shift a
+stranger and forgets the last one, unless you teach it to remember. This is a
+use-case course, and one dataset threads through all of it: what you record in
+`Record` is what you query, reconcile, retire and share later. Follow it in order
+and the ship ends up keeping its own log.
 
-Every mission is a conversation. You speak in plain human terms; the agent infers
-the rest - which domain a fact belongs in, how to file it, what to search first -
-then proposes and does it. The italic line after each prompt shows that inference
-at work. Only the first step and a small terminal corner touch a command line. The
-[reference README](../README.md) is the map; this is the flight training.
+Every step is a conversation. You speak in plain terms; the agent infers the rest,
+proposes and does it - the italic line after each prompt shows that inference at
+work, and each chapter also shows the artifact that lands on disk so you can see
+exactly what the agent wrote. Only setup and a small terminal corner touch a
+command line. The [reference README](../README.md) is the map; this is the flight
+training.
 
-## Mission 00 - Preflight
+## Setup
 
-> *Tank, load me the operations manual. A pause. I know the ship.*
-
-Install the binary first - pick your platform from the
+Install the binary once - pick your platform from the
 [install matrix](../README.md#install-the-binary) and come back. Then one command
-jacks the agent in:
+wires the whole integration:
 
 ```sh
 crystalline install claude-code
 ```
 
-That single step wires the whole rig - MCP registration, the `SessionStart`
-routing hook, the `Stop` capture nudge and the four skills. It is the "I know
-kung fu" moment: next session the agent wakes already knowing how to route,
-capture and share. The same command takes `codex` or `copilot`. This is the last
-time you need a terminal. Claude Desktop skips even this: install the `.mcpb`
-extension from the latest release, upload the `crystalline-memory` skill zip and
-never open a terminal.
+That single step registers the MCP server, the `SessionStart` routing hook, the
+`Stop` capture nudge and the four skills. Think of it as the agent loading a
+program: next session it wakes already knowing how to route, capture and share.
+The same command takes `codex` or `copilot`. This is the last time you need a
+terminal. Claude Desktop skips even this: install the `.mcpb` extension from the
+latest release, upload the `crystalline-memory` skill zip and never open a
+terminal.
 
-Start a session and ask what it already knows:
-
-```text
-What do you already know about this ship?
-```
-
-*A fresh install can see no domains yet - that is Mission 01. A healthy archive
-keeps its sync ratio: what the agent sees and what is on disk track one to one.*
-
-## Mission 01 - Commission the archive
-
-> *Computer: commission the ship's archive. Log our five-year mission.*
-
-A domain is a folder of knowledge with a `MANIFEST.md` at its root. Just tell the
-agent what you want it to remember:
+Start a session and give the agent its first domain in plain language:
 
 ```text
-Set up a place to keep everything about the ship - the docking gear, the
-coolant loop, the vent drivers.
+Set up a place for you to remember everything about this ship - the docking gear,
+the coolant loop, the vent drivers.
 ```
 
-*The agent proposes a file domain named `ship-ops` in its domains folder, scaffolds
-its `MANIFEST.md` and registers it, confirming the name and location first.*
+*The agent proposes a file domain named `ship-ops` under its domains root
+(`~/Documents/Crystalline` by default), scaffolds its `MANIFEST.md` and registers
+it, confirming the name and location first.* The scaffold is a stub you fill in -
+its routing sections are what an agent reads each session to decide whether a task
+belongs here:
 
-Now the manifest matters. Ask the agent to fill in that `MANIFEST.md`, or edit it
-yourself - its `## Scope` and `## When to Use` sections are the routing beacon the
-agent reads each session to decide whether a task belongs here. Write them like
-standing orders - "when asked about docking, coolant or the vent drivers, look
-here". Vague scope is a computer that answers every hail with "insufficient data".
-Next session the domain shows up in the agent's routing block, and you have given
-it somewhere to think.
+```markdown
+---
+type: manifest
+title: ship-ops
+permalink: manifest
+tags:
+  - manifest
+status: current
+recorded_at: 2026-07-19
+---
 
-## Mission 02 - First entries
+# ship-ops
 
-> *Captain's log, supplemental: the docking clamps, again.*
+## Scope
+
+- Describe the knowledge this domain covers
+
+## When to Use
+
+- Describe when an agent should route here
+
+## Notes for Agents
+
+- Add guidance for agents working in this domain
+```
+
+Replace the placeholders with the ship's real scope - docking, coolant, the vent
+drivers and the hull - so the `When to Use` bullets route clamp and coolant
+questions straight here. From then on every session opens with the agent reading
+those bullets as a routing brief, so it knows `ship-ops` owns them without being
+told. A healthy archive keeps its sync ratio: what the agent sees and what is on
+disk track one to one, and everything below drifts them apart then back.
+
+## Record
 
 Capture is a byproduct of the work, not a chore. Say what you learned the way you
 would tell a crewmate:
 
 ```text
 Remember this: docking clamp 3 reads locked about half a second before it
-actually seats, so wait for the green tone before cutting thrust.
+actually seats when the bay is cold, so wait for the green tone before cutting
+thrust.
 ```
 
-*You named no domain and no category. The agent searches the archive first, finds
-nothing, then proposes filing it in `ship-ops` as a `[gotcha]` tagged `docking`
-and writes only once you say yes - it named the domain for you, so nothing lands
-wrong.*
+*You named no domain and no category. The agent searches `ship-ops` first, finds
+nothing, then proposes filing it as a `[gotcha]` tagged `docking` and writes only
+once you say yes - it named the domain for you, so nothing lands wrong.* Here is
+the artifact that lands on disk:
 
-Knowledge that leans on other knowledge gets a relation. You still just talk:
+```markdown
+---
+type: engram
+title: Docking clamp cold-weather seating
+permalink: docking-clamp-cold-weather-seating
+tags:
+- docking
+- clamps
+status: current
+recorded_at: 2026-07-19
+timestamp: 2026-07-19T09:12:00+00:00
+---
+
+# Docking clamp cold-weather seating
+
+Clamp 3 misreports its lock state when the aft bay is cold.
+
+## Observations
+
+- [gotcha] Clamp 3 reads locked about half a second before it seats; wait for the green tone before cutting thrust #docking
+- [fact] Seen below roughly 5C in the aft bay #docking
+```
+
+The top-level `- [category] text #tag` bullets are observations, the atomic unit
+of an engram. Categories are free text but precise ones earn their keep (the
+appendix lists them); `type` and `status` have recommended values that are
+guidance, not a fixed enum. The stardate `recorded_at` and the `timestamp` are
+filled in for you.
+
+The agent proposes before it captures. Even unprompted it would raise the insight
+first - "I noticed clamp 3 misreads in the cold; should I record that in
+`ship-ops`?" - and wait for your yes. A blunt "store this" is already a complete
+instruction; idle grumbling about the clamp it lets pass without a word.
+
+Next you record how the vents are driven, a fact other knowledge will lean on:
 
 ```text
-Also note that we decided to run the coolant loop on glycol mix B - it rides on
-the vent driver firmware.
+Note that every vent actuator runs one shared firmware image, flashed from a
+single controller. A bad flash grounds all the vents at once.
 ```
 
-*The agent files a `[decision]` and, seeing the firmware engram already exists,
-links them on disk as `- depends_on [[Vent Driver Firmware]]`.*
+*The agent files it with `type: reference`, catching the single-point-of-failure
+angle as a `[risk]`:*
 
-On disk each capture is a bullet like `- [gotcha] Clamp 3 seats late #docking`.
-Pick a precise category (the appendix lists them); `type` and `status` have
-recommended values but are guidance, not a fixed enum. Your stardate
-(`recorded_at`) is filled in for you.
+```markdown
+---
+type: reference
+title: Vent Driver Firmware
+permalink: vent-driver-firmware
+tags:
+- vents
+- firmware
+status: current
+recorded_at: 2026-07-19
+timestamp: 2026-07-19T11:47:00+00:00
+---
 
-## Mission 03 - Recall
+# Vent Driver Firmware
 
-> *Time is a big ball of what-was-true-then. Do be careful. Spoilers.*
+Every vent actuator runs one shared firmware image, flashed from a single
+controller.
 
-Ask the way it forms in your head:
+## Observations
+
+- [fact] All vent actuators run the same firmware build from one controller #vents
+- [risk] The shared image is a single point of failure; a bad flash grounds every vent at once #vents
+```
+
+Now knowledge that leans on other knowledge gets a relation. You still just talk:
+
+```text
+Also note we decided to run the coolant loop on glycol mix B - it rides on the
+vent driver firmware.
+```
+
+*The agent files a `[decision]` and, seeing the Vent Driver Firmware engram it
+just wrote, links the two.* On disk the decision carries a `Relations` section:
+
+```markdown
+---
+type: decision
+title: Coolant loop runs glycol mix B
+permalink: coolant-loop-runs-glycol-mix-b
+tags:
+- coolant
+- cooling
+status: current
+recorded_at: 2026-07-19
+timestamp: 2026-07-19T14:03:00+00:00
+---
+
+# Coolant loop runs glycol mix B
+
+The primary coolant loop runs glycol mix B for its cold-start margin.
+
+## Observations
+
+- [decision] Run the coolant loop on glycol mix B #coolant
+- [fact] Chosen for a wider cold-start window than the stock coolant #coolant
+
+## Relations
+
+- depends_on [[Vent Driver Firmware]]
+```
+
+The `[[Vent Driver Firmware]]` link resolves to the engram you just recorded, so
+the graph knows the coolant choice rides on the firmware. One more capture goes in
+the same way: on the walkaround you notice the two-meter thermal exhaust port
+vents straight to the reactor with no shielding, and the agent files it as a
+`[risk]` tagged `structural`. Four engrams recorded now. Everything after this
+queries, refines or retires them.
+
+## Query
+
+Ask the way the question forms in your head. A narrow ask stays in one domain:
 
 ```text
 What do we know about the docking clamps?
 ```
 
-*A narrow question, so the agent scopes itself to `ship-ops`.*
+*A narrow question, so the agent scopes itself to `ship-ops` and relays the hit
+with its tags visible:*
 
 ```text
-What do we know about coolant - check everything.
+1 hit in ship-ops - Docking clamp cold-weather seating [docking, clamps]
+  - [gotcha] Clamp 3 reads locked about half a second before it seats; wait for
+    the green tone before cutting thrust
 ```
 
-*The archive is vast and every domain answers; the agent sweeps them all.* For
-the neighbourhood around one engram, ask "what connects to the coolant loop?" and
-the agent walks the relations from Mission 02.
-
-Two questions, two searches. Ask *what is true now?* and the agent filters on
-status; ask *what applied last June?* and it reasons over validity windows. Heed
-the timey-wimey warning: an engram with no `valid_from` has always been valid and
-one with no `valid_to` is valid forever, so a strict date bound sees only the
-windows that exist and can skip the unbounded rows - the very ones the question
-means to keep. Absence means always, so the agent leans on status for
-now-versus-then, never filtering the open-ended rows into silence.
-
-Back from leave? Ask "what changed while I was away?" and the agent pulls the
-recent captures across every domain. An engram is what persists of a session after
-the session is gone; write enough of them and the ship remembers what the crew
-forgets.
-
-## Mission 04 - Bulk intake
-
-> *Legacy knowledge, like life, finds a way. Preserve it in amber, not a tar pit.*
-
-Crystalline ships no scraper, by design: the agent is the ingester, reading a
-source and distilling it into engrams, one truth per domain. The cardinal sin is
-mirroring - copying a source wholesale so it looks complete, filling the gaps with
-frog DNA that breeds surprises nobody signed off on. Distill the durable facts and
-drop the rest. Four intake jobs, four things you say. A webpage:
+A broad ask drops the domain filter and sweeps everything you have - just
+`ship-ops` today, fanning out across every domain as the archive grows. The net is
+vast:
 
 ```text
-Read this page and remember the parts that will still be true next month - and
-keep a link back to where you found it.
+Any single points of failure we should worry about?
 ```
 
-*The agent distills the durable facts into `ship-ops`, records the source URL and
-date in frontmatter (`resource`, `source_date`) and drops whatever goes stale.
-Webpage intake needs a harness with web access.*
-
-Local documents on disk:
+*The agent sweeps every domain and relays the two engrams that carry a
+single-point-of-failure `[risk]`, tags attached:*
 
 ```text
-Here are three spec PDFs in ./specs - pull out what is worth keeping, one topic
-each.
+2 hits in ship-ops
+  Vent Driver Firmware                 [vents, firmware]
+  Thermal exhaust port is unshielded   [structural]
 ```
 
-*The agent proposes an engram per keeper and waits for your yes.*
+Both hits earned their place: the shared vent firmware grounds every vent on a bad
+flash, and the exhaust-port `[risk]` you filed on the walkaround vents straight to
+the reactor. The clamp gotcha is not here - it is annoying, not fatal, so it does
+not match the question. For the neighbourhood around one engram rather than a flat
+list, hand the agent a `crystalline://` anchor - "walk out from
+`crystalline://ship-ops/coolant-loop-runs-glycol-mix-b`" - and it follows the
+relations to the vent driver firmware and back.
 
-A git repository:
+Time matters too. Ask *what is true now?* and the agent filters on status; ask
+*what coolant applied last June?* and it reasons over validity windows instead.
+Mind the spoilers: an engram with no `valid_from` has always been valid and one
+with no `valid_to` is valid forever, so a strict date bound sees only the windows
+that exist and can skip the unbounded rows - the very ones the question means to
+keep. Absence means always, so the agent leans on status for now-versus-then.
+
+Coming back after a few shifts away, ask "what changed while I was away?" and the
+agent pulls the recent captures across every domain so you start current. An
+engram is what persists of a session after the session is gone; the more you
+record, the more the ship recalls.
+
+## Ingest
+
+Crystalline ships no scraper, by design: the agent is the ingester. It reads a
+source and distills it into engrams, one truth per domain. The cardinal sin is
+mirroring - copying a source wholesale so it looks complete, then filling the gaps
+with guesswork the way the old park bred its exhibits with spare frog DNA. Distill
+the durable facts and drop the rest.
+
+Make the contrast concrete. A vendor recall notice for the hyperdrive is a
+forty-screen webpage: marketing header, a revision table, legalese, a support
+matrix and three paragraphs that actually matter. You say:
 
 ```text
-Look through this repo and remember how it is built and the conventions it
-follows.
+Read this vendor recall page and remember only the parts that affect our ship -
+keep a link back to the source.
 ```
 
-*The agent proposes a fresh domain for it - say `vessel-arch` - lists the engrams
-it will write and holds until you approve. Distilled architecture, not a copy of
-the code.*
+*The agent distills the durable risk into `ship-ops`, records the source in
+frontmatter and drops the rest:*
 
-Your team wiki:
+```markdown
+---
+type: reference
+title: Hyperdrive motivator recall QX-114
+permalink: hyperdrive-motivator-recall-qx-114
+tags:
+- hyperdrive
+- vendor
+- recall
+status: current
+recorded_at: 2026-07-19
+source_date: 2026-06-30
+resource: https://vendor.example/notices/qx-114
+timestamp: 2026-07-19T16:20:00+00:00
+---
+
+# Hyperdrive motivator recall QX-114
+
+The vendor recalls QX-114 motivators shipped before mid-2026. Ours is affected.
+
+## Observations
+
+- [risk] QX-114 motivators built before 2026-06 can desync under sustained load; the vendor offers a free swap #hyperdrive
+- [fact] Our unit shipped 2026-04, inside the recall window #hyperdrive
+```
+
+Forty screens became two facts and a source link. That is distilling, not
+mirroring. A second pass over the vendor's install guide lands another engram, and
+you tag that one `hyper-drive` out of habit - a drift the next chapter cleans up.
+The other intake jobs follow the same shape, each a sentence you say:
+
+- **Local documents.** "Read the raptor-paddock containment PDFs in `./isla-nublar`
+  and propose engrams for a new `containment` domain, the keepers only." The agent
+  reads the files and proposes an engram list before writing a line.
+- **A git repository.** "Look through the flux-capacitor firmware repo and distill
+  how it is built and its conventions into a new `vessel-arch` domain." The agent
+  proposes the domain and the engram list first, holds for your yes, then captures
+  distilled architecture - never a copy of the source.
+- **Your team wiki.** "Export our team wiki to markdown and bring over the pages
+  still worth keeping, leaving the dead ones behind." It distills the keepers and
+  leaves the fossils where they lie.
+
+Proposing first is the rule for a whole domain too. Point the agent at the
+flux-capacitor firmware repo and it comes back with a list before touching disk:
 
 ```text
-Our team wiki has years of pages - bring over the ones still worth keeping and
-leave the rest.
+Proposed for a new vessel-arch domain (5 engrams):
+  - Flux capacitor firmware architecture
+  - Build and flash workflow
+  - Timing-calibration convention
+  - Fault codes and recovery
+  - Hardware revision notes
+Write these? (y / n)
 ```
 
-*It distills the keepers into `ship-ops` and leaves the fossils in the amber.*
+You trim it to the ones that matter and it writes only those, distilled into their
+own domain rather than dumped into `ship-ops`.
 
 A legacy markdown tree that is already frontmatter-shaped is the one exception
 that stays in the terminal: an import command in the
-[terminal corner](#the-terminal-corner) folds it into the domain, source tree
-untouched. They spared no expense on the old archive, and it shows: half is
-scaffold. The Jurassic Park lesson holds - the crew got so preoccupied with
-whether they could ingest all of it that nobody stopped to ask whether they
-should. Distill.
+[terminal corner](#the-terminal-corner) folds it into a domain, source tree
+untouched. They spared no expense on that old archive, and it shows - half of it
+is scaffold. Distill.
 
-## Mission 05 - Reconciliation
+## Reconcile
 
-> *If my calculations are right, when two engrams disagree you are about to see
-> some serious reconciliation.*
-
-Two standing orders keep the timeline single: search before you write, and edit
-over create. When new knowledge lands on a topic that already has an owner, that
-owner gets refined in place - no rival engram that contradicts it. Nudge the agent
-when it forgets:
+Two standing orders keep the record single: search before you write, and edit over
+create. A later cold snap teaches you the clamp misread starts earlier than you
+first logged - not at 5C but nearer 8C. You do not file a second clamp engram:
 
 ```text
-Do we already have something on coolant? Update it instead of starting a new one.
+Correction on the docking clamps: the cold misread starts around 8C, not 5C. We
+measured it more carefully this run.
 ```
 
-*The agent searches `ship-ops` first and, when an owner exists, refines it in
-place rather than forking a duplicate.*
+*The agent searches `ship-ops` first, finds the existing gotcha and refines it in
+place rather than forking a duplicate.* This is a correction, so it edits the fact
+where it stands - the observation section goes from
 
-Reconcile in place, never as an append log. An engram is what is true now, so the
-changed fact gets replaced where it stands; nobody staples a dated `## Update`
-section under it. "Checked the source, nothing changed" is one frontmatter field,
-`last_verified: <date>`, that the agent keeps current. A stale engram nobody has
-re-checked is the photograph where the crew is slowly fading out; a current
-`last_verified` keeps everyone in the picture.
+```markdown
+- [gotcha] Clamp 3 reads locked about half a second before it seats; wait for the green tone before cutting thrust #docking
+- [fact] Seen below roughly 5C in the aft bay #docking
+```
 
-Vocabulary drifts the same way a timeline does - `docking` here, `docking-clamp`
-there, the same idea under two names. Just ask:
+to
+
+```markdown
+- [gotcha] Clamp 3 reads locked about half a second before it seats; wait for the green tone before cutting thrust #docking
+- [fact] Seen below roughly 8C in the aft bay #docking
+```
+
+An engram is what is true now, so a changed value is replaced where it stands, not
+stapled on as a dated `## Update` note. When you have only re-checked a source and
+nothing changed, that is one frontmatter field, `last_verified: <date>`, kept
+current - never a heading.
+
+The test is simple: does the new fact make the old one false going forward? A
+sharper measurement of the same behavior does not, so it is a correction edited in
+place. A value that genuinely changed in the world does, and that is a
+supersession - the next chapter.
+
+Vocabulary drifts the same way. Two engrams now touch the hyperdrive - the recall
+notice tagged `hyperdrive` and the install guide tagged `hyper-drive` - the same
+topic split under two spellings. The agent surveys the vocabulary and surfaces the
+pair as a near-duplicate cluster rather than acting on its own. Folding them is a
+deliberate bulk rewrite, so the merge lives in the
+[terminal corner](#the-terminal-corner). It rewrites every tag and records the
+fold in the domain MANIFEST so nothing gets lost:
+
+```markdown
+## Tag Aliases
+
+- hyper-drive -> hyperdrive
+```
+
+From then on a search for `hyper-drive` folds into `hyperdrive` in both
+directions, so the old name keeps finding everything it always did.
+
+## Retire
+
+Knowledge retires, it does not disappear - all of it stays in the record so the
+crew never re-learns it the hard way. When mix B gives way to mix C, you supersede
+rather than overwrite:
 
 ```text
-Have our tags drifted - anything meaning the same thing under two names?
+We switched the coolant to glycol mix C on 2026-08-01 - mix B ran hot above 80%
+load. Retire the old decision but keep why it changed.
 ```
 
-*The agent surveys the vocabulary and flags near-duplicate clusters like `docking`
-and `docking-clamp`.* Folding them is a deliberate bulk rewrite, so it stays in
-the terminal: a merge command in the [terminal corner](#the-terminal-corner)
-rewrites the tag everywhere and records `- docking-clamp -> docking` in the
-MANIFEST's `## Tag Aliases` section, so the old name still finds everything. The
-agent proposes the alias when it spots the drift; the merge is yours to run.
+*The agent runs the full recipe.* First it writes the replacement as a new engram
+with `status: current`, carrying the lesson forward so it outlives the retired
+fact:
 
-## Mission 06 - Retirement
+```markdown
+---
+type: decision
+title: Coolant loop runs glycol mix C
+permalink: coolant-loop-runs-glycol-mix-c
+tags:
+- coolant
+- cooling
+status: current
+recorded_at: 2026-08-01
+timestamp: 2026-08-01T17:40:00+00:00
+---
 
-> *All of this has happened before. The old log stays in the record; the lesson
-> jumps forward.*
+# Coolant loop runs glycol mix C
 
-Knowledge retires, it does not disappear. When a fact stops holding it is
-superseded, not overwritten into silence, and on disk the recipe is exact:
+The primary coolant loop runs glycol mix C after mix B overheated under load.
 
-1. The replacement is written as a new engram with `status: current` - not edited
-   into the old fact, which would leave the outdated value searchable as current.
-2. The old engram is edited: a `find_replace` flips its frontmatter
-   `status: current` to `status: superseded`, and a `- superseded_by [[New
-   Engram]]` relation is added.
-3. If the date it stopped holding is known, the same edit adds a `valid_to:
-   <date>` line - the real transition date, never a sentinel - so a later search
-   can answer "what applied last June" with the engram that was true then.
-4. The lesson carries forward: any insight that outlives the retired fact becomes
-   a `[lesson]` bullet on the new engram. The experience stays time-scoped; what
-   it taught travels on unbounded.
+## Observations
 
-You do not run those steps. You just say what happened:
+- [decision] Run the coolant loop on glycol mix C #coolant
+- [lesson] Mix B ran hot above 80% load; mix C holds its margin there #coolant
 
-```text
-The coolant mix changed on the first of June - we are off glycol mix B and
-running mix C now. Mix B ran hot; make sure we remember why.
+## Relations
+
+- supersedes [[Coolant loop runs glycol mix B]]
 ```
 
-*The agent runs the recipe for you: mix C becomes a new `current` engram, the old
-one flips to `superseded` with a `- superseded_by` link, its window closes at
-2026-06-01 and the "why B ran hot" lesson moves to a `[lesson]` bullet.*
+Then it edits the old engram - flipping its status and closing its validity window
+in one edit, and adding the back-relation. The old frontmatter goes from
 
-The status words: `deprecated` says do not do this again, `superseded` says a
-newer engram replaced this one and `archived` says retired but kept for the
-record. `delete` is for mistakes, not history - the old log is how the ship learns
-it has seen this before.
+```markdown
+status: current
+```
 
-## Mission 07 - Joint operations
+to
 
-> *Help us keep this knowledge. Transmit the plans. You are our only hope.*
+```markdown
+status: superseded
+valid_to: 2026-08-01
+```
+
+with a `- superseded_by [[Coolant loop runs glycol mix C]]` line added to its
+relations. The old decision is still readable and still addressable by date, but it
+can no longer read as current. Use the real transition date for `valid_to`, never
+a sentinel, and leave the window open when the date is unknown.
+
+The status words each mean one thing: `deprecated` says do not do this again,
+`superseded` says a newer engram replaced this one and `archived` says retired but
+kept for the record. `delete` is for mistakes, not history.
+
+## Share
 
 A team domain is an ordinary domain whose files also live in a GitHub repository:
 your local markdown stays the truth, and an origin records which repository it
-tracks. Wiring up the alliance is a conversation, not a config file:
+tracks. Wiring up the fleet is a conversation, not a config file:
 
 ```text
-Let us start sharing knowledge with the rest of the fleet.
+Turn on GitHub team sharing, connect this machine, then pull in the fleet's shared
+repo fleet/fleet-ops.
 ```
 
-*The agent turns on GitHub team sharing and connects this machine, handing you a
-short browser code to confirm - no git, no SSH keys, just this machine's identity.*
-
-```text
-Pull in the fleet's shared knowledge repo, alliance/fleet-ops.
-```
-
-*The agent registers it as a team domain - `fleet-ops` - tracking that
+*The agent turns on team sharing and hands you a short browser code to confirm - no
+git, no SSH keys - then registers `fleet-ops` as a team domain tracking that
 repository's main branch and downloads it.*
 
-From there the loop is a rhythm you speak: ask where the domain stands at session
-start, pull the team's merged work before you dig in and share when your own work
-is worth it:
+The loop is a rhythm you speak. Ask where the domain stands at session start, pull
+the team's merged work before you dig in and share when your own work is worth it:
 
 ```text
-My docking clamp notes are worth sharing - send them to the fleet for review.
+Share my docking clamp findings to fleet-ops as a proposal and give me the review
+URL.
 ```
 
-*The agent opens a proposal from your local changes and hands back a review URL.*
-A person at command reads it and merges on GitHub; the agent never merges its own
-work, only relays the link. A declined proposal is normal - refine and share
-again, or let it lapse (dropping one for good is a terminal-corner move:
-`crystalline origin discard`). If two edits collide, ask the agent to resolve
-it, keeping your side or theirs. Some gave everything to bring that knowledge back; a proposal is how
-you add to it without trampling what it cost.
+*The agent opens a proposal from your local changes and hands back a review URL.* A
+person at command reads it and merges on GitHub; the agent never merges its own
+work, it only relays the link. If two edits collide, ask the agent to resolve the
+conflict, keeping your side or theirs. A declined proposal is normal - it lapses,
+or you discard it from the [terminal corner](#the-terminal-corner). Hard-won
+knowledge is worth the review.
 
-## Appendix - The ship's computer
-
-> *This is Mother. I can tell you what I know. You only have to ask.*
-
-The computer answers when queried and stays silent when not, so query it.
-Knowledge hoarded is knowledge lost - every mission above is about what you learn
-reaching the next shift and the rest of the crew. Below is a quick reference; the
-terminal corner is optional.
+## Appendix
 
 ### Quick reference
 
 | To do this | Say to your agent |
 |---|---|
-| Commission a domain | "Give me somewhere to remember everything about the ship." |
+| Commission a domain | "Set up a place to remember everything about the ship." |
 | Capture a fact | "Remember this: the port clamp sticks in the cold." |
 | Recall, scoped | "What do we know about docking?" |
-| Recall, everywhere | "What do we know about coolant - check everything." |
-| Read one engram | "Show me the clamp gotcha." |
-| Walk the graph | "What connects to the coolant loop?" |
-| Refine in place | "Update what we have on coolant, do not start a new note." |
+| Recall, everywhere | "Any single points of failure we should worry about?" |
+| Walk the graph | "Walk out from the coolant decision and show what connects." |
+| Recall what was true then | "What coolant applied last June?" |
 | Catch up | "What changed while I was away?" |
-| Recall what was true then | "What applied last June?" |
-| Tidy vocabulary | "Have our tags drifted?" |
-| Retire a fact | "The old coolant mix is retired - update the archive." |
-| Share with the team | "These notes are worth sharing - send them for review." |
+| Ingest a source | "Read this recall page and remember only what affects us." |
+| Correct a fact | "Update the clamp threshold, do not start a new note." |
+| Retire a fact | "The old coolant mix is retired - supersede it, keep why." |
+| Tidy vocabulary | "Have our hyperdrive tags drifted?" |
+| Share with the team | "Share the clamp findings as a proposal for review." |
 
 ### Reference blocks
 
@@ -346,7 +534,7 @@ Observation categories: `- [decision]`, `- [fact]`, `- [pattern]`, `-
 one.
 
 Relation syntax: `- rel_type [[Other Engram]]`, or quote a multi-word type,
-`- "relates to" [[Other Engram]]`.
+`- "relates to" [[Other Engram]]`. Aliases in a MANIFEST are `- old -> canonical`.
 
 Temporal rules: no `valid_from` means always valid, no `valid_to` means valid
 forever. Set a bound only when validity is genuinely limited, as a plain ISO date
@@ -360,16 +548,16 @@ name the domain separately.
 ### The terminal corner
 
 Optional power-user territory - a reader who never opens a terminal can skip it.
-But skip the quarantine checks before you share and you are the crew that let the
-thing aboard, so `verify` and `doctor` earn their keep. These are the only
-commands the missions did not hand to the agent:
+But like the quarantine protocol on a certain other freighter, the checks earn
+their keep: run `verify` and `doctor` before you trust a shared branch. These are
+the only commands the chapters did not hand to the agent:
 
 ```sh
-crystalline install claude-code                     # wire up a harness (Mission 00)
+crystalline install claude-code                     # wire up a harness (Setup)
 crystalline import ./old-notes --domain ship-ops    # convert a legacy markdown tree
 crystalline tags rename <old> <new>                 # rename a tag everywhere
 crystalline tags merge <old> <into>                 # fold one tag into another
-crystalline origin discard <domain> --proposal <n>  # drop a declined proposal for good
+crystalline origin discard fleet-ops --proposal 4   # abandon a declined proposal
 crystalline verify                                  # static check: frontmatter, links, schema
 crystalline doctor                                  # diagnose index and service; add --fix to repair
 crystalline reindex --full                          # rebuild the derived index from the files
@@ -381,6 +569,7 @@ files, ratio restored.
 
 ---
 
-That is the whole flight. Eight missions, one ship, an agent that now reads the
-log before it touches the clamps. Keep capturing, keep reconciling, retire what
-stops holding and share the rest. See you around, space cowboy.
+That is the whole flight: record what you learn, query it back, ingest by
+distilling, reconcile in place, retire without forgetting and share for review.
+Keep the log honest and the ship stops being a stranger to itself. See you around,
+space cowboy.

--- a/docs/playbook.md
+++ b/docs/playbook.md
@@ -45,13 +45,15 @@ terminal.
 Start a session and give the agent its first domain in plain language:
 
 ```text
-Set up a place for you to remember everything about this ship - the docking gear,
-the coolant loop, the vent drivers.
+Create a new Crystalline domain called ship-ops for everything about this ship -
+the docking gear, the coolant loop, the vent drivers.
 ```
 
-*The agent proposes a file domain named `ship-ops` under its domains root
+*The agent creates a file domain named `ship-ops` under its domains root
 (`~/Documents/Crystalline` by default), scaffolds its `MANIFEST.md` and registers
-it, confirming the name and location first.* The scaffold is a stub you fill in -
+it, confirming the location before it writes anything. Naming the domain yourself
+keeps the outcome predictable; leave the name out and the agent will propose one
+and ask.* The scaffold is a stub you fill in -
 its routing sections are what an agent reads each session to decide whether a task
 belongs here:
 
@@ -509,7 +511,7 @@ knowledge is worth the review.
 
 | To do this | Say to your agent |
 |---|---|
-| Commission a domain | "Set up a place to remember everything about the ship." |
+| Commission a domain | "Create a new Crystalline domain called ship-ops for everything about the ship." |
 | Capture a fact | "Remember this: the port clamp sticks in the cold." |
 | Recall, scoped | "What do we know about docking?" |
 | Recall, everywhere | "Any single points of failure we should worry about?" |


### PR DESCRIPTION
Third iteration of the playbook, redone on user direction: the course is now structured by clear use-cases with very clear examples that build on each other, and the sci-fi fun lives in the example data instead of chapter theming.

## What changed

- Chapters are plain use-cases that scan as a reference: Setup, Record, Query, Ingest, Reconcile, Retire, Share, then the appendix (cheatsheet, reference blocks, terminal corner). Mission numbering and per-chapter epigraphs are gone
- One cumulative dataset threads the whole course: the clamp gotcha and vent-driver firmware recorded in Record are what Query finds, the coolant decision recorded in Record is what Retire supersedes, the hyperdrive tag drift introduced in Ingest is what Reconcile merges and the clamp knowledge is what Share proposes to the fleet
- Every chapter from Record on shows its on-disk artifact - the actual engram markdown a capture writes (real emitter block-sequence tags, faithful MANIFEST scaffold), the before/after of a reconcile edit, the exact status flip and valid_to of a supersede and the ## Tag Aliases line a merge records. All shown artifacts are valid engram markdown; crystalline verify returns 0 errors on them
- The franchise references ride the data: a flux-capacitor firmware repo, raptor-paddock containment PDFs, a hyperdrive recall notice and a thermal exhaust port that is exactly the kind of single point of failure a broad risk query should surface
- Agent-first with natural-language prompts and truthful narration carried over from the previous round; the terminal still appears exactly once plus the optional terminal corner

Review ran two passes: the first found two cumulative-coherence bugs (a relation target the course never created, which would have failed verify, and a retire date preceding the record date) plus fidelity gaps between shown artifacts and what the emitter really writes - all fixed and re-review approved.