### PR TITLE
Onboard remote clients through list_domains and a connector snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Engrams written through Crystalline are indexed immediately; `crystalline sync` 
 
 Every MCP client is onboarded automatically: the crystalline server's instructions, returned when a client connects, carry a live routing block - one line per registered domain summarizing when to use it, plus the behavior rules (narrow question -> search that domain; broad question -> sweep all of them; writes always name a domain explicitly). The block names the exact crystalline tools each rule refers to (`search_engrams`, `write_engram` and the rest), so an agent with several MCP servers connected knows which tool on which server to call. Domain lists and file-domain MANIFESTs are read fresh for every new connection; virtual-domain routing lines follow the daemon's latest snapshot, refreshed on every stdio connection and on every local virtual write. Claude Desktop and any harness that shows the model its MCP server instructions need no further setup.
 
-The same routing block is available outside MCP: `crystalline prompt system` renders it to stdout from every registered domain's `MANIFEST.md`, to feed to an agent as session context. Over MCP there is no workspace, so `prompt.rules` filters and repo-local `preferred_domains` apply only on this path - `crystalline prompt system --workspace .` scopes it to the current repository. `prompt` takes a subcommand naming the kind of prompt to generate; `system` is the only kind today.
+The same routing block is available outside MCP: `crystalline prompt system` renders it to stdout from every registered domain's `MANIFEST.md`, to feed to an agent as session context. Over MCP there is no workspace, so `prompt.rules` filters and repo-local `preferred_domains` apply only on this path - `crystalline prompt system --workspace .` scopes it to the current repository. `prompt` takes a subcommand naming the kind of prompt to generate: `system` for hook-driven harnesses, `connector` for the snippet below.
 
 The generic harness recipe: run `crystalline prompt system` at session start and inject its stdout as context before the agent does anything else. In Claude Code that is a `SessionStart` hook in `settings.json`, matched on `startup|clear|compact` so the routing block is re-injected after `/clear` and after a compaction as well as on a fresh start (a resumed session is deliberately excluded, since its transcript already carries the earlier routing block). [Get started](#get-started) covers `crystalline install`, which writes this hook for you; by hand it is:
 
@@ -191,6 +191,16 @@ The generic harness recipe: run `crystalline prompt system` at session start and
 ```
 
 Any harness with an equivalent session-start hook can run the same command the same way.
+
+### Remote clients
+
+A remote service or a chat harness runs no session hooks, and most of them never show the model an MCP server's instructions, so neither onboarding path above reaches the agent. Give it a standing instruction instead: paste this into the client's custom instructions and the agent onboards itself with one tool call at the start of every session.
+
+```text
+This environment includes the Crystalline knowledge server over MCP. At the start of every session call its list_domains tool with include_routing set to true; the result is your onboarding: one routing line per knowledge domain plus the behavior rules for this server's tools. Follow it, search those domains before answering from memory and re-fetch the index mid-session with the same call whenever you need it again.
+```
+
+`crystalline prompt connector` prints the same snippet, ready to copy.
 
 ### The learning loop
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -520,8 +520,10 @@ enum HookEvent {
     Stop,
 }
 
-/// The kind of prompt to generate. `system` is the only kind today; future
-/// kinds attach here without reshaping the `prompt` command again.
+/// The kind of prompt to generate: `system` renders the live routing block for
+/// a hook-driven harness, `connector` prints the static snippet a remote client
+/// takes as standing custom instructions. Future kinds attach here without
+/// reshaping the `prompt` command again.
 #[derive(Subcommand, Debug)]
 enum PromptKind {
     /// Generate the knowledge routing prompt for a workspace: registered
@@ -545,6 +547,13 @@ enum PromptKind {
         #[arg(long, value_enum)]
         format: Option<PromptFormat>,
     },
+    /// Print the standing onboarding snippet for a remote MCP client: paste it
+    /// into the client's custom instructions and the agent onboards itself
+    /// through `list_domains` on every session. The text is static, so this
+    /// reads no config and touches no database: deterministic and instant,
+    /// satisfying the prompt module's determinism and latency contracts by
+    /// construction.
+    Connector,
 }
 
 /// How `prompt system` renders its output. `Text` and `Json` are the two
@@ -980,6 +989,7 @@ fn main() -> anyhow::Result<()> {
                 config,
                 format,
             } => run_prompt(workspace, read_only, config, cli.db, cli.json, format),
+            PromptKind::Connector => run_prompt_connector(cli.json),
         },
         Some(Command::Domain { command }) => run_domain(command, cli.db, cli.json),
         Some(Command::Tags { command }) => on_runtime(move || run_tags(command, cli.db, cli.json)),
@@ -2481,6 +2491,26 @@ fn run_verify(
     }
 
     std::process::exit(report.exit_code());
+}
+
+/// Print the static connector snippet, plain or wrapped in the same
+/// `{version, kind, text}` envelope shape `--json` uses elsewhere. Nothing is
+/// loaded, reconciled or read: the copy is a constant, so the command answers
+/// identically on a machine with no config at all.
+fn run_prompt_connector(json: bool) -> anyhow::Result<()> {
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "version": 1,
+                "kind": "connector",
+                "text": crystalline_core::CONNECTOR_SNIPPET,
+            })
+        );
+    } else {
+        println!("{}", crystalline_core::CONNECTOR_SNIPPET);
+    }
+    Ok(())
 }
 
 fn run_prompt(

--- a/crates/cli/tests/prompt.rs
+++ b/crates/cli/tests/prompt.rs
@@ -275,6 +275,81 @@ fn bare_prompt_without_a_kind_fails_with_subcommand_help() {
         .stderr(predicate::str::contains("system"));
 }
 
+/// The connector snippet is the standing instruction a remote client pastes
+/// into its custom instructions: static copy, printed as one paragraph.
+#[test]
+fn prompt_connector_matches_snapshot() {
+    let output = Command::cargo_bin("crystalline")
+        .unwrap()
+        .args(["prompt", "connector"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let text = String::from_utf8(output).unwrap();
+    assert!(
+        text.contains("include_routing"),
+        "the snippet must point at the onboarding call:\n{text}"
+    );
+    insta::assert_snapshot!(text);
+}
+
+#[test]
+fn prompt_connector_json_matches_snapshot() {
+    let output = Command::cargo_bin("crystalline")
+        .unwrap()
+        .args(["prompt", "connector", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let line = String::from_utf8(output).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(parsed["kind"], "connector");
+    insta::assert_snapshot!(line);
+}
+
+/// Determinism contract: the snippet is a constant, so two separate
+/// invocations must agree byte for byte.
+#[test]
+fn prompt_connector_is_byte_identical_across_invocations() {
+    let run = || {
+        Command::cargo_bin("crystalline")
+            .unwrap()
+            .args(["prompt", "connector"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone()
+    };
+
+    assert_eq!(
+        run(),
+        run(),
+        "crystalline prompt connector must produce byte-identical stdout across separate process invocations"
+    );
+}
+
+/// The snippet is what a user reaches for before anything is configured, so
+/// the command must answer from a directory with no config at all.
+#[test]
+fn prompt_connector_works_with_no_config() {
+    let tmp = tempfile::tempdir().unwrap();
+    Command::cargo_bin("crystalline")
+        .unwrap()
+        .current_dir(tmp.path())
+        .env("CRYSTALLINE_CONFIG", tmp.path().join("config.yaml"))
+        .args(["prompt", "connector"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("list_domains"));
+}
+
 /// Latency contract, part (c): a CI-safe guard, generous against runner
 /// noise, that `prompt system` stays well under budget even at 30 scaffolded
 /// domains. The real target (under 50ms wall-clock in a release build) is

--- a/crates/cli/tests/snapshots/prompt__prompt_connector_json_matches_snapshot.snap
+++ b/crates/cli/tests/snapshots/prompt__prompt_connector_json_matches_snapshot.snap
@@ -1,0 +1,5 @@
+---
+source: crates/cli/tests/prompt.rs
+expression: line
+---
+{"kind":"connector","text":"This environment includes the Crystalline knowledge server over MCP. At the start of every session call its list_domains tool with include_routing set to true; the result is your onboarding: one routing line per knowledge domain plus the behavior rules for this server's tools. Follow it, search those domains before answering from memory and re-fetch the index mid-session with the same call whenever you need it again.","version":1}

--- a/crates/cli/tests/snapshots/prompt__prompt_connector_matches_snapshot.snap
+++ b/crates/cli/tests/snapshots/prompt__prompt_connector_matches_snapshot.snap
@@ -1,0 +1,5 @@
+---
+source: crates/cli/tests/prompt.rs
+expression: text
+---
+This environment includes the Crystalline knowledge server over MCP. At the start of every session call its list_domains tool with include_routing set to true; the result is your onboarding: one routing line per knowledge domain plus the behavior rules for this server's tools. Follow it, search those domains before answering from memory and re-fetch the index mid-session with the same call whenever you need it again.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,8 +43,8 @@ pub use manifest::{
 };
 pub use parse::{LosslessEngram, ParseError, parse_engram, parse_engram_lossless};
 pub use prompt::{
-    PromptDomain, PromptOutput, generate_prompt, generate_prompt_unscoped, render_instructions,
-    render_json, render_text,
+    CONNECTOR_SNIPPET, PromptDomain, PromptOutput, behavior_bullets, generate_prompt,
+    generate_prompt_unscoped, render_instructions, render_json, render_text,
 };
 pub use provision::{
     ActionStatus, Agent, ArtifactAction, ArtifactFile, Command, DeferringMcpRunner, DesiredFile,

--- a/crates/core/src/prompt.rs
+++ b/crates/core/src/prompt.rs
@@ -364,38 +364,62 @@ fn render_routing_body(
     }
 
     out.push_str("Behavior:\n");
-    out.push_str(
-        "- Narrow question, one domain clearly fits: search_engrams with domains=[that domain].\n",
-    );
-    out.push_str(
-        "- Broad or unclear question: search_engrams without domains is an all-domain sweep.\n",
-    );
-    if output.read_only {
+    for bullet in behavior_bullets(output.read_only) {
+        let _ = writeln!(out, "- {bullet}");
+    }
+}
+
+/// The behavior rules an agent follows when working with this server's tools,
+/// one string per rule, without the leading `- ` and without a trailing
+/// newline. The read-only set drops the four content-mutating tools and the
+/// capture language; the read-write set names them.
+///
+/// This is the single source of the rule set: [`render_routing_body`] renders
+/// it as the Behavior block of both onboarding renderers, and the MCP
+/// `list_domains` response returns it verbatim for remote clients that never
+/// see the initialize instructions. Both paths therefore teach exactly the
+/// same rules and the set can never drift between them.
+pub fn behavior_bullets(read_only: bool) -> Vec<String> {
+    let mut bullets = vec![
+        "Narrow question, one domain clearly fits: search_engrams with domains=[that domain]."
+            .to_string(),
+        "Broad or unclear question: search_engrams without domains is an all-domain sweep."
+            .to_string(),
+    ];
+    if read_only {
         // Read-only variant: no write-tools line and no capture language; the
         // knowledge is maintained outside this deployment.
-        out.push_str(
-            "- This deployment's knowledge is read-only and curated externally; search and read to learn and do not attempt to capture or change anything.\n",
+        bullets.push(
+            "This deployment's knowledge is read-only and curated externally; search and read to learn and do not attempt to capture or change anything."
+                .to_string(),
         );
     } else {
-        out.push_str(
-            "- write_engram, edit_engram, move_engram and delete_engram always require an explicit domain; there is no default domain for writes.\n",
+        bullets.push(
+            "write_engram, edit_engram, move_engram and delete_engram always require an explicit domain; there is no default domain for writes."
+                .to_string(),
         );
-        out.push_str(
-            "- Match the domain's folder layout when writing: write_engram's folder files an engram under a topic prefix that build_context can glob; start a subfolder when a topic clusters, keep singletons at the root.\n",
+        bullets.push(
+            "Match the domain's folder layout when writing: write_engram's folder files an engram under a topic prefix that build_context can glob; start a subfolder when a topic clusters, keep singletons at the root."
+                .to_string(),
         );
-        out.push_str(
-            "- vocabulary lists tags and categories already in use; check it before inventing a new tag.\n",
+        bullets.push(
+            "vocabulary lists tags and categories already in use; check it before inventing a new tag."
+                .to_string(),
         );
-        out.push_str(
-            "- Mark exceptionally valuable knowledge with a numeric salience (0-10) at write time; salient engrams rank higher in search. Raise the salience of an engram that turned out to be the key to a task.\n",
+        bullets.push(
+            "Mark exceptionally valuable knowledge with a numeric salience (0-10) at write time; salient engrams rank higher in search. Raise the salience of an engram that turned out to be the key to a task."
+                .to_string(),
         );
     }
-    out.push_str(
-        "- build_context on a crystalline:// anchor assembles related knowledge around a task.\n",
+    bullets.push(
+        "build_context on a crystalline:// anchor assembles related knowledge around a task."
+            .to_string(),
     );
-    out.push_str(
-        "- Read a domain's MANIFEST via read_engram only when its routing line above is not enough; list_domains with include_routing=true re-fetches this index mid-session.\n",
+    bullets.push(
+        "Read a domain's MANIFEST via read_engram only when its routing line above is not enough; list_domains with include_routing=true re-fetches this index mid-session."
+            .to_string(),
     );
+    bullets
 }
 
 /// Render the onboarding block for the MCP `instructions` channel: the same
@@ -406,26 +430,40 @@ fn render_routing_body(
 /// This is the block a server hands the model at initialize, so the intro
 /// frames the tools as this server's own (the harness may prefix their names)
 /// rather than assuming a workspace context: there is no workspace over MCP, so
-/// `prompt.rules` and `preferred_domains` never shaped this output. The
-/// read-write intro tells the agent to read, write and refine engrams and to
-/// search before writing; the read-only intro states the knowledge is curated
-/// and drops the write sentence. The shared body then handles read-only tool
-/// dropping and the `list_domains include_routing=true` re-fetch.
+/// `prompt.rules` and `preferred_domains` never shaped this output. Both intros
+/// are compressed so that the first 512 bytes of the rendered block stand on
+/// their own: a client that truncates the instructions still reads what
+/// Crystalline is, that searching these domains comes before answering from
+/// memory and that `list_domains` with `include_routing=true` re-fetches the
+/// whole index and its behavior rules at any time. The read-write intro adds
+/// the write and refine language and the search-before-you-write rule; the
+/// read-only intro states the knowledge is curated and drops both. The shared
+/// body then handles read-only tool dropping and repeats the re-fetch rule.
 pub fn render_instructions(output: &PromptOutput) -> String {
     let mut out = String::new();
     out.push_str("CRYSTALLINE KNOWLEDGE ROUTING\n\n");
     if output.read_only {
         out.push_str(
-            "Crystalline gives you durable memory across sessions: the domains below hold curated knowledge as engrams you search and read while you work. These instructions govern this server's tools (your harness may prefix their names, for example mcp__crystalline__search_engrams). Route searches and reads through these domains instead of starting from zero.\n\n",
+            "Crystalline gives you durable memory across sessions: the domains below hold curated knowledge as engrams you search and read while you work (your harness may prefix tool names, for example mcp__crystalline__search_engrams). Search these domains before answering from memory; list_domains with include_routing=true returns this full index and its behavior rules at any time.\n\n",
         );
     } else {
         out.push_str(
-            "Crystalline gives you durable memory across sessions: the domains below hold knowledge as engrams you read, write and refine while you work. These instructions govern this server's tools (your harness may prefix their names, for example mcp__crystalline__search_engrams). Route searches and reads through these domains instead of starting from zero and search before you write.\n\n",
+            "Crystalline gives you durable memory across sessions: the domains below hold knowledge as engrams you read, write and refine while you work (your harness may prefix tool names, for example mcp__crystalline__search_engrams). Search these domains before answering from memory and search before you write; list_domains with include_routing=true returns this full index and its behavior rules at any time.\n\n",
         );
     }
     render_routing_body(output, 3, "(no domains are registered yet)", &mut out);
     out
 }
+
+/// The paste-able custom-instructions snippet for remote clients whose harness
+/// runs no session hooks and never shows the model a server's initialize
+/// instructions: a standing instruction that points the agent at the one tool
+/// call which onboards it.
+///
+/// It is deliberately static and content-free - it names no domain, no count
+/// and no setting - so it can never go stale in a place Crystalline cannot
+/// update. All dynamic routing comes from the `list_domains` call it points at.
+pub const CONNECTOR_SNIPPET: &str = "This environment includes the Crystalline knowledge server over MCP. At the start of every session call its list_domains tool with include_routing set to true; the result is your onboarding: one routing line per knowledge domain plus the behavior rules for this server's tools. Follow it, search those domains before answering from memory and re-fetch the index mid-session with the same call whenever you need it again.";
 
 #[derive(Serialize)]
 struct JsonPromptDomain<'a> {
@@ -715,6 +753,30 @@ mod tests {
         // The read tools an agent still needs are named.
         assert!(text.contains("search_engrams"));
         assert!(text.contains("build_context"));
+    }
+
+    /// A remote client may truncate the instructions it shows the model, so
+    /// the head of the block has to stand on its own: the fallback that
+    /// re-fetches the whole index must be inside the first 512 bytes in both
+    /// modes, even with no domain registered at all.
+    #[test]
+    fn render_instructions_first_512_bytes_carry_the_fallback_call() {
+        let global = GlobalConfig::default();
+        let mut output = generate_prompt_unscoped(&global, &BTreeMap::new());
+        assert!(output.domains.is_empty());
+        for read_only in [false, true] {
+            output.read_only = read_only;
+            let text = render_instructions(&output);
+            let head = std::str::from_utf8(&text.as_bytes()[..512.min(text.len())]).unwrap();
+            assert!(
+                head.contains("list_domains"),
+                "read_only={read_only}: list_domains expected in the first 512 bytes:\n{head}"
+            );
+            assert!(
+                head.contains("include_routing=true"),
+                "read_only={read_only}: include_routing=true expected in the first 512 bytes:\n{head}"
+            );
+        }
     }
 
     #[test]

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -2246,6 +2246,12 @@ impl Engine {
     /// domain reports its path and reads routing bullets from its `MANIFEST.md`
     /// on disk; a virtual domain reports a null path, its kind and reads routing
     /// bullets from its MANIFEST engram in the database.
+    ///
+    /// With `include_routing` the response also carries a top-level `behavior`
+    /// array: the same rules the onboarding block renders, from
+    /// [`crystalline_core::behavior_bullets`]. Remote clients never show the
+    /// model the initialize instructions, so this one call is their whole
+    /// onboarding - the routing lines and the rules that govern them together.
     pub async fn list_domains(&self, p: &ListDomainsParams) -> Result<Value> {
         let store = self.store.lock().await;
         let stats = store.domain_stats().await.unwrap_or_default();
@@ -2286,6 +2292,12 @@ impl Engine {
                 obj["when_to_use"] = json!(bullets);
             }
             out.push(obj);
+        }
+        if p.include_routing {
+            return Ok(json!({
+                "behavior": crystalline_core::behavior_bullets(self.read_only()),
+                "domains": out,
+            }));
         }
         Ok(json!({ "domains": out }))
     }

--- a/crates/service/src/mcp.rs
+++ b/crates/service/src/mcp.rs
@@ -327,7 +327,7 @@ impl McpServer {
     #[tool(
         name = "list_domains",
         title = "List domains",
-        description = "List the registered domains with their engram counts to see what the agent has been taught. Set include_routing to also get each domain's When to Use routing bullets from its MANIFEST - the routing source the server instructions summarize, with every bullet included.",
+        description = "List the registered domains with their engram counts to see what the agent has been taught. If no CRYSTALLINE KNOWLEDGE ROUTING block reached you this session, call this at session start with include_routing=true: it returns each domain's When to Use routing bullets plus the behavior rules for this server's tools; follow them and route searches through those domains before answering from memory. The same call re-fetches the index mid-session.",
         annotations(read_only_hint = true, open_world_hint = false)
     )]
     async fn list_domains(

--- a/crates/service/tests/mcp_tools.rs
+++ b/crates/service/tests/mcp_tools.rs
@@ -329,6 +329,45 @@ async fn tool_descriptions_teach_folders() {
     );
 }
 
+/// A remote client never sees the initialize instructions, so `list_domains`
+/// with `include_routing` has to carry the behavior rules itself: the response
+/// returns exactly the shared bullet set, read-write here and the read-only
+/// set in a read-only deployment.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn list_domains_routing_carries_the_behavior_rules() {
+    let h = Harness::new(&["eng"]).await;
+    let (client, _server) = h.connect().await;
+    let peer = client.peer();
+
+    let plain = call(peer, "list_domains", json!({})).await.unwrap();
+    assert!(
+        plain.get("behavior").is_none(),
+        "behavior rides along with include_routing only: {plain}"
+    );
+
+    let routed = call(peer, "list_domains", json!({ "include_routing": true }))
+        .await
+        .unwrap();
+    assert_eq!(
+        routed["behavior"],
+        json!(crystalline_core::behavior_bullets(false))
+    );
+
+    let ro = Harness::new_read_only(&["eng"]).await;
+    let (ro_client, _ro_server) = ro.connect().await;
+    let ro_routed = call(
+        ro_client.peer(),
+        "list_domains",
+        json!({ "include_routing": true }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        ro_routed["behavior"],
+        json!(crystalline_core::behavior_bullets(true))
+    );
+}
+
 /// The `configure` tool's `set` and `unset` inputs must advertise the plain
 /// `object`/`array` JSON Schema `type` rather than a `["object", "null"]` or
 /// `["array", "null"]` union: some MCP clients (Claude Desktop) do not


### PR DESCRIPTION
Remote services and chat harnesses run no session hooks and most never inject an MCP server's initialize instructions (claude.ai connectors and Claude Desktop included), so the routing block never reached their agents. This makes one tool call the whole onboarding:

- `list_domains` with `include_routing=true` now returns a top-level `behavior` array next to the routing bullets, sourced from a new shared `behavior_bullets(read_only)` in core that `render_routing_body` also consumes - the rendered block and the tool response can never drift (refactor verified byte-identical: no existing snapshot moved)
- the `list_domains` description is rewritten as the session-start trigger for agents that received no routing block
- both `render_instructions` intros are compressed so the first 512 bytes stand on their own (per OpenAI's documented truncation guidance for server instructions), enforced by a new unit test
- new `crystalline prompt connector` prints a static paste-able custom-instructions snippet pointing the agent at that call; deliberately content-free (no domain names, no counts) so it never goes stale - all dynamic routing comes from the call it points at
- README: Session onboarding names both prompt kinds and gains a Remote clients subsection with the snippet

Full workspace gates green (1326 tests incl. new list_domains/behavior, 512-byte and four connector tests; toon_measurement still holds TOON < JSON for the enriched payload; clippy -D warnings; fmt; style-lint).