### PR TITLE
Hint at macOS privacy denials and stop scanning denied roots as empty

### DIFF
--- a/crates/cli/src/cmd.rs
+++ b/crates/cli/src/cmd.rs
@@ -325,7 +325,7 @@ pub(crate) async fn sync_domain_direct(
         let snapshot = store.file_stamps(domain).await?;
         (domain, snapshot)
     };
-    let scan = scan_domain(name, root, snapshot, &params).await;
+    let scan = scan_domain(name, root, snapshot, &params).await?;
     let store = store.lock().await;
     apply_scan(&*store, domain, scan)
         .await
@@ -861,7 +861,7 @@ pub async fn sync(
             let snapshot = store.file_stamps(domain).await?;
             (domain, snapshot)
         };
-        let scan = scan_domain(&name, &path, snapshot, &params).await;
+        let scan = scan_domain(&name, &path, snapshot, &params).await?;
         let report = {
             let store = store.lock().await;
             apply_scan(&*store, domain, scan)
@@ -949,7 +949,7 @@ pub async fn reindex(
             let snapshot = store.file_stamps(domain).await?;
             (domain, snapshot)
         };
-        let scan = scan_domain(name, path, snapshot, &params).await;
+        let scan = scan_domain(name, path, snapshot, &params).await?;
         let report = {
             let store = store.lock().await;
             apply_scan(&*store, domain, scan)

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -520,6 +520,37 @@ fn home_dir() -> Result<PathBuf, ConfigError> {
     etcetera::home_dir().map_err(|e| ConfigError::Home(e.to_string()))
 }
 
+/// The remediation text appended when macOS privacy protection is the likely
+/// cause of an io error. Kept to one sentence so every surface (an MCP tool
+/// error, the daemon log, the CLI) can carry it verbatim.
+const MACOS_PRIVACY_HINT: &str = "macOS privacy protection is likely blocking access to this folder - allow it in System Settings > Privacy & Security > Files and Folders for the app that runs Crystalline (for example Claude or your terminal) or grant that app Full Disk Access, then restart it";
+
+/// A suffix for io error displays when macOS privacy protection is the likely
+/// cause: the error is EPERM (os error 1, what TCC denials return, unlike the
+/// EACCES of plain permission bits) and the path sits in a protected user
+/// folder (Documents, Desktop, Downloads). Empty otherwise, so display
+/// attributes can append it unconditionally.
+pub fn io_hint_suffix(path: &str, source: &std::io::Error) -> String {
+    if cfg!(target_os = "macos")
+        && source.raw_os_error() == Some(1)
+        && let Ok(home) = home_dir()
+        && in_protected_folder(path, &home)
+    {
+        return format!("; {MACOS_PRIVACY_HINT}");
+    }
+    String::new()
+}
+
+/// Whether `path` sits inside one of the user folders macOS privacy
+/// protection guards. Component-wise prefix match, so `Documents-alt` never
+/// matches.
+fn in_protected_folder(path: &str, home: &std::path::Path) -> bool {
+    let p = std::path::Path::new(path);
+    ["Documents", "Desktop", "Downloads"]
+        .iter()
+        .any(|f| p.starts_with(home.join(f)))
+}
+
 // --- default paths -----------------------------------------------------------
 
 const APP: &str = "crystalline";
@@ -651,6 +682,38 @@ pub fn models_dir() -> Result<PathBuf, ConfigError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn protected_folder_detection_is_prefix_scoped() {
+        let home = Path::new("/Users/u");
+        assert!(in_protected_folder(
+            "/Users/u/Documents/Crystalline/x.md",
+            home
+        ));
+        assert!(in_protected_folder("/Users/u/Desktop/a", home));
+        assert!(in_protected_folder("/Users/u/Downloads/b", home));
+        assert!(!in_protected_folder("/Users/u/Projects/x.md", home));
+        assert!(!in_protected_folder("/Users/u/Documents-alt/x.md", home));
+        assert!(!in_protected_folder("/tmp/Documents/x.md", home));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn eperm_under_documents_earns_the_privacy_hint() {
+        let docs = crate::config::expand_tilde("~/Documents/Crystalline/kb/x.md");
+        let path = docs.to_string_lossy();
+        let eperm = std::io::Error::from_raw_os_error(1);
+        let suffix = io_hint_suffix(&path, &eperm);
+        assert!(
+            suffix.contains("Files and Folders"),
+            "hint expected: {suffix}"
+        );
+        // EACCES is a plain permission problem, not privacy protection.
+        let eacces = std::io::Error::from_raw_os_error(13);
+        assert_eq!(io_hint_suffix(&path, &eacces), "");
+        // EPERM outside a protected folder gets no hint.
+        assert_eq!(io_hint_suffix("/tmp/x.md", &eperm), "");
+    }
 
     #[test]
     fn database_absent_defaults_to_turso() {

--- a/crates/index/src/error.rs
+++ b/crates/index/src/error.rs
@@ -34,7 +34,7 @@ pub enum IndexError {
     #[error("json error: {0}")]
     Json(String),
     /// A filesystem error during sync.
-    #[error("io error at {path}: {source}")]
+    #[error("io error at {path}: {source}{}", crystalline_core::config::io_hint_suffix(.path, .source))]
     Io {
         /// The path involved.
         path: String,
@@ -108,5 +108,23 @@ impl From<sqlx::Error> for IndexError {
 impl From<reqwest::Error> for IndexError {
     fn from(e: reqwest::Error) -> Self {
         IndexError::Remote(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn io_display_carries_the_privacy_hint_for_eperm_under_documents() {
+        let path = crystalline_core::config::expand_tilde("~/Documents/x")
+            .to_string_lossy()
+            .to_string();
+        let e = IndexError::Io {
+            path,
+            source: std::io::Error::from_raw_os_error(1),
+        };
+        assert!(e.to_string().contains("Files and Folders"), "{e}");
     }
 }

--- a/crates/index/src/error.rs
+++ b/crates/index/src/error.rs
@@ -111,11 +111,12 @@ impl From<reqwest::Error> for IndexError {
     }
 }
 
-#[cfg(test)]
+// The whole module is macos-gated, not just the test: on other platforms a
+// gated-out lone test would leave `use super::*` dangling and fail clippy.
+#[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;
 
-    #[cfg(target_os = "macos")]
     #[test]
     fn io_display_carries_the_privacy_hint_for_eperm_under_documents() {
         let path = crystalline_core::config::expand_tilde("~/Documents/x")

--- a/crates/index/src/sync.rs
+++ b/crates/index/src/sync.rs
@@ -139,7 +139,7 @@ pub async fn sync_domain_with<S: Store + ?Sized>(
         )
         .await?;
     let stamps = store.file_stamps(domain).await?;
-    let scan = scan_domain(name, root, stamps, chunk_params).await;
+    let scan = scan_domain(name, root, stamps, chunk_params).await?;
     apply_scan(store, domain, scan).await
 }
 
@@ -183,7 +183,7 @@ pub async fn scan_domain(
     root: &Path,
     stamps: HashMap<String, FileStamp>,
     chunk_params: &ChunkParams,
-) -> DomainScan {
+) -> Result<DomainScan> {
     let started = Instant::now();
 
     // Folders the MANIFEST provisions from inside this root hold deployable
@@ -206,6 +206,20 @@ pub async fn scan_domain(
     {
         let entry = match entry {
             Ok(e) => e,
+            // The walk root itself being unreadable is a domain-level
+            // failure: scanning on would see zero files and mark every
+            // recorded engram deleted, so a denied root errors loudly
+            // instead of emptying the index.
+            Err(err) if err.depth() == 0 => {
+                let msg = err.to_string();
+                let source = err
+                    .into_io_error()
+                    .unwrap_or_else(|| std::io::Error::other(msg));
+                return Err(IndexError::Io {
+                    path: root.display().to_string(),
+                    source,
+                });
+            }
             Err(_) => continue,
         };
         if !entry.file_type().is_file() {
@@ -242,16 +256,17 @@ pub async fn scan_domain(
         .cloned()
         .collect();
 
-    classify_and_parse(
+    Ok(classify_and_parse(
         name,
         root,
         stamps,
         current,
         deleted_paths,
+        Vec::new(),
         chunk_params,
         started,
     )
-    .await
+    .await)
 }
 
 /// Scan a specific list of relative paths against a stamp snapshot, the
@@ -295,6 +310,7 @@ pub async fn scan_paths(
 
     let mut current: HashMap<String, Scanned> = HashMap::new();
     let mut deleted_paths: Vec<String> = Vec::new();
+    let mut unreadable: Vec<(String, String)> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
     for rel in paths {
         // The same path can arrive twice in one debounce batch; classify it once.
@@ -329,13 +345,18 @@ pub async fn scan_paths(
             // non-markdown file, a hidden or artifact path): ignore it, matching
             // the walk which never indexes it either.
             Ok(_) => {}
-            // Absent on disk: a recorded path is a delete candidate (scoped to
-            // the given paths, no walk), an unrecorded one is a no-op.
-            Err(_) => {
+            // Not found on disk: a recorded path is a delete candidate (scoped
+            // to the given paths, no walk), an unrecorded one is a no-op.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 if stamps.contains_key(&rel) {
                     deleted_paths.push(rel);
                 }
             }
+            // Any other metadata error (a denied parent, an io fault) means the
+            // path is unreadable, not gone: reporting it as failed keeps the row
+            // instead of dropping an engram that is still there but momentarily
+            // unreadable, the targeted counterpart of the walk-root guard.
+            Err(e) => unreadable.push((rel, e.to_string())),
         }
     }
 
@@ -345,6 +366,7 @@ pub async fn scan_paths(
         stamps,
         current,
         deleted_paths,
+        unreadable,
         chunk_params,
         started,
     )
@@ -370,12 +392,18 @@ async fn classify_and_parse(
     stamps: HashMap<String, FileStamp>,
     current: HashMap<String, Scanned>,
     deleted_paths: Vec<String>,
+    unreadable: Vec<(String, String)>,
     chunk_params: &ChunkParams,
     started: Instant,
 ) -> DomainScan {
     // Prefilter: unchanged files (same mtime and size) are skipped entirely.
     let mut report = SyncReport {
         domain: name.to_string(),
+        // Paths that could not be stat'd (a denied parent, an io fault) are
+        // failures the caller already collected: fold them in up front, then
+        // the hashing and parsing phases append their own read and parse
+        // failures to the same list.
+        failed: unreadable,
         ..SyncReport::default()
     };
     let mut to_hash: Vec<Scanned> = Vec::new();

--- a/crates/index/tests/sync_phases.rs
+++ b/crates/index/tests/sync_phases.rs
@@ -141,7 +141,7 @@ async fn concurrent_write_defers(store: &dyn Store) {
     let domain = upsert_domain(store, "d", root).await;
     let snapshot = store.file_stamps(domain).await.unwrap();
     assert!(snapshot.is_empty(), "nothing indexed yet");
-    let scan = scan_domain("d", root, snapshot, &params()).await;
+    let scan = scan_domain("d", root, snapshot, &params()).await.unwrap();
 
     // A concurrent writer indexes the same path with different content between
     // the snapshot and the apply.
@@ -191,7 +191,7 @@ async fn concurrent_rewrite_skips_delete(store: &dyn Store) {
     std::fs::remove_file(root.join("a.md")).unwrap();
     let snapshot = store.file_stamps(domain).await.unwrap();
     assert!(snapshot.contains_key("a.md"), "a.md still recorded");
-    let scan = scan_domain("d", root, snapshot, &params()).await;
+    let scan = scan_domain("d", root, snapshot, &params()).await.unwrap();
 
     // A concurrent writer rewrites the row (a new stamp) mid-window.
     store
@@ -230,7 +230,7 @@ async fn recreated_file_skips_delete(store: &dyn Store) {
     // can catch this.
     std::fs::remove_file(root.join("a.md")).unwrap();
     let snapshot = store.file_stamps(domain).await.unwrap();
-    let scan = scan_domain("d", root, snapshot, &params()).await;
+    let scan = scan_domain("d", root, snapshot, &params()).await.unwrap();
     write(root, "a.md", &engram("A", "a", "recreated body"));
 
     let report = apply_scan(store, domain, scan).await.unwrap();
@@ -260,7 +260,7 @@ async fn move_with_moved_end_defers(store: &dyn Store) {
     // move.
     std::fs::rename(root.join("old.md"), root.join("new.md")).unwrap();
     let snapshot = store.file_stamps(domain).await.unwrap();
-    let scan = scan_domain("d", root, snapshot, &params()).await;
+    let scan = scan_domain("d", root, snapshot, &params()).await.unwrap();
 
     // A concurrent writer mutates the move's `from` end mid-window.
     store
@@ -342,3 +342,58 @@ parity!(
     the_composition_is_identical_when_uncontended,
     composition_identical_uncontended
 );
+
+/// A denied domain root is a loud per-domain error, not a silent empty scan: a
+/// full scan of an unreadable root returns an io error and the recorded rows
+/// survive, rather than the scan seeing zero files and the apply deleting them.
+#[cfg(unix)]
+mod unreadable_root {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn full_scan_of_an_unreadable_root_errors_and_keeps_the_rows() {
+        let store = TursoStore::open_in_memory().await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "a.md", &engram("A", "a", "keepme body"));
+
+        let seeded = sync_domain_with(&store, "d", root, &params())
+            .await
+            .unwrap();
+        assert_eq!(seeded.added, 1, "the seed indexed the file");
+        let domain = upsert_domain(&store, "d", root).await;
+        assert!(
+            store
+                .file_stamps(domain)
+                .await
+                .unwrap()
+                .contains_key("a.md"),
+            "the row exists after the seed sync"
+        );
+
+        // Deny the root so the walk cannot read its entries.
+        std::fs::set_permissions(root, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let result = sync_domain_with(&store, "d", root, &params()).await;
+        // Restore before any assertion can unwind past the tempdir drop.
+        std::fs::set_permissions(root, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let err = result.expect_err("an unreadable root must error, not scan empty");
+        let msg = err.to_string();
+        assert!(msg.contains("io error at"), "io error expected: {msg}");
+        assert!(
+            msg.contains(&root.display().to_string()),
+            "the root path is named: {msg}"
+        );
+        // The scan errored before the apply, so the row was never deleted.
+        assert!(
+            store
+                .file_stamps(domain)
+                .await
+                .unwrap()
+                .contains_key("a.md"),
+            "the row survives a denied scan"
+        );
+    }
+}

--- a/crates/index/tests/sync_targeted.rs
+++ b/crates/index/tests/sync_targeted.rs
@@ -314,3 +314,52 @@ parity!(
     rows_outside_the_targeted_batch_are_untouched,
     outside_batch_untouched
 );
+
+/// An unreadable targeted path is a reported failure, not a delete: a metadata
+/// error other than "not found" keeps the row in the index and surfaces the
+/// path in the report's `failed` list instead of dropping it.
+#[cfg(unix)]
+mod unreadable_path {
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn targeted_scan_of_an_unreadable_path_reports_failure_and_keeps_the_row() {
+        let store = TursoStore::open_in_memory().await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        write(root, "sub/a.md", &engram("A", "a", "keepme body"));
+
+        let seeded = sync_domain_with(&store, "d", root, &params())
+            .await
+            .unwrap();
+        assert_eq!(seeded.added, 1, "the seed indexed the file");
+        let domain = upsert_domain(&store, "d", root).await;
+
+        // Deny the subfolder so the file's metadata cannot be stat'd.
+        let sub = root.join("sub");
+        std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let snapshot = store.file_stamps(domain).await.unwrap();
+        let scan = scan_paths("d", root, snapshot, vec!["sub/a.md".to_string()], &params()).await;
+        let report = apply_scan(&store, domain, scan).await.unwrap();
+
+        // Restore before any assertion can unwind past the tempdir drop.
+        std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(
+            report.failed.iter().any(|(p, _)| p == "sub/a.md"),
+            "the unreadable path is reported as failed: {report:?}"
+        );
+        assert_eq!(report.deleted, 0, "an unreadable path is not a delete");
+        assert!(
+            store
+                .file_stamps(domain)
+                .await
+                .unwrap()
+                .contains_key("sub/a.md"),
+            "the row survives an unreadable targeted path"
+        );
+    }
+}

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -155,11 +155,12 @@ impl From<crystalline_index::IndexError> for EngineError {
     }
 }
 
-#[cfg(test)]
+// The whole module is macos-gated, not just the test: on other platforms a
+// gated-out lone test would leave `use super::*` dangling and fail clippy.
+#[cfg(all(test, target_os = "macos"))]
 mod error_tests {
     use super::*;
 
-    #[cfg(target_os = "macos")]
     #[test]
     fn io_display_carries_the_privacy_hint_for_eperm_under_documents() {
         let path = crystalline_core::config::expand_tilde("~/Documents/x")

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -107,7 +107,7 @@ pub enum EngineError {
     )]
     EnvTokenConnect,
     /// A filesystem error.
-    #[error("io error at {path}: {source}")]
+    #[error("io error at {path}: {source}{}", crystalline_core::config::io_hint_suffix(.path, .source))]
     Io {
         /// The path involved.
         path: String,
@@ -152,6 +152,24 @@ impl From<crystalline_index::IndexError> for EngineError {
             }
             other => EngineError::Internal(other.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod error_tests {
+    use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn io_display_carries_the_privacy_hint_for_eperm_under_documents() {
+        let path = crystalline_core::config::expand_tilde("~/Documents/x")
+            .to_string_lossy()
+            .to_string();
+        let e = EngineError::Io {
+            path,
+            source: std::io::Error::from_raw_os_error(1),
+        };
+        assert!(e.to_string().contains("Files and Folders"), "{e}");
     }
 }
 

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -2838,6 +2838,7 @@ impl Engine {
         let collab = !self.instance_id.is_empty();
         let mut reports = Vec::new();
         let mut skipped = Vec::new();
+        let mut failed = Vec::new();
         // Two short store-lock windows per domain with the scan in between, so the
         // walk-hash-parse pass of a large domain no longer blocks every concurrent
         // read behind the mutex. The first window claims the host, resolves the
@@ -2878,7 +2879,18 @@ impl Engine {
                 let snapshot = store.file_stamps(domain).await?;
                 (domain, snapshot)
             };
-            let scan = scan_domain(name, root, snapshot, &self.chunk_params).await;
+            let scan = match scan_domain(name, root, snapshot, &self.chunk_params).await {
+                Ok(scan) => scan,
+                Err(e) if only.is_none() => {
+                    // One denied domain must not block the rest of the
+                    // sweep; its error is carried in the result and the
+                    // daemon log, and the next sync retries it.
+                    tracing::warn!("sync of '{name}' skipped: {e}");
+                    failed.push(json!({ "domain": name, "error": e.to_string() }));
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            };
             let report = {
                 let store = self.store.lock().await;
                 apply_scan(&*store, domain, scan)
@@ -2890,6 +2902,7 @@ impl Engine {
         Ok(json!({
             "reports": serde_json::to_value(&reports).unwrap_or(Value::Null),
             "skipped": skipped,
+            "failed": failed,
         }))
     }
 
@@ -2993,7 +3006,7 @@ impl Engine {
                 let snapshot = store.file_stamps(domain).await?;
                 (domain, snapshot)
             };
-            let scan = scan_domain(&name, &root, snapshot, &self.chunk_params).await;
+            let scan = scan_domain(&name, &root, snapshot, &self.chunk_params).await?;
             let report = {
                 let store = self.store.lock().await;
                 apply_scan(&*store, domain, scan).await.map_err(|e| {

--- a/crates/service/tests/sync_denied.rs
+++ b/crates/service/tests/sync_denied.rs
@@ -1,0 +1,82 @@
+//! The full sweep contains a domain whose root cannot be read: one denied
+//! domain lands in `failed`, its neighbor still syncs and a named sync of the
+//! denied domain surfaces the error rather than silently emptying its index.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::sync::Arc;
+
+use crystalline_core::config::{DomainEntry, GlobalConfig};
+use crystalline_index::TursoStore;
+use crystalline_service::Engine;
+use tokio::sync::Mutex;
+
+fn engram(title: &str, permalink: &str, body: &str) -> String {
+    format!(
+        "---\ntype: engram\ntitle: {title}\npermalink: {permalink}\ntags:\n  - t\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# {title}\n\n{body}\n"
+    )
+}
+
+fn seed_domain(dir: &std::path::Path, token: &str) {
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(dir.join("a.md"), engram("A", "a", token)).unwrap();
+}
+
+#[tokio::test]
+async fn full_sweep_continues_past_a_denied_domain() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a_dir = tmp.path().join("a");
+    let b_dir = tmp.path().join("b");
+    seed_domain(&a_dir, "alpha body");
+    seed_domain(&b_dir, "beta body");
+
+    let mut cfg = GlobalConfig::default();
+    cfg.domains
+        .insert("a".to_string(), DomainEntry::file(a_dir.clone()));
+    cfg.domains
+        .insert("b".to_string(), DomainEntry::file(b_dir.clone()));
+
+    let store = TursoStore::open_in_memory().await.unwrap();
+    let engine = Engine::new(Arc::new(Mutex::new(store)), cfg, None, None);
+
+    // Both domains sync cleanly the first time.
+    engine.sync(None).await.unwrap();
+
+    // Deny domain A's root so its walk cannot read its entries.
+    std::fs::set_permissions(&a_dir, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    // The full sweep must contain A's failure and still report B; a named sync of
+    // the denied domain must surface the error.
+    let swept = engine.sync(None).await;
+    let named = engine.sync(Some("a")).await;
+
+    // Restore before any assertion can unwind past the tempdir drop.
+    std::fs::set_permissions(&a_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    let swept = swept.expect("a full sweep past a denied domain is Ok");
+    let failed = swept["failed"]
+        .as_array()
+        .expect("the sweep result carries a failed array");
+    assert!(
+        failed.iter().any(|f| f["domain"] == "a"
+            && f["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("io error at")),
+        "A is listed under failed with an io error: {swept}"
+    );
+    let reports = swept["reports"]
+        .as_array()
+        .expect("the sweep result carries a reports array");
+    assert!(
+        reports.iter().any(|r| r["domain"] == "b"),
+        "B still synced during the sweep: {swept}"
+    );
+
+    let named = named.expect_err("a named sync of a denied domain must error");
+    assert!(
+        named.to_string().contains("io error at"),
+        "the named sync error carries the io error: {named}"
+    );
+}


### PR DESCRIPTION
Field incident follow-up: a macOS user denied the Files and Folders privacy prompt for the app hosting Crystalline, the daemon got EPERM under ~/Documents/Crystalline and two things went wrong: the surfaced error was a bare "Operation not permitted (os error 1)" with no remediation, and every startup sync silently emptied the denied domains' index rows because the scan swallows walk errors and an empty scan reads as "everything was deleted".

## What changed

- io error displays (`EngineError::Io` and `IndexError::Io`) append a remediation hint when the error is EPERM on macOS under a privacy-protected user folder (Documents, Desktop, Downloads): allow access in System Settings > Privacy & Security > Files and Folders for the app that runs Crystalline or grant it Full Disk Access, then restart it. EACCES and paths outside protected folders never get the hint
- `scan_domain` now errors on an unreadable walk root instead of scanning empty, so a denied root can no longer delete a domain's index rows. The daemon's full sync sweep contains the error per domain (new `failed` array in the sync result, warning in the daemon log) and keeps syncing healthy domains; a named sync propagates it loudly
- The targeted watcher scan treats only NotFound as a delete candidate; any other metadata error lands in the report's failed list and the row survives

Files on disk were never at risk (they are the source of truth); a denied domain's index self-heals on the first sync after access is granted.

## Tests

Pure hint-detection tests, macOS-gated display tests, and unix-gated integration tests: unreadable root errors and keeps rows, unreadable targeted path reports failure and keeps rows, full sweep continues past one denied domain while a named sync errors.
