### PR TITLE
Serve the shipped agent skills over MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The other half of what `crystalline install` wires: a `Stop` hook running `cryst
 
 ## Teach and learn
 
-The MCP server exposes 15 tools, 19 once team domains are turned on (see [Share knowledge with a team](#share-knowledge-with-a-team)); capturing knowledge as a byproduct of work is the core loop:
+The MCP server exposes 16 tools, 20 once team domains are turned on (see [Share knowledge with a team](#share-knowledge-with-a-team)); capturing knowledge as a byproduct of work is the core loop:
 
 - **`write_engram`** - capture a new engram. `domain` is always required (there is no default domain for writes, so an agent never writes into the wrong place). `permalink`, `status` and `recorded_at` are filled in for you.
 - **`search_engrams`** - search before writing, and search to recall what is already known. Defaults to hybrid text-plus-semantic ranking across every domain; pass `domains` to narrow it, or filter by `type`, `tags`, `status` or arbitrary `metadata_filters` with no query text at all.
@@ -306,7 +306,7 @@ From there, `crystalline origin` covers the team domain lifecycle:
 
 The same actions are MCP tools an agent calls directly: `update_domain`, `origin_status`, `share_changes` and `resolve_conflict`, plus `configure` for settings and connecting. These four only appear once `github.enabled` is true, so an install that never uses team domains carries no extra tool beyond `configure` itself. `add_domain` is not among them: it creates domains of every kind (local, virtual, team) and is always available, though its team-domain branch still needs `github.enabled`. Sharing always ends with the agent relaying the proposal's review URL to the person it is working with, since review and merging happen on GitHub, by a person, never by the agent.
 
-`crystalline config show`, `set <key> <value>` and `unset <key>` read and write the same settings registry the `configure` MCP tool exposes, today `domains_root` plus the `github.*`, `service.*`, `database.*` and `search.*` blocks. Every settings key also maps to a `CRYSTALLINE_*` environment variable, so a container never needs to mount this file at all - see [Configure through environment variables](docs/deployment.md#configure-through-environment-variables) for the full list. A domain's origin and the global `github` block look like this in `config.yaml`:
+`crystalline config show`, `set <key> <value>` and `unset <key>` read and write the same settings registry the `configure` MCP tool exposes, today `domains_root` plus the `github.*`, `service.*`, `skills.*`, `database.*` and `search.*` blocks. Every settings key also maps to a `CRYSTALLINE_*` environment variable, so a container never needs to mount this file at all - see [Configure through environment variables](docs/deployment.md#configure-through-environment-variables) for the full list. A domain's origin and the global `github` block look like this in `config.yaml`:
 
 ```yaml
 domains:

--- a/crates/cli/src/doctor.rs
+++ b/crates/cli/src/doctor.rs
@@ -817,7 +817,7 @@ fn check_harnesses() -> Option<Vec<HarnessDoctor>> {
 /// One harness's diagnostics: read its settings/hooks file read-only, check
 /// both managed hooks via [`install::harness_hook_present`] (which knows
 /// each harness's file shape and session start command) and count how many
-/// of [`install::MANAGED_SKILLS`] are present (and, of those, how many were
+/// of [`install::managed_skills`] are present (and, of those, how many were
 /// locally modified against either the embedded copy or `entry`'s recorded
 /// hash) at its skills folder. `entry` is this harness's user-scope install
 /// receipt record, `None` when it was never installed or predates receipts.
@@ -854,7 +854,7 @@ fn check_one_harness(
 
     let mut skills_installed = 0;
     let mut skills_modified = 0;
-    for &(name, content) in install::MANAGED_SKILLS {
+    for &(name, content) in install::managed_skills().iter() {
         let path = paths.skills_dir.join(name).join("SKILL.md");
         if let Ok(existing) = std::fs::read(&path) {
             skills_installed += 1;
@@ -873,7 +873,7 @@ fn check_one_harness(
     // remembers, deduplicated, that is not a currently managed skill and
     // whose `SKILL.md` still sits on disk. Mirrors the retirement logic in
     // `install::reconcile_skill_set` without shelling out to it.
-    let managed: HashSet<&str> = install::MANAGED_SKILLS.iter().map(|&(n, _)| n).collect();
+    let managed: HashSet<&str> = install::managed_skills().iter().map(|&(n, _)| n).collect();
     let mut seen: HashSet<&str> = HashSet::new();
     let mut retired_leftovers = Vec::new();
     let candidate_names = entry
@@ -1376,7 +1376,7 @@ pub fn render_human(report: &DoctorReport) -> String {
                     out,
                     "    skills: {}/{} installed{modified}",
                     h.skills_installed,
-                    install::MANAGED_SKILLS.len()
+                    install::managed_skills().len()
                 );
             } else {
                 let _ = writeln!(out, "    skills: none installed");

--- a/crates/cli/src/install.rs
+++ b/crates/cli/src/install.rs
@@ -89,30 +89,22 @@ const SESSION_START_MATCHER: &str = "startup|clear|compact";
 /// is generous headroom, not a real budget.
 const HOOK_TIMEOUT_SECS: u64 = 10;
 
-/// The topical skills copied into every harness's skills folder,
-/// each as `(folder name, embedded SKILL.md)`. Embedded with `include_str!`
-/// so the binary is self-contained and an install from a downloaded release
-/// carries the same skills a clone would. `crystalline-memory` is deliberately
-/// absent: it is the single consolidated skill for Claude Desktop, which has
-/// no hooks and installs one skill at a time.
-pub(crate) const MANAGED_SKILLS: &[(&str, &str)] = &[
-    (
-        "crystalline-routing",
-        include_str!("../../../skills/crystalline-routing/SKILL.md"),
-    ),
-    (
-        "crystalline-capture",
-        include_str!("../../../skills/crystalline-capture/SKILL.md"),
-    ),
-    (
-        "crystalline-schema",
-        include_str!("../../../skills/crystalline-schema/SKILL.md"),
-    ),
-    (
-        "crystalline-collaboration",
-        include_str!("../../../skills/crystalline-collaboration/SKILL.md"),
-    ),
-];
+/// The topical skills copied into every harness's skills folder, each as
+/// `(folder name, embedded SKILL.md)`, derived from the shipped skill assets
+/// in [`crystalline_core::SKILL_ASSETS`] by their `install_managed` flag. The
+/// assets are embedded with `include_str!` so the binary is self-contained and
+/// an install from a downloaded release carries the same skills a clone would.
+/// `crystalline-memory` is deliberately not managed: it is the single
+/// consolidated skill for Claude Desktop, which has no hooks and installs one
+/// skill at a time. The MCP server serves all five regardless (see
+/// [`crystalline_core::skills`]); only installation is filtered here.
+pub(crate) fn managed_skills() -> Vec<(&'static str, &'static str)> {
+    crystalline_core::SKILL_ASSETS
+        .iter()
+        .filter(|s| s.install_managed)
+        .map(|s| (s.name, s.content))
+        .collect()
+}
 
 /// Skill folder names shipped by past releases and no longer managed. When a
 /// release drops or renames a managed skill, its old folder name is appended
@@ -721,7 +713,7 @@ fn uninstall_owned_hooks(path: &Path) -> anyhow::Result<HooksReport> {
 
 // --- skills install / uninstall ----------------------------------------------
 
-/// Reconcile one skills folder against [`MANAGED_SKILLS`]: install or update
+/// Reconcile one skills folder against [`managed_skills`]: install or update
 /// every current skill, retire leftovers named by the receipt or by
 /// [`RETIRED_SKILLS`] and return the per-skill report plus fresh receipt
 /// records for everything now on disk.
@@ -730,7 +722,7 @@ pub(crate) fn reconcile_skills(
     prior: &[receipt::RecordedSkill],
     mode: ReconcileMode,
 ) -> anyhow::Result<(SkillsReport, Vec<receipt::RecordedSkill>)> {
-    reconcile_skill_set(dir, MANAGED_SKILLS, RETIRED_SKILLS, prior, mode)
+    reconcile_skill_set(dir, &managed_skills(), RETIRED_SKILLS, prior, mode)
 }
 
 /// The engine behind [`reconcile_skills`], parameterized over the current
@@ -836,7 +828,7 @@ fn reconcile_skill_set(
 /// Whether `name` is safe to use as a single path component under a skills
 /// folder, i.e. whether `dir.join(name)` can only ever land inside `dir`.
 ///
-/// [`MANAGED_SKILLS`] and [`RETIRED_SKILLS`] are compiled into this binary,
+/// [`managed_skills`] and [`RETIRED_SKILLS`] are compiled into this binary,
 /// so their names are trusted outright. A name read back from the install
 /// receipt is not: the receipt is attacker-writable local state (plain JSON
 /// under `<state_dir>/installs.json`, editable by anything that can write
@@ -953,7 +945,7 @@ fn uninstall_skills(
         }
     };
 
-    for &(name, content) in MANAGED_SKILLS {
+    for &(name, content) in managed_skills().iter() {
         seen.insert(name);
         if let Some(status) = drop_one(name, Some(content))? {
             skills.push(SkillReport {

--- a/crates/cli/tests/configure.rs
+++ b/crates/cli/tests/configure.rs
@@ -36,7 +36,7 @@ fn config_show_set_unset_round_trip_against_a_temp_config() {
     assert!(out.status.success());
     let shown: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
     let settings = shown["settings"].as_array().unwrap();
-    assert_eq!(settings.len(), 13);
+    assert_eq!(settings.len(), 14);
     assert!(settings.iter().all(|s| s["source"] == "default"));
 
     // Set writes the config file and returns the new effective value.

--- a/crates/cli/tests/service.rs
+++ b/crates/cli/tests/service.rs
@@ -417,9 +417,10 @@ fn read_only_daemon_reports_hides_and_refuses() {
     let status: Value = serde_json::from_str(&out).unwrap();
     assert_eq!(status["read_only"], json!(true), "status: {status}");
 
-    // tools/list hides the four content-mutating tools and keeps the nine reads.
+    // tools/list hides the four content-mutating tools and keeps the ten
+    // reads, `skills` among them: reading a skill is a read.
     let names = c1.list_tools();
-    assert_eq!(names.len(), 9, "read-only exposes 9 tools: {names:?}");
+    assert_eq!(names.len(), 10, "read-only exposes 10 tools: {names:?}");
     for hidden in [
         "write_engram",
         "edit_engram",
@@ -431,6 +432,7 @@ fn read_only_daemon_reports_hides_and_refuses() {
             "{hidden} hidden: {names:?}"
         );
     }
+    assert!(names.contains(&"skills".to_string()), "{names:?}");
 
     // Calling a hidden tool by name returns the read-only error, not a panic.
     c1.send_call(
@@ -900,7 +902,7 @@ fn http_smoke_initialize_list_and_search() {
     // is off by default, so the five collaboration tools stay hidden, but
     // `add_domain` is write-gated not collab-gated, so it is visible (see
     // crystalline-service's mcp_collab test suite for the full gating matrix).
-    assert_eq!(tools.len(), 15, "15 tools over HTTP");
+    assert_eq!(tools.len(), 16, "16 tools over HTTP");
     let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
     assert!(names.contains(&"configure"), "{names:?}");
     assert!(names.contains(&"add_domain"), "{names:?}");

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -72,6 +72,11 @@ pub struct GlobalConfig {
     /// existing config keeps working untouched.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub search: Option<SearchConfig>,
+    /// Skill-serving settings. Absent means the shipped agent skills are
+    /// served over MCP, the default, so every existing config keeps working
+    /// untouched.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skills: Option<SkillsConfig>,
 }
 
 impl GlobalConfig {
@@ -133,6 +138,14 @@ impl GlobalConfig {
     /// store default.
     pub fn retired_weight(&self) -> Option<f64> {
         self.search.as_ref().and_then(|s| s.retired_weight)
+    }
+
+    /// Whether the shipped agent skills are served over MCP, from
+    /// `skills.serve`. Absent config or an absent key means on (true): the
+    /// skills are static public copy this binary already carries, so a remote
+    /// client that never runs the CLI can learn from them out of the box.
+    pub fn skills_serve(&self) -> bool {
+        self.skills.as_ref().and_then(|s| s.serve).unwrap_or(true)
     }
 }
 
@@ -322,6 +335,18 @@ pub struct GitHubConfig {
     /// Needed only for a GitHub Enterprise Server deployment.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oauth_client_id: Option<String>,
+}
+
+/// The `skills` block: whether this server serves the agent skills it ships.
+/// Reads like a settings-page section - see the `configure` tool, which
+/// exposes exactly these keys.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SkillsConfig {
+    /// Serve the shipped agent skills over MCP: the `skills` tool, the
+    /// `skill://` resources and the onboarding and connector prompts. Absent
+    /// means on.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serve: Option<bool>,
 }
 
 /// Service configuration.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod parse;
 pub mod prompt;
 pub mod provision;
 pub mod schema;
+pub mod skills;
 pub mod tags;
 pub mod temporal;
 pub mod verify;
@@ -56,6 +57,7 @@ pub use provision::{
 pub use schema::{
     FieldDecl, FieldType, ScalarType, Schema, SchemaDrift, SchemaIssue, ValidationMode,
 };
+pub use skills::{SKILL_ASSETS, SkillAsset, skill};
 pub use tags::{is_lower_hyphen, retag};
 pub use temporal::{DATE_FIELDS, DateFieldError, normalize_temporal_fields};
 pub use verify::{Issue, Severity, VerifyOptions, VerifyReport, verify_paths};

--- a/crates/core/src/skills.rs
+++ b/crates/core/src/skills.rs
@@ -1,0 +1,149 @@
+//! The agent skills this binary ships, embedded as static assets.
+//!
+//! A skill is a folder under `skills/` with a `SKILL.md` playbook teaching one
+//! kind of Crystalline work: routing to a domain, capturing what was learned,
+//! modelling a schema, collaborating with a team. `include_str!` bakes each one
+//! into the binary, so an install from a downloaded release carries exactly the
+//! skills a clone would.
+//!
+//! The assets live in core because two very different consumers need the same
+//! bytes. `crystalline install` copies the managed ones into a harness's skills
+//! folder, where the harness loads them itself. The MCP server serves all of
+//! them to a remote client that never runs the CLI at all: as `skill://`
+//! resources, as the `skills` tool's index and full-text reads, and as the
+//! shape a future ratified skills extension would advertise. Keeping the list
+//! here means neither consumer can drift from the other, and core stays static
+//! (no async, no database, no ML) the way the rest of the crate is.
+//!
+//! [`SkillAsset::install_managed`] is the one axis the two consumers differ on.
+//! `crystalline-memory` is the single consolidated skill for Claude Desktop,
+//! which has no hooks and installs one skill at a time, so it ships only as
+//! its own zip and is never copied into a harness skills folder beside the
+//! four topical skills - installing both would teach the same lessons twice.
+//! It is still served over MCP like any other: a remote client reading the
+//! skills should see everything this binary knows how to teach.
+
+/// One shipped agent skill: its folder name, its embedded `SKILL.md` and
+/// whether `crystalline install` copies it into a harness skills folder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SkillAsset {
+    /// The skill folder name, which is also its frontmatter `name` and the
+    /// name it is served under (`skill://<name>/SKILL.md`).
+    pub name: &'static str,
+    /// The full `SKILL.md`, frontmatter included, exactly as it ships.
+    pub content: &'static str,
+    /// Whether `crystalline install` copies this skill into a harness's
+    /// skills folder. False for the consolidated Claude Desktop skill, which
+    /// ships as its own zip; see the module docs.
+    pub install_managed: bool,
+}
+
+impl SkillAsset {
+    /// The skill's one-line `description` from its frontmatter: what a harness
+    /// (or an agent reading the `skills` index) uses to decide whether this
+    /// playbook applies. Every shipped skill has exactly one such line; an
+    /// asset that somehow lost it reads as an empty description rather than
+    /// failing, since a missing line is a copy problem, never a runtime one.
+    pub fn description(&self) -> &str {
+        self.content
+            .lines()
+            .find_map(|line| line.strip_prefix("description:"))
+            .map(str::trim)
+            .unwrap_or_default()
+    }
+}
+
+/// Every skill this binary ships, in the order a reader should meet them:
+/// route to a domain, capture what was learned, model a schema, collaborate
+/// with a team, and the consolidated Claude Desktop skill last.
+pub const SKILL_ASSETS: &[SkillAsset] = &[
+    SkillAsset {
+        name: "crystalline-routing",
+        content: include_str!("../../../skills/crystalline-routing/SKILL.md"),
+        install_managed: true,
+    },
+    SkillAsset {
+        name: "crystalline-capture",
+        content: include_str!("../../../skills/crystalline-capture/SKILL.md"),
+        install_managed: true,
+    },
+    SkillAsset {
+        name: "crystalline-schema",
+        content: include_str!("../../../skills/crystalline-schema/SKILL.md"),
+        install_managed: true,
+    },
+    SkillAsset {
+        name: "crystalline-collaboration",
+        content: include_str!("../../../skills/crystalline-collaboration/SKILL.md"),
+        install_managed: true,
+    },
+    SkillAsset {
+        name: "crystalline-memory",
+        content: include_str!("../../../skills/crystalline-memory/SKILL.md"),
+        install_managed: false,
+    },
+];
+
+/// Look one shipped skill up by name, or `None` when nothing ships under that
+/// name.
+pub fn skill(name: &str) -> Option<&'static SkillAsset> {
+    SKILL_ASSETS.iter().find(|s| s.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn five_skills_ship_with_four_installed_into_harnesses() {
+        assert_eq!(SKILL_ASSETS.len(), 5);
+        let managed: Vec<&str> = SKILL_ASSETS
+            .iter()
+            .filter(|s| s.install_managed)
+            .map(|s| s.name)
+            .collect();
+        assert_eq!(
+            managed,
+            vec![
+                "crystalline-routing",
+                "crystalline-capture",
+                "crystalline-schema",
+                "crystalline-collaboration",
+            ]
+        );
+        assert_eq!(
+            skill("crystalline-memory").map(|s| s.install_managed),
+            Some(false),
+            "the consolidated Desktop skill is served but never installed"
+        );
+    }
+
+    #[test]
+    fn every_asset_carries_its_own_frontmatter_name_and_a_description() {
+        for asset in SKILL_ASSETS {
+            let name_line = asset
+                .content
+                .lines()
+                .find_map(|l| l.strip_prefix("name:"))
+                .map(str::trim)
+                .unwrap_or_default();
+            assert_eq!(
+                name_line, asset.name,
+                "{}: frontmatter name must match the folder name",
+                asset.name
+            );
+            assert!(
+                !asset.description().is_empty(),
+                "{}: a skill without a description cannot be routed to",
+                asset.name
+            );
+        }
+    }
+
+    #[test]
+    fn skill_looks_up_by_name_and_misses_cleanly() {
+        let routing = skill("crystalline-routing").expect("the routing skill ships");
+        assert!(routing.content.starts_with("---\n"));
+        assert!(skill("crystalline-nonesuch").is_none());
+    }
+}

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -689,6 +689,14 @@ impl Engine {
         self.config.read().unwrap().github_enabled()
     }
 
+    /// Whether the shipped agent skills are served over MCP, read fresh under
+    /// the config guard the same way [`Engine::github_enabled`] is, so a
+    /// runtime `configure` flip of `skills.serve` applies from the next call
+    /// on rather than at the next daemon start.
+    pub fn skills_serve(&self) -> bool {
+        self.config.read().unwrap().skills_serve()
+    }
+
     /// How the MCP server encodes list-shaped tool results, from the
     /// effective `service.response_format`. Read per response, so a runtime
     /// configure switch applies from the next tool call on.

--- a/crates/service/src/mcp.rs
+++ b/crates/service/src/mcp.rs
@@ -19,7 +19,7 @@
 //!
 //! In read-only mode (the engine's `read_only` flag) the four content-mutating
 //! tools are filtered out of `list_tools` and `get_tool`, so the surface is the
-//! nine read tools; the routes stay registered so a client that calls a hidden
+//! ten read tools; the routes stay registered so a client that calls a hidden
 //! tool by name reaches the engine's read-only guard and gets a clean error.
 //!
 //! The collaboration tools (`configure`, `add_domain`, `share_changes`,
@@ -39,13 +39,31 @@
 //! name still reaches the engine: `status` answers for real even with no
 //! declaring domain, and a mutating action still hits the read-only guard.
 //!
+//! The shipped agent skills are served here too, so a remote client that never
+//! runs `crystalline install` can still learn how to use Crystalline well:
+//! the `skills` tool (an index with no arguments, one skill's full `SKILL.md`
+//! with `name`), five `skill://<name>/SKILL.md` resources and two prompts,
+//! `onboarding` (the live routing block) and `connector` (the static snippet
+//! that teaches a client to onboard itself). The whole surface shares one
+//! gate, the live `skills.serve` setting, on by default; when it is off the
+//! tool, the resource list and the prompt list are empty while direct reads
+//! keep answering, the same hidden-not-disabled doctrine the tool gates
+//! follow. The resource shape follows the converging skills-over-MCP proposal
+//! without advertising its extension id, which is not ratified yet. The
+//! prompts are declared with rmcp's `#[prompt_router]`/`#[prompt]` macros but
+//! `list_prompts` and `get_prompt` are hand-written, since
+//! `#[prompt_handler]` replaces any `list_prompts` in its impl block and the
+//! gate needs one it can empty.
+//!
 //! rmcp 2.1 supports a server pushing `notifications/tools/list_changed` to
 //! a connected client (`Peer::notify_tool_list_changed`, gated behind
 //! `ServerCapabilities::enable_tool_list_changed`); `configure` sends one
 //! whenever a `set`/`unset` call flips `github.enabled`, and `add_domain`/
 //! `update_domain` send one whenever they flip whether any domain declares
 //! provisioning, so a client that honours the notification refreshes its
-//! tool list immediately rather than waiting for its own next poll.
+//! tool list immediately rather than waiting for its own next poll. A
+//! `skills.serve` flip moves three lists at once, so `configure` sends the
+//! prompt and resource list-changed notifications alongside the tool one.
 //!
 //! Every tool also advertises MCP tool annotations: a display `title` plus the
 //! readOnly/destructive/idempotent/openWorld hints, so a client can tune its
@@ -60,15 +78,21 @@
 
 use std::sync::Arc;
 
+use rmcp::handler::server::prompt::PromptContext;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
-    CallToolResult, ContentBlock, ErrorData, Implementation, ListToolsResult,
-    PaginatedRequestParams, ProgressNotificationParam, ServerCapabilities, ServerInfo, Tool,
+    CallToolResult, ContentBlock, ErrorData, GetPromptRequestParams, GetPromptResult,
+    Implementation, ListPromptsResult, ListResourcesResult, ListToolsResult,
+    PaginatedRequestParams, ProgressNotificationParam, PromptMessage, ReadResourceRequestParams,
+    ReadResourceResult, Resource, ResourceContents, Role, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::RequestContext;
-use rmcp::{Peer, RoleServer, ServerHandler, tool, tool_handler, tool_router};
-use serde_json::Value;
+use rmcp::{
+    Peer, RoleServer, ServerHandler, prompt, prompt_router, tool, tool_handler, tool_router,
+};
+use serde_json::{Value, json};
 
+use crystalline_core::SKILL_ASSETS;
 use crystalline_remote::RemoteError;
 
 /// The tools hidden in read-only mode: the four content-mutating engram tools
@@ -129,6 +153,53 @@ fn is_collab_tool(name: &str) -> bool {
 /// engine either way.
 fn hidden_provision_tool(read_only: bool, provisioning_declared: bool) -> bool {
     read_only || !provisioning_declared
+}
+
+/// The MIME type every shipped skill is served with, as a resource and in the
+/// `skills` tool's full read: a `SKILL.md` is plain markdown.
+const SKILL_MIME_TYPE: &str = "text/markdown";
+
+/// The resource uri one shipped skill is served under. The shape follows the
+/// converging skills-over-MCP proposal (`skill://<name>/SKILL.md`) without
+/// advertising its extension id, which is not ratified yet: a client that
+/// learns the shape reads the same bytes either way.
+fn skill_uri(name: &str) -> String {
+    format!("skill://{name}/SKILL.md")
+}
+
+/// The shipped skill a resource uri names, or `None` when the uri is not one
+/// of the five this server serves.
+fn skill_for_uri(uri: &str) -> Option<&'static crystalline_core::SkillAsset> {
+    let name = uri.strip_prefix("skill://")?.strip_suffix("/SKILL.md")?;
+    crystalline_core::skill(name)
+}
+
+/// The five shipped skill names, comma separated, for an error that names
+/// what the caller could have asked for instead.
+fn skill_names() -> String {
+    SKILL_ASSETS
+        .iter()
+        .map(|s| s.name)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// The five skill resource uris, comma separated, for the same reason.
+fn skill_uris() -> String {
+    SKILL_ASSETS
+        .iter()
+        .map(|s| skill_uri(s.name))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Whether the `skills` tool is hidden given the engine's live `skills.serve`
+/// setting. The whole skill-serving surface (this tool, the `skill://`
+/// resources and the two prompts) shares that one gate, and it is read fresh
+/// on every call rather than cached, since `configure` can flip it
+/// mid-session. Read-only mode is not part of it: reading a skill is a read.
+fn hidden_skills_tool(skills_serve: bool) -> bool {
+    !skills_serve
 }
 
 /// Whether collaboration tool `name` is hidden given the engine's live
@@ -446,12 +517,27 @@ impl McpServer {
         }
 
         let before = self.engine.github_enabled();
+        let skills_before = self.engine.skills_serve();
         self.apply_settings(&p).await?;
         let after = self.engine.github_enabled();
-        if before != after
+        let skills_after = self.engine.skills_serve();
+        // A `skills.serve` flip moves three lists at once (the `skills` tool,
+        // the `skill://` resources and the two prompts), a `github.enabled`
+        // flip only the tool list; one call can do both, and the tool
+        // notification is sent once either way.
+        let skills_flipped = skills_before != skills_after;
+        if (before != after || skills_flipped)
             && let Err(e) = peer.notify_tool_list_changed().await
         {
             tracing::warn!("failed to send tools/list_changed after configure: {e}");
+        }
+        if skills_flipped {
+            if let Err(e) = peer.notify_prompt_list_changed().await {
+                tracing::warn!("failed to send prompts/list_changed after configure: {e}");
+            }
+            if let Err(e) = peer.notify_resource_list_changed().await {
+                tracing::warn!("failed to send resources/list_changed after configure: {e}");
+            }
         }
 
         self.engine
@@ -707,6 +793,84 @@ impl McpServer {
             .map_err(to_error)
             .and_then(|v| self.ok_list(v))
     }
+
+    #[tool(
+        name = "skills",
+        title = "Skills",
+        description = "List the agent skills this server ships and read any skill's full SKILL.md playbook: how to route, capture, model schemas and collaborate well with Crystalline. Call with no arguments for the index of names and descriptions; pass name to read one skill before its kind of task.",
+        annotations(
+            read_only_hint = true,
+            destructive_hint = false,
+            open_world_hint = false
+        )
+    )]
+    async fn skills(
+        &self,
+        Parameters(p): Parameters<SkillsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let Some(name) = p.name.as_deref() else {
+            let index: Vec<Value> = SKILL_ASSETS
+                .iter()
+                .map(|s| json!({ "name": s.name, "description": s.description() }))
+                .collect();
+            return self.ok_list(json!({ "skills": index }));
+        };
+        match crystalline_core::skill(name) {
+            // The playbook is markdown a model reads directly, so it is the
+            // single text block verbatim rather than a JSON-wrapped string.
+            Some(asset) => Ok(CallToolResult::success(vec![ContentBlock::text(
+                asset.content,
+            )])),
+            None => Err(ErrorData::invalid_params(
+                format!(
+                    "skills: no skill named '{name}'; this server ships {}",
+                    skill_names()
+                ),
+                None,
+            )),
+        }
+    }
+}
+
+/// The two prompts a client can insert verbatim: the live routing block for
+/// this server and the static snippet that teaches any client to onboard
+/// itself. Declared with the rmcp prompt macros so each one's name,
+/// description and (absent) arguments live at its handler; `list_prompts` and
+/// `get_prompt` are hand-written in the `ServerHandler` impl instead of
+/// generated, so the `skills.serve` gate can empty the list. See the module
+/// docs.
+#[prompt_router]
+impl McpServer {
+    /// The routing block the initialize `instructions` also carry, re-rendered
+    /// per call: the cache refresh first is what makes a virtual domain's
+    /// bullets current, exactly as the daemon does before `get_info`.
+    #[prompt(
+        name = "onboarding",
+        title = "Knowledge routing",
+        description = "The live knowledge routing block for this server: one routing line per domain plus the behavior rules. Insert at session start."
+    )]
+    async fn onboarding_prompt(&self) -> Vec<PromptMessage> {
+        self.engine.refresh_routing_cache().await;
+        vec![PromptMessage::new_text(
+            Role::User,
+            self.engine.routing_text(),
+        )]
+    }
+
+    /// The static bootstrap snippet, identical to what `crystalline prompt
+    /// connector` prints: a client whose custom instructions carry it onboards
+    /// itself through `list_domains` even when nothing else reaches it.
+    #[prompt(
+        name = "connector",
+        title = "Connector instructions",
+        description = "A short static snippet to paste into a client's custom instructions so every session onboards itself through list_domains."
+    )]
+    async fn connector_prompt(&self) -> Vec<PromptMessage> {
+        vec![PromptMessage::new_text(
+            Role::User,
+            crystalline_core::CONNECTOR_SNIPPET,
+        )]
+    }
 }
 
 impl McpServer {
@@ -796,9 +960,19 @@ impl ServerHandler for McpServer {
             instructions.push_str(TOON_INSTRUCTIONS_NOTE);
         }
         info.instructions = Some(instructions);
+        // Capabilities are initialize facts a session cannot renegotiate, so
+        // resources and prompts stay advertised whatever `skills.serve` says;
+        // the gate empties the two lists instead of retracting the capability
+        // mid-session. Resource subscribe is deliberately not enabled: the
+        // shipped skills are static for a binary's lifetime, so there is
+        // nothing to subscribe to.
         info.capabilities = ServerCapabilities::builder()
             .enable_tools()
             .enable_tool_list_changed()
+            .enable_resources()
+            .enable_resources_list_changed()
+            .enable_prompts()
+            .enable_prompts_list_changed()
             .build();
         info
     }
@@ -822,6 +996,7 @@ impl ServerHandler for McpServer {
         let read_only = self.engine.read_only();
         let github_enabled = self.engine.github_enabled();
         let provisioning_declared = self.engine.provisioning_declared();
+        let skills_serve = self.engine.skills_serve();
         let mut tools = Self::tool_router().list_all();
         tools.retain(|t| {
             if is_write_tool(&t.name) && read_only {
@@ -831,6 +1006,9 @@ impl ServerHandler for McpServer {
                 return false;
             }
             if t.name == "provision" && hidden_provision_tool(read_only, provisioning_declared) {
+                return false;
+            }
+            if t.name == "skills" && hidden_skills_tool(skills_serve) {
                 return false;
             }
             true
@@ -864,9 +1042,98 @@ impl ServerHandler for McpServer {
         {
             return None;
         }
+        if name == "skills" && hidden_skills_tool(self.engine.skills_serve()) {
+            return None;
+        }
         let mut tool = Self::tool_router().get(name).cloned()?;
         crate::tool_schema::sanitize_tool(&mut tool);
         Some(tool)
+    }
+
+    /// List the shipped agent skills as `skill://<name>/SKILL.md` resources,
+    /// so a remote client that never runs the CLI can read the same playbooks
+    /// an installed harness gets. Empty while `skills.serve` is off, read
+    /// fresh here the way the tool gates are.
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, ErrorData> {
+        if !self.engine.skills_serve() {
+            return Ok(ListResourcesResult::with_all_items(Vec::new()));
+        }
+        let resources = SKILL_ASSETS
+            .iter()
+            .map(|s| {
+                Resource::new(skill_uri(s.name), s.name)
+                    .with_description(s.description())
+                    .with_mime_type(SKILL_MIME_TYPE)
+            })
+            .collect();
+        Ok(ListResourcesResult::with_all_items(resources))
+    }
+
+    /// Read one shipped skill by its resource uri. Like every hidden tool,
+    /// this answers even while `skills.serve` is off: the gate hides the
+    /// surface from a listing rather than disabling it, and a skill is static
+    /// public copy this binary already carries, so a client holding a uri from
+    /// an earlier listing gets the bytes rather than a puzzle.
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, ErrorData> {
+        match skill_for_uri(&request.uri) {
+            Some(asset) => Ok(ReadResourceResult::new(vec![
+                ResourceContents::text(asset.content, &request.uri).with_mime_type(SKILL_MIME_TYPE),
+            ])),
+            None => Err(ErrorData::invalid_params(
+                format!(
+                    "unknown resource '{}'; this server serves {}",
+                    request.uri,
+                    skill_uris()
+                ),
+                None,
+            )),
+        }
+    }
+
+    /// List the two onboarding prompts, empty while `skills.serve` is off.
+    /// Hand-written rather than `#[prompt_handler]`-generated for exactly that
+    /// gate: the macro replaces any `list_prompts` in the impl block it is
+    /// applied to, so a generated one could never be emptied.
+    async fn list_prompts(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListPromptsResult, ErrorData> {
+        let prompts = if self.engine.skills_serve() {
+            Self::prompt_router().list_all()
+        } else {
+            Vec::new()
+        };
+        Ok(ListPromptsResult {
+            prompts,
+            meta: None,
+            next_cursor: None,
+        })
+    }
+
+    /// Render one prompt through the macro-declared router. Answers while the
+    /// gate is off for the same reason `read_resource` does.
+    async fn get_prompt(
+        &self,
+        request: GetPromptRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<GetPromptResult, ErrorData> {
+        Self::prompt_router()
+            .get_prompt(PromptContext::new(
+                self,
+                request.name,
+                request.arguments,
+                context,
+            ))
+            .await
     }
 }
 
@@ -1012,6 +1279,24 @@ mod tests {
         assert!(is_write_tool("add_domain"));
         assert!(!is_collab_tool("write_engram"));
         assert!(!is_collab_tool("search_engrams"));
+    }
+
+    #[test]
+    fn hidden_skills_tool_follows_the_serve_setting_alone() {
+        assert!(!hidden_skills_tool(true), "on by default, so visible");
+        assert!(hidden_skills_tool(false));
+    }
+
+    #[test]
+    fn skill_uris_round_trip_to_their_assets() {
+        for asset in SKILL_ASSETS {
+            let uri = skill_uri(asset.name);
+            assert_eq!(uri, format!("skill://{}/SKILL.md", asset.name));
+            assert_eq!(skill_for_uri(&uri).map(|a| a.name), Some(asset.name));
+        }
+        assert!(skill_for_uri("skill://crystalline-routing").is_none());
+        assert!(skill_for_uri("skill://nonesuch/SKILL.md").is_none());
+        assert!(skill_for_uri("https://example.com/SKILL.md").is_none());
     }
 
     #[test]

--- a/crates/service/src/overlay.rs
+++ b/crates/service/src/overlay.rs
@@ -647,6 +647,17 @@ mod tests {
     }
 
     #[test]
+    fn skills_serving_is_on_by_default_and_the_env_can_turn_it_off() {
+        assert!(
+            GlobalConfig::default().skills_serve(),
+            "an unconfigured install serves its skills"
+        );
+        let ov = overlay(&[("CRYSTALLINE_SKILLS_SERVE", "false")]).unwrap();
+        assert!(ov.overrides_key("skills.serve"));
+        assert!(!ov.apply(&GlobalConfig::default()).skills_serve());
+    }
+
+    #[test]
     fn domains_root_is_a_setting_not_an_env_domain() {
         // CRYSTALLINE_DOMAINS_ROOT must be read as the domains_root setting, and
         // never mistaken for a CRYSTALLINE_DOMAIN_<NAME> env-defined domain.

--- a/crates/service/src/params.rs
+++ b/crates/service/src/params.rs
@@ -392,6 +392,15 @@ pub struct ResolveConflictParams {
     pub content: Option<String>,
 }
 
+/// Parameters for `skills`.
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+pub struct SkillsParams {
+    /// The skill to read in full. Omit for the index of every shipped skill
+    /// with its description.
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
 /// Parameters for `provision`.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct ProvisionParams {

--- a/crates/service/src/settings.rs
+++ b/crates/service/src/settings.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use crystalline_core::config::{
     DatabaseBackend, DatabaseConfig, GitHubConfig, GlobalConfig, HttpSetting, ResponseFormat,
-    SearchConfig, ServiceConfig,
+    SearchConfig, ServiceConfig, SkillsConfig,
 };
 use crystalline_index::{DEFAULT_RETIRED_WEIGHT, DEFAULT_SALIENCE_WEIGHT};
 
@@ -189,6 +189,15 @@ pub fn registry() -> &'static [SettingSpec] {
             effective: response_format_effective,
         },
         SettingSpec {
+            key: "skills.serve",
+            doc: "Serve the shipped agent skills over MCP: the skills tool, skill:// resources and the onboarding and connector prompts (default true)",
+            kind: SettingKind::Bool,
+            startup_effective: false,
+            apply: set_skills_serve,
+            clear: clear_skills_serve,
+            effective: skills_serve_effective,
+        },
+        SettingSpec {
             key: "database.backend",
             doc: "Which storage backend serves the derived index, turso or postgres (applies at the next daemon start)",
             kind: SettingKind::String,
@@ -358,6 +367,15 @@ fn drop_service_if_empty(config: &mut GlobalConfig) {
 fn drop_database_if_empty(config: &mut GlobalConfig) {
     if config.database.as_ref() == Some(&DatabaseConfig::default()) {
         config.database = None;
+    }
+}
+
+/// Drop the `skills` block entirely once every field in it has been cleared,
+/// so an unset config round-trips to exactly the pre-feature shape (no empty
+/// `skills: {}` line).
+fn drop_skills_if_empty(config: &mut GlobalConfig) {
+    if config.skills.as_ref() == Some(&SkillsConfig::default()) {
+        config.skills = None;
     }
 }
 
@@ -626,6 +644,31 @@ fn allowed_hosts_effective(config: &GlobalConfig) -> (String, bool) {
     }
 }
 
+// --- skills.serve -------------------------------------------------------------
+
+fn set_skills_serve(config: &mut GlobalConfig, value: &str) -> Result<(), SettingsError> {
+    let parsed: bool = value
+        .parse()
+        .map_err(|_| SettingsError(format!("skills.serve must be true or false, got '{value}'")))?;
+    config
+        .skills
+        .get_or_insert_with(SkillsConfig::default)
+        .serve = Some(parsed);
+    Ok(())
+}
+
+fn clear_skills_serve(config: &mut GlobalConfig) {
+    if let Some(s) = config.skills.as_mut() {
+        s.serve = None;
+    }
+    drop_skills_if_empty(config);
+}
+
+fn skills_serve_effective(config: &GlobalConfig) -> (String, bool) {
+    let is_default = config.skills.as_ref().and_then(|s| s.serve).is_none();
+    (config.skills_serve().to_string(), is_default)
+}
+
 // --- service.response_format ------------------------------------------------
 
 fn set_response_format(config: &mut GlobalConfig, value: &str) -> Result<(), SettingsError> {
@@ -826,7 +869,7 @@ mod tests {
     }
 
     #[test]
-    fn registry_lists_exactly_the_thirteen_keys_in_order() {
+    fn registry_lists_exactly_the_fourteen_keys_in_order() {
         assert_eq!(
             known_keys(),
             vec![
@@ -839,6 +882,7 @@ mod tests {
                 "service.http",
                 "service.allowed_hosts",
                 "service.response_format",
+                "skills.serve",
                 "database.backend",
                 "database.url",
                 "search.salience_weight",
@@ -878,6 +922,7 @@ mod tests {
                     "service.response_format",
                     "CRYSTALLINE_SERVICE_RESPONSE_FORMAT".to_string()
                 ),
+                ("skills.serve", "CRYSTALLINE_SKILLS_SERVE".to_string()),
                 (
                     "database.backend",
                     "CRYSTALLINE_DATABASE_BACKEND".to_string()
@@ -1172,7 +1217,7 @@ mod tests {
         apply(&mut cfg, "github.enabled", "true").unwrap();
 
         let views = snapshot(&cfg, &EnvOverlay::default());
-        assert_eq!(views.len(), 13);
+        assert_eq!(views.len(), 14);
         assert_eq!(
             views.iter().map(|v| v.key.as_str()).collect::<Vec<_>>(),
             vec![
@@ -1185,6 +1230,7 @@ mod tests {
                 "service.http",
                 "service.allowed_hosts",
                 "service.response_format",
+                "skills.serve",
                 "database.backend",
                 "database.url",
                 "search.salience_weight",
@@ -1233,19 +1279,23 @@ mod tests {
         assert_eq!(response_format.value, "toon");
         assert_eq!(response_format.source, SettingSource::Default);
 
-        let backend = &views[9];
+        let skills_serve = &views[9];
+        assert_eq!(skills_serve.value, "true");
+        assert_eq!(skills_serve.source, SettingSource::Default);
+
+        let backend = &views[10];
         assert_eq!(backend.value, "turso");
         assert_eq!(backend.source, SettingSource::Default);
 
-        let url = &views[10];
+        let url = &views[11];
         assert_eq!(url.value, "");
         assert_eq!(url.source, SettingSource::Default);
 
-        let salience_weight = &views[11];
+        let salience_weight = &views[12];
         assert_eq!(salience_weight.value, "0.15");
         assert_eq!(salience_weight.source, SettingSource::Default);
 
-        let retired_weight = &views[12];
+        let retired_weight = &views[13];
         assert_eq!(retired_weight.value, "0.6");
         assert_eq!(retired_weight.source, SettingSource::Default);
     }

--- a/crates/service/src/stub.rs
+++ b/crates/service/src/stub.rs
@@ -10,6 +10,14 @@
 //! this binary's version, the daemon that owns the index and the fix, so the
 //! model can relay it to the user rather than the whole session going dark.
 //!
+//! The healthy server also serves the shipped agent skills (the `skills`
+//! tool, `skill://` resources and two prompts); this one deliberately does
+//! not. There is no engine here to read the `skills.serve` gate from, and a
+//! degraded session that answered a skills listing normally would look
+//! healthy in exactly the place it must not: the whole point of this server is
+//! to report the failure and the fix, with nothing else competing for the
+//! model's attention.
+//!
 //! The most common cause is an upgrade skew: the Claude Desktop extension
 //! bundles its own `crystalline` binary, and a daemon installed another way
 //! (a newer brew, say) owns the index at a version the bundled binary is too

--- a/crates/service/tests/configure.rs
+++ b/crates/service/tests/configure.rs
@@ -56,7 +56,7 @@ async fn show_lists_every_registry_key_at_its_default() {
 
     let data = engine.configure(&ConfigureAction::Show).await.unwrap();
     let views = settings_of(&data);
-    assert_eq!(views.len(), 13);
+    assert_eq!(views.len(), 14);
     assert!(
         views
             .iter()

--- a/crates/service/tests/mcp_collab.rs
+++ b/crates/service/tests/mcp_collab.rs
@@ -359,7 +359,7 @@ async fn configure_with_no_args_reports_the_settings_snapshot_and_github_block()
 
     let out = call(peer, "configure", json!({})).await.unwrap();
     let settings = out["settings"].as_array().unwrap();
-    assert_eq!(settings.len(), 13, "{settings:?}");
+    assert_eq!(settings.len(), 14, "{settings:?}");
     assert!(settings.iter().any(|s| s["key"] == "github.enabled"));
     assert!(settings.iter().any(|s| s["key"] == "domains_root"));
     assert_eq!(out["github"]["connected"], json!(false));

--- a/crates/service/tests/mcp_skills.rs
+++ b/crates/service/tests/mcp_skills.rs
@@ -1,0 +1,377 @@
+//! In-process rmcp duplex tests for the skill-serving surface: the `skills`
+//! tool, the `skill://` resources and the onboarding and connector prompts.
+//!
+//! Same harness shape as `mcp_tools.rs` (a `tokio::io::duplex` pair driving
+//! the real `McpServer` over JSON-RPC), narrowed to what a remote client that
+//! never runs the CLI can read, and to the one `skills.serve` gate all three
+//! surfaces share.
+
+use std::sync::Arc;
+
+use crystalline_core::config::{DomainEntry, GlobalConfig, ResponseFormat, ServiceConfig};
+use crystalline_index::TursoStore;
+use crystalline_service::Engine;
+use crystalline_service::mcp::McpServer;
+use rmcp::RoleClient;
+use rmcp::model::{CallToolRequestParams, GetPromptRequestParams, ReadResourceRequestParams};
+use rmcp::service::{Peer, RunningService};
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+
+/// Every skill this binary ships, in served order.
+const SKILL_NAMES: [&str; 5] = [
+    "crystalline-routing",
+    "crystalline-capture",
+    "crystalline-schema",
+    "crystalline-collaboration",
+    "crystalline-memory",
+];
+
+struct Harness {
+    _tmp: tempfile::TempDir,
+    engine: Arc<Engine>,
+}
+
+impl Harness {
+    async fn new(domains: &[&str]) -> Harness {
+        Harness::build(domains, false).await
+    }
+
+    /// A harness whose engine serves the content API read-only, where the
+    /// `skills` tool must stay visible: reading a skill is a read.
+    async fn new_read_only(domains: &[&str]) -> Harness {
+        Harness::build(domains, true).await
+    }
+
+    async fn build(domains: &[&str], read_only: bool) -> Harness {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path().to_path_buf();
+        let mut cfg = GlobalConfig::default();
+        for d in domains {
+            let dir = root.join(d);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("MANIFEST.md"),
+                format!(
+                    "---\ntype: manifest\ntitle: {d}\npermalink: manifest\ntags:\n  - manifest\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# {d}\n\n## Scope\n\n- Everything about {d}\n\n## When to Use\n\n- Route here for {d} questions\n"
+                ),
+            )
+            .unwrap();
+            cfg.domains.insert(d.to_string(), DomainEntry::file(dir));
+        }
+        // Pin JSON so the tool assertions stay on data semantics rather than
+        // on the TOON encoding, which has its own tests.
+        cfg.service = Some(ServiceConfig {
+            response_format: Some(ResponseFormat::Json),
+            ..ServiceConfig::default()
+        });
+        let config_path = root.join("config.yaml");
+        crystalline_core::config::save_yaml(&config_path, &cfg).unwrap();
+        let store = TursoStore::open_in_memory().await.unwrap();
+        let engine = Arc::new(
+            Engine::new(Arc::new(Mutex::new(store)), cfg, None, Some(config_path))
+                .with_read_only(read_only),
+        );
+        engine.sync(None).await.unwrap();
+        Harness { _tmp: tmp, engine }
+    }
+
+    async fn connect(
+        &self,
+    ) -> (
+        RunningService<RoleClient, ()>,
+        RunningService<rmcp::RoleServer, McpServer>,
+    ) {
+        let (client_io, server_io) = tokio::io::duplex(1 << 16);
+        let engine = self.engine.clone();
+        let server_task =
+            tokio::spawn(
+                async move { rmcp::serve_server(McpServer::new(engine), server_io).await },
+            );
+        let client = rmcp::serve_client((), client_io).await.unwrap();
+        let server = server_task.await.unwrap().unwrap();
+        (client, server)
+    }
+}
+
+/// Call a tool, returning the raw text of its first content block on success.
+async fn call_text(peer: &Peer<RoleClient>, tool: &str, args: Value) -> Result<String, String> {
+    let mut params = CallToolRequestParams::new(tool.to_string());
+    if let Value::Object(map) = args {
+        params = params.with_arguments(map);
+    }
+    match peer.call_tool(params).await {
+        Ok(result) => {
+            let v = serde_json::to_value(&result).unwrap();
+            Ok(v.pointer("/content/0/text")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string())
+        }
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+async fn tool_names(peer: &Peer<RoleClient>) -> Vec<String> {
+    peer.list_tools(Default::default())
+        .await
+        .unwrap()
+        .tools
+        .iter()
+        .map(|t| t.name.to_string())
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_skills_tool_indexes_every_shipped_skill_and_serves_one_in_full() {
+    let h = Harness::new(&["eng"]).await;
+    let (client, _server) = h.connect().await;
+    let peer = client.peer();
+
+    let index: Value = serde_json::from_str(&call_text(peer, "skills", json!({})).await.unwrap())
+        .expect("the index is JSON");
+    let listed = index["skills"].as_array().expect("skills array");
+    let names: Vec<&str> = listed
+        .iter()
+        .filter_map(|s| s["name"].as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(names, SKILL_NAMES, "every shipped skill is indexed");
+    for entry in listed {
+        let description = entry["description"].as_str().unwrap_or_default();
+        assert!(
+            !description.is_empty(),
+            "a skill without a description cannot be routed to: {entry}"
+        );
+    }
+
+    // Fetching one by name returns the playbook verbatim, not JSON-wrapped.
+    let routing = call_text(peer, "skills", json!({ "name": "crystalline-routing" }))
+        .await
+        .unwrap();
+    assert_eq!(
+        routing,
+        crystalline_core::skill("crystalline-routing")
+            .unwrap()
+            .content
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unknown_skill_name_names_the_ones_that_ship() {
+    let h = Harness::new(&["eng"]).await;
+    let (client, _server) = h.connect().await;
+
+    let err = call_text(
+        client.peer(),
+        "skills",
+        json!({ "name": "crystalline-nonesuch" }),
+    )
+    .await
+    .unwrap_err();
+    for name in SKILL_NAMES {
+        assert!(err.contains(name), "{name} missing from: {err}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn resources_list_the_skills_and_read_back_their_playbooks() {
+    let h = Harness::new(&["eng"]).await;
+    let (client, _server) = h.connect().await;
+    let peer = client.peer();
+
+    let resources = peer.list_resources(Default::default()).await.unwrap();
+    let uris: Vec<&str> = resources
+        .resources
+        .iter()
+        .map(|r| r.uri.as_str())
+        .collect::<Vec<_>>();
+    let expected: Vec<String> = SKILL_NAMES
+        .iter()
+        .map(|n| format!("skill://{n}/SKILL.md"))
+        .collect();
+    assert_eq!(
+        uris,
+        expected.iter().map(String::as_str).collect::<Vec<_>>()
+    );
+    for r in &resources.resources {
+        assert_eq!(r.mime_type.as_deref(), Some("text/markdown"), "{}", r.uri);
+        assert!(
+            r.description.as_deref().is_some_and(|d| !d.is_empty()),
+            "{} carries its skill's description",
+            r.uri
+        );
+    }
+
+    let read = peer
+        .read_resource(ReadResourceRequestParams::new(
+            "skill://crystalline-capture/SKILL.md",
+        ))
+        .await
+        .unwrap();
+    let contents = serde_json::to_value(&read.contents[0]).unwrap();
+    assert_eq!(
+        contents["text"].as_str().unwrap(),
+        crystalline_core::skill("crystalline-capture")
+            .unwrap()
+            .content
+    );
+    assert_eq!(contents["mimeType"].as_str(), Some("text/markdown"));
+
+    let err = peer
+        .read_resource(ReadResourceRequestParams::new("skill://nonesuch/SKILL.md"))
+        .await
+        .unwrap_err()
+        .to_string();
+    for uri in &expected {
+        assert!(err.contains(uri), "{uri} missing from: {err}");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_two_prompts_carry_the_live_routing_block_and_the_static_snippet() {
+    let h = Harness::new(&["eng"]).await;
+    let (client, _server) = h.connect().await;
+    let peer = client.peer();
+
+    let listed = peer.list_prompts(Default::default()).await.unwrap();
+    let mut names: Vec<&str> = listed.prompts.iter().map(|p| p.name.as_str()).collect();
+    names.sort_unstable();
+    assert_eq!(names, vec!["connector", "onboarding"]);
+    for p in &listed.prompts {
+        assert!(
+            p.description.as_deref().is_some_and(|d| !d.is_empty()),
+            "{} needs a description a client can show",
+            p.name
+        );
+    }
+
+    let onboarding = peer
+        .get_prompt(GetPromptRequestParams::new("onboarding"))
+        .await
+        .unwrap();
+    let text = prompt_text(&onboarding);
+    assert!(
+        text.contains("CRYSTALLINE KNOWLEDGE ROUTING"),
+        "the live routing block: {text}"
+    );
+    assert!(text.contains("eng"), "the registered domain: {text}");
+
+    let connector = peer
+        .get_prompt(GetPromptRequestParams::new("connector"))
+        .await
+        .unwrap();
+    assert_eq!(prompt_text(&connector), crystalline_core::CONNECTOR_SNIPPET);
+}
+
+/// The text of a prompt result's single message.
+fn prompt_text(result: &rmcp::model::GetPromptResult) -> String {
+    let v = serde_json::to_value(result).unwrap();
+    v.pointer("/messages/0/content/text")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turning_skills_serve_off_empties_the_lists_while_direct_reads_answer() {
+    let h = Harness::new(&["eng"]).await;
+    let (client, _server) = h.connect().await;
+    let peer = client.peer();
+
+    assert!(tool_names(peer).await.contains(&"skills".to_string()));
+
+    call_text(
+        peer,
+        "configure",
+        json!({ "set": { "skills.serve": "false" } }),
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        !tool_names(peer).await.contains(&"skills".to_string()),
+        "the tool is hidden while the gate is off"
+    );
+    assert!(
+        peer.list_resources(Default::default())
+            .await
+            .unwrap()
+            .resources
+            .is_empty(),
+        "no skill resources are advertised while the gate is off"
+    );
+    assert!(
+        peer.list_prompts(Default::default())
+            .await
+            .unwrap()
+            .prompts
+            .is_empty(),
+        "no prompts are advertised while the gate is off"
+    );
+
+    // Hidden, not disabled: a client holding a name or a uri from an earlier
+    // listing still gets the bytes, exactly like every other gated tool.
+    let routing = call_text(peer, "skills", json!({ "name": "crystalline-routing" }))
+        .await
+        .unwrap();
+    assert_eq!(
+        routing,
+        crystalline_core::skill("crystalline-routing")
+            .unwrap()
+            .content
+    );
+    let read = peer
+        .read_resource(ReadResourceRequestParams::new(
+            "skill://crystalline-routing/SKILL.md",
+        ))
+        .await
+        .expect("a direct resource read answers while the gate is off");
+    assert!(!read.contents.is_empty());
+    let connector = peer
+        .get_prompt(GetPromptRequestParams::new("connector"))
+        .await
+        .expect("a direct prompt read answers while the gate is off");
+    assert_eq!(prompt_text(&connector), crystalline_core::CONNECTOR_SNIPPET);
+
+    // Unsetting the key restores the default, which is on.
+    call_text(peer, "configure", json!({ "unset": ["skills.serve"] }))
+        .await
+        .unwrap();
+    assert!(tool_names(peer).await.contains(&"skills".to_string()));
+    assert_eq!(
+        peer.list_resources(Default::default())
+            .await
+            .unwrap()
+            .resources
+            .len(),
+        SKILL_NAMES.len()
+    );
+    assert_eq!(
+        peer.list_prompts(Default::default())
+            .await
+            .unwrap()
+            .prompts
+            .len(),
+        2
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn read_only_serving_still_teaches_the_skills() {
+    let h = Harness::new_read_only(&["eng"]).await;
+    let (client, _server) = h.connect().await;
+    let peer = client.peer();
+
+    assert!(
+        tool_names(peer).await.contains(&"skills".to_string()),
+        "reading a skill is a read"
+    );
+    assert_eq!(
+        peer.list_resources(Default::default())
+            .await
+            .unwrap()
+            .resources
+            .len(),
+        SKILL_NAMES.len()
+    );
+}

--- a/crates/service/tests/mcp_tools.rs
+++ b/crates/service/tests/mcp_tools.rs
@@ -233,6 +233,7 @@ async fn list_tools_exposes_the_core_tools_plus_configure_and_add_domain() {
         "vocabulary",
         "configure",
         "add_domain",
+        "skills",
     ] {
         assert!(names.contains(&expected.to_string()), "missing {expected}");
     }
@@ -247,7 +248,7 @@ async fn list_tools_exposes_the_core_tools_plus_configure_and_add_domain() {
             "{hidden} must be hidden while github.enabled is off: {names:?}"
         );
     }
-    assert_eq!(names.len(), 15, "exactly 15 tools: {names:?}");
+    assert_eq!(names.len(), 16, "exactly 16 tools: {names:?}");
 }
 
 /// The salience prior (Tasks 1-4) is invisible to an agent unless the tool
@@ -420,7 +421,8 @@ async fn read_only_hides_the_write_gated_tools() {
             "{hidden} must be hidden in read-only mode: {names:?}"
         );
     }
-    // The nine read tools remain.
+    // The ten read tools remain, `skills` among them: reading a skill is a
+    // read, so the gate that hides it is `skills.serve`, never read-only.
     for expected in [
         "read_engram",
         "search_engrams",
@@ -431,6 +433,7 @@ async fn read_only_hides_the_write_gated_tools() {
         "validate_engrams",
         "infer_schema",
         "vocabulary",
+        "skills",
     ] {
         assert!(names.contains(&expected.to_string()), "missing {expected}");
     }
@@ -449,7 +452,7 @@ async fn read_only_hides_the_write_gated_tools() {
             "{hidden} must be hidden read-only: {names:?}"
         );
     }
-    assert_eq!(names.len(), 9, "exactly 9 tools in read-only: {names:?}");
+    assert_eq!(names.len(), 10, "exactly 10 tools in read-only: {names:?}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -188,6 +188,7 @@ An immutable image with no `config.yaml` to mount or edit configures purely thro
 | `CRYSTALLINE_SERVICE_HTTP` | `service.http` | `serve --http` wins over it |
 | `CRYSTALLINE_SERVICE_ALLOWED_HOSTS` | `service.allowed_hosts` | comma-separated `Host` allow-list; loopback is always allowed and a single `*` allows any Host; `serve --allowed-host` wins over it |
 | `CRYSTALLINE_SERVICE_RESPONSE_FORMAT` | `service.response_format` | `toon` (token-efficient list results, default) or `json` |
+| `CRYSTALLINE_SKILLS_SERVE` | `skills.serve` | `true` (default) serves the shipped agent skills over MCP: the `skills` tool, `skill://` resources and the onboarding and connector prompts |
 | `CRYSTALLINE_DATABASE_BACKEND` | `database.backend` | `turso` or `postgres` |
 | `CRYSTALLINE_DATABASE_URL` | `database.url` | |
 | `CRYSTALLINE_GITHUB_ENABLED` and the other `github.*` keys | `github.enabled`, `github.poll_secs`, `github.api_url`, `github.oauth_client_id` | |

--- a/packaging/mcpb/generate-manifest.sh
+++ b/packaging/mcpb/generate-manifest.sh
@@ -195,6 +195,10 @@ cat >"$manifest_path" <<JSON
     {
       "name": "add_domain",
       "description": "Create or connect a domain to capture engrams in: a local folder of markdown files, a database-backed virtual domain or a GitHub team domain."
+    },
+    {
+      "name": "skills",
+      "description": "List the agent skills this server ships and read any skill's full playbook before its kind of task."
     }
   ],
   "tools_generated": false


### PR DESCRIPTION
Remote clients that never run `crystalline install` (claude.ai connectors, hosted agents, Desktop without the zips) had no way to read the skills this binary ships. This serves them over MCP, all on by default behind one new `skills.serve` setting (`CRYSTALLINE_SKILLS_SERVE`):

- a read-only `skills` tool: no arguments returns the index of names and descriptions (TOON-eligible), `name` returns that skill's full SKILL.md verbatim
- five `skill://<name>/SKILL.md` resources (`text/markdown`), following the converging skills-over-MCP proposal's shape WITHOUT advertising its unratified extension id
- two prompts: `onboarding` (the live routing block, cache-refreshed per call) and `connector` (the static bootstrap snippet from #29)
- skill bytes move from the CLI into core as embedded `SkillAsset`s so installer and server can never drift; `crystalline-memory` stays excluded from installs but is served like the rest
- gate doctrine matches every existing gate: hidden-not-disabled, read fresh per call; a flip pushes tools/prompts/resources list-changed notifications; capabilities stay advertised (initialize facts) while the gate empties the lists
- `#[prompt_router]`/`#[prompt]` macros declare the prompts, but `list_prompts`/`get_prompt` are hand-written: rmcp 2.2.0's `#[prompt_handler]` silently replaces a hand-written `list_prompts`, and the gate needs one it can empty
- settings registry grows to 14 keys; tool surface 15 -> 16 (read-only 9 -> 10); mcpb manifest gains the 16th tool entry; deployment env table and README counts updated in the same change

New integration suite `mcp_skills.rs` covers index/fetch/unknown-name, resource list/read round-trips, both prompts, the gate-off matrix (lists empty, direct reads answer, unset restores), read-only visibility and the env override. Full workspace gates green (1338 tests, doctests, clippy -D warnings, fmt, style-lint, manifest jq smoke).