### PR TITLE
Bound the embed path's memory and never let one batch starve the backlog

### DIFF
--- a/crates/index/src/embed/chunk.rs
+++ b/crates/index/src/embed/chunk.rs
@@ -5,9 +5,13 @@
 //! budget (bge accepts 512 tokens; the default budget of 450 leaves room for the
 //! special tokens and the title prepended to the first chunk). A fenced code
 //! block is kept intact as a single unit even when it contains blank lines, so a
-//! code sample is never cut in half. The first chunk gets the engram title and
-//! description prepended so a short engram still carries its heading into the
-//! vector space.
+//! code sample is never cut in half. A paragraph that exceeds the budget on its
+//! own is the one exception: it is hard-split into budget-sized pieces (a fence
+//! included, kept whole only up to the budget), because a body with no blank
+//! line would otherwise become a single chunk of unbounded size and every
+//! consumer downstream, the tokenizer first, would pay for it. The first chunk
+//! gets the engram title and description prepended so a short engram still
+//! carries its heading into the vector space.
 //!
 //! Each chunk carries a fingerprint `sha256(model_id + ":" + text)`. The sync
 //! engine hands the fingerprints to [`crate::Store::replace_chunks`], which
@@ -142,9 +146,10 @@ fn build_header(title: &str, description: Option<&str>) -> String {
     parts.join("\n\n")
 }
 
-/// Greedily pack consecutive paragraphs up to the token budget. A single
-/// paragraph larger than the budget becomes its own chunk (paragraphs are never
-/// split, so a fenced block stays whole).
+/// Greedily pack consecutive paragraphs up to the token budget. A paragraph
+/// that fits is never split, so a fenced block stays whole; one larger than the
+/// budget on its own is cut into budget-sized pieces first, so no chunk can
+/// exceed the budget however the body is written.
 fn pack(paragraphs: &[String], max_tokens: usize, count: &dyn Fn(&str) -> usize) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
     let mut current = String::new();
@@ -152,24 +157,135 @@ fn pack(paragraphs: &[String], max_tokens: usize, count: &dyn Fn(&str) -> usize)
 
     for p in paragraphs {
         let pt = count(p);
-        if !current.is_empty() && current_tokens + pt > max_tokens {
-            out.push(std::mem::take(&mut current));
-            current_tokens = 0;
+        // A paragraph within the budget takes the same path it always did; only
+        // an oversized one is cut, and only then is anything measured twice.
+        if pt <= max_tokens || max_tokens == 0 {
+            add_piece(
+                p,
+                pt,
+                max_tokens,
+                &mut out,
+                &mut current,
+                &mut current_tokens,
+            );
+            continue;
         }
-        if !current.is_empty() {
-            current.push_str("\n\n");
-        }
-        current.push_str(p);
-        current_tokens += pt;
-        if current_tokens >= max_tokens {
-            out.push(std::mem::take(&mut current));
-            current_tokens = 0;
+        for piece in split_to_budget(p, max_tokens, count) {
+            let piece_tokens = count(piece);
+            add_piece(
+                piece,
+                piece_tokens,
+                max_tokens,
+                &mut out,
+                &mut current,
+                &mut current_tokens,
+            );
         }
     }
     if !current.is_empty() {
         out.push(current);
     }
     out
+}
+
+/// Add one piece to the chunk being packed, flushing before it when it would
+/// overflow the budget and after it once the budget is reached.
+fn add_piece(
+    piece: &str,
+    piece_tokens: usize,
+    max_tokens: usize,
+    out: &mut Vec<String>,
+    current: &mut String,
+    current_tokens: &mut usize,
+) {
+    if !current.is_empty() && *current_tokens + piece_tokens > max_tokens {
+        out.push(std::mem::take(current));
+        *current_tokens = 0;
+    }
+    if !current.is_empty() {
+        current.push_str("\n\n");
+    }
+    current.push_str(piece);
+    *current_tokens += piece_tokens;
+    if *current_tokens >= max_tokens {
+        out.push(std::mem::take(current));
+        *current_tokens = 0;
+    }
+}
+
+/// Cut one paragraph into pieces that each fit the token budget. A paragraph
+/// within the budget is returned whole, so an ordinary body packs exactly as it
+/// did before the cap existed. Cuts land on char boundaries and prefer the last
+/// newline or space in the tail of a piece so words stay intact, and the pieces
+/// concatenate back to the input.
+fn split_to_budget<'a>(
+    text: &'a str,
+    max_tokens: usize,
+    count: &dyn Fn(&str) -> usize,
+) -> Vec<&'a str> {
+    if max_tokens == 0 || count(text) <= max_tokens {
+        return vec![text];
+    }
+    // Characters per token measured on this text, so both the built-in estimate
+    // and a real tokenizer land near the budget on the first cut. Only the
+    // candidate piece is measured after that: measuring the whole remainder on
+    // every cut would make splitting a huge paragraph quadratic.
+    let per_token = (text.chars().count() / count(text).max(1)).max(1);
+    let target_chars = max_tokens.saturating_mul(per_token).max(1);
+
+    let mut pieces: Vec<&str> = Vec::new();
+    let mut rest = text;
+    while !rest.is_empty() {
+        let mut take = target_chars;
+        let mut end = loop {
+            let end = char_boundary_at(rest, take);
+            if take <= 1 || count(&rest[..end]) <= max_tokens {
+                break end;
+            }
+            take = (take * 3 / 4).max(1);
+        };
+        if end == rest.len() {
+            pieces.push(rest);
+            break;
+        }
+        if let Some(cut) = whitespace_cut(&rest[..end]) {
+            end = cut;
+        }
+        let (head, tail) = rest.split_at(end);
+        pieces.push(head);
+        rest = tail;
+    }
+    pieces
+}
+
+/// The byte offset of the `chars`-th char boundary, or the end of the string.
+fn char_boundary_at(text: &str, chars: usize) -> usize {
+    text.char_indices()
+        .nth(chars)
+        .map(|(i, _)| i)
+        .unwrap_or(text.len())
+}
+
+/// A cut point just past the last newline (else the last space) in the final
+/// fifth of `head`, so a piece ends on a word rather than mid-word. `None` when
+/// the tail holds no whitespace to cut on. ASCII whitespace bytes never occur
+/// inside a multi-byte sequence, so the offset is always a char boundary.
+fn whitespace_cut(head: &str) -> Option<usize> {
+    let window = (head.len() / 5).max(1);
+    let bytes = head.as_bytes();
+    let mut newline: Option<usize> = None;
+    let mut space: Option<usize> = None;
+    for i in (head.len() - window..head.len()).rev() {
+        let b = bytes[i];
+        if b == b'\n' {
+            newline = Some(i + 1);
+            break;
+        }
+        if space.is_none() && b.is_ascii_whitespace() {
+            space = Some(i + 1);
+        }
+    }
+    newline.or(space).filter(|&cut| cut < head.len())
 }
 
 /// Split a body into paragraphs on blank lines, keeping fenced code blocks whole.

--- a/crates/index/src/embed/local.rs
+++ b/crates/index/src/embed/local.rs
@@ -34,6 +34,13 @@ const HF_REPO: &str = "BAAI/bge-small-en-v1.5";
 const DIMS: usize = 384;
 /// The model's maximum input length in tokens.
 const MAX_INPUT_TOKENS: usize = 512;
+/// The hard character cap applied to every input before tokenization. The
+/// tokenizer materializes the full `Encoding` (ids, tokens, offsets and masks,
+/// tens of bytes per token) and only then truncates to [`MAX_INPUT_TOKENS`], so
+/// an oversized input costs memory proportional to its length. Six characters
+/// per token is well above any real ratio, so this never cuts a chunk the
+/// chunker produced; it only bounds a caller that skipped chunking.
+const MAX_INPUT_CHARS: usize = MAX_INPUT_TOKENS * 6;
 
 /// A locally hosted bge provider.
 pub struct LocalProvider {
@@ -77,7 +84,13 @@ impl EmbeddingProvider for LocalProvider {
             return Ok(Vec::new());
         }
         let inner = self.inner.clone();
-        let texts = texts.to_vec();
+        // Capped here, where the batch is first copied for the blocking task, so
+        // an oversized chunk row bounds every copy downstream. See
+        // MAX_INPUT_CHARS.
+        let texts: Vec<String> = texts
+            .iter()
+            .map(|t| cap_chars(t, MAX_INPUT_CHARS).to_string())
+            .collect();
         tokio::task::spawn_blocking(move || embed_texts(&inner, &texts))
             .await
             .map_err(|e| IndexError::Embedding(format!("embedding task failed: {e}")))?
@@ -315,10 +328,25 @@ fn build_bert(files: &ModelFiles) -> Result<Bert> {
     })
 }
 
+/// Truncate to at most `max_chars` characters on a char boundary.
+fn cap_chars(text: &str, max_chars: usize) -> &str {
+    match text.char_indices().nth(max_chars) {
+        Some((i, _)) => &text[..i],
+        None => text,
+    }
+}
+
 fn embed_texts(bert: &Bert, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+    // The last line of defense before `encode_batch`, a no-op on a batch the
+    // caller already capped. The batch is copied for `encode_batch` either way,
+    // so the cap costs nothing on top.
+    let inputs: Vec<String> = texts
+        .iter()
+        .map(|t| cap_chars(t, MAX_INPUT_CHARS).to_string())
+        .collect();
     let encodings = bert
         .tokenizer
-        .encode_batch(texts.to_vec(), true)
+        .encode_batch(inputs, true)
         .map_err(|e| IndexError::Embedding(format!("tokenizing: {e}")))?;
 
     let batch = encodings.len();
@@ -352,4 +380,24 @@ fn normalize_l2(v: &Tensor) -> candle_core::Result<Tensor> {
 fn wipe_model_dir(cache_dir: &Path) {
     let dir = cache_dir.join(format!("models--{}", HF_REPO.replace('/', "--")));
     let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_INPUT_CHARS, cap_chars};
+
+    #[test]
+    fn cap_chars_bounds_input_on_a_char_boundary() {
+        // Short input passes through untouched.
+        assert_eq!(cap_chars("hello", MAX_INPUT_CHARS), "hello");
+        // A long input is cut to the character count, not the byte count, and
+        // never inside a multi-byte character.
+        let text = "aé漢".repeat(10);
+        let capped = cap_chars(&text, 5);
+        assert_eq!(capped.chars().count(), 5);
+        assert_eq!(capped, "aé漢aé");
+        // The cap is generous enough that no chunk-sized text is ever cut.
+        let chunk = "word ".repeat(crate::embed::DEFAULT_MAX_TOKENS);
+        assert_eq!(cap_chars(&chunk, MAX_INPUT_CHARS), chunk.as_str());
+    }
 }

--- a/crates/index/src/embed/mod.rs
+++ b/crates/index/src/embed/mod.rs
@@ -35,6 +35,12 @@ pub const BGE_QUERY_PREFIX: &str = "Represent this sentence for searching releva
 /// How many chunks are embedded per provider call.
 pub const EMBED_BATCH_SIZE: usize = 16;
 
+/// How many outstanding chunks one backlog page pulls from the store. An embed
+/// pass loops pages instead of snapshotting the whole backlog, so a first index
+/// over a large corpus never holds every chunk's text at once. A multiple of
+/// [`EMBED_BATCH_SIZE`] so a full page splits into whole batches.
+pub const EMBED_PAGE_SIZE: usize = 512;
+
 /// Turns text into unit-normalized embedding vectors.
 ///
 /// `embed` is for documents (chunk text, embedded bare). `embed_queries` is for
@@ -155,54 +161,97 @@ pub fn order_jobs_for_batching(jobs: &mut [ChunkJob]) {
 
 /// Embed every chunk that needs it for the active provider's model, in batches,
 /// writing the vectors back through the store. `progress` is called after each
-/// batch with `(done, total)`.
+/// batch with `(done, total)`, where `total` is every chunk pulled so far: the
+/// backlog is paged, so the final call reports the true total and the earlier
+/// ones a lower bound.
+///
+/// A batch the provider rejects is logged and skipped, not fatal: its chunks
+/// keep no embedding and stay in the backlog for a later pass, so one poisoned
+/// batch cannot starve everything queued behind it. Only store errors abort.
 ///
 /// This is the synchronous fill used by `sync --embed` and `reindex --embed`.
 /// The M5 daemon reuses the same batching from its background queue.
 pub async fn run_embedding_pass(
     store: &dyn Store,
     provider: &dyn EmbeddingProvider,
+    progress: impl FnMut(usize, usize),
+) -> Result<EmbedReport> {
+    run_embedding_pass_with_page(store, provider, EMBED_PAGE_SIZE, progress).await
+}
+
+/// [`run_embedding_pass`] with an explicit backlog page size. Production callers
+/// take [`EMBED_PAGE_SIZE`] through the wrapper; the parameter lets a test drive
+/// several pages over a small corpus.
+pub async fn run_embedding_pass_with_page(
+    store: &dyn Store,
+    provider: &dyn EmbeddingProvider,
+    page_size: usize,
     mut progress: impl FnMut(usize, usize),
 ) -> Result<EmbedReport> {
-    // The standalone `sync --embed` / `reindex --embed` fill embeds every domain
-    // (`None`); the daemon's background queue scopes its own pass instead.
-    let mut jobs = store
-        .chunks_needing_embedding(provider.model_id(), None)
-        .await?;
-    order_jobs_for_batching(&mut jobs);
-    let total = jobs.len();
-    if total == 0 {
-        return Ok(EmbedReport::default());
-    }
-
+    let page_size = page_size.max(1);
     let mut done = 0usize;
     let mut batches = 0usize;
-    for batch in jobs.chunks(EMBED_BATCH_SIZE) {
-        let texts: Vec<String> = batch.iter().map(|j| j.text.clone()).collect();
-        let vectors = provider.embed(&texts).await?;
-        if vectors.len() != batch.len() {
-            return Err(IndexError::Embedding(format!(
-                "provider returned {} vectors for {} inputs",
-                vectors.len(),
-                batch.len()
-            )));
+    let mut cursor: Option<(i64, i64)> = None;
+    loop {
+        // The standalone `sync --embed` / `reindex --embed` fill embeds every
+        // domain (`None`); the daemon's background queue scopes its own pass.
+        let mut jobs = store
+            .chunks_needing_embedding(provider.model_id(), None, page_size, cursor)
+            .await?;
+        if jobs.is_empty() {
+            break;
         }
-        let rows: Vec<EmbeddingRow> = batch
-            .iter()
-            .zip(vectors)
-            .map(|(job, embedding)| EmbeddingRow {
-                chunk_id: job.chunk_id,
-                dims: embedding.len(),
-                embedding,
-            })
-            .collect();
-        store.store_embeddings(&rows, provider.model_id()).await?;
-        done += batch.len();
-        batches += 1;
-        progress(done, total);
+        // A short page is the last one. The cursor is taken from the store's
+        // ordering, before the length sort reorders the page.
+        let last_page = jobs.len() < page_size;
+        cursor = jobs.last().map(|j| (j.engram_id, j.seq));
+        order_jobs_for_batching(&mut jobs);
+        let total = done + jobs.len();
+
+        for batch in jobs.chunks(EMBED_BATCH_SIZE) {
+            let texts: Vec<String> = batch.iter().map(|j| j.text.clone()).collect();
+            // A batch the provider cannot handle is logged and skipped, never
+            // fatal: its chunks keep no embedding, so they stay in the backlog
+            // for a later pass instead of starving every batch behind them.
+            let vectors = match provider.embed(&texts).await {
+                Ok(v) if v.len() == batch.len() => v,
+                Ok(v) => {
+                    tracing::warn!(
+                        chunks = ?batch.iter().map(|j| j.chunk_id).collect::<Vec<_>>(),
+                        "skipping an embed batch: the provider returned {} vectors for {} inputs",
+                        v.len(),
+                        batch.len()
+                    );
+                    continue;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        chunks = ?batch.iter().map(|j| j.chunk_id).collect::<Vec<_>>(),
+                        "skipping an embed batch the provider rejected: {e}"
+                    );
+                    continue;
+                }
+            };
+            let rows: Vec<EmbeddingRow> = batch
+                .iter()
+                .zip(vectors)
+                .map(|(job, embedding)| EmbeddingRow {
+                    chunk_id: job.chunk_id,
+                    dims: embedding.len(),
+                    embedding,
+                })
+                .collect();
+            store.store_embeddings(&rows, provider.model_id()).await?;
+            done += batch.len();
+            batches += 1;
+            progress(done, total);
+        }
+        if last_page {
+            break;
+        }
     }
     Ok(EmbedReport {
-        chunks: total,
+        chunks: done,
         batches,
     })
 }

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -27,8 +27,9 @@ pub mod vocab;
 
 pub use alias::AliasMap;
 pub use embed::{
-    ChunkParams, EmbedReport, EmbeddingProvider, ModelDownload, chunk_engram, configured_model_id,
-    download_local_model, order_jobs_for_batching, provider_from_config, run_embedding_pass,
+    ChunkParams, EMBED_PAGE_SIZE, EmbedReport, EmbeddingProvider, ModelDownload, chunk_engram,
+    configured_model_id, download_local_model, order_jobs_for_batching, provider_from_config,
+    run_embedding_pass, run_embedding_pass_with_page,
 };
 pub use error::{IndexError, Result};
 pub use factory::open_store;

--- a/crates/index/src/postgres/mod.rs
+++ b/crates/index/src/postgres/mod.rs
@@ -1457,21 +1457,25 @@ impl Store for PostgresStore {
         &self,
         model: &str,
         domains: Option<&[DomainId]>,
+        limit: usize,
+        after: Option<(i64, i64)>,
     ) -> Result<Vec<ChunkJob>> {
         // The base predicate is unchanged; an optional domain scope adds an
         // `engram_id IN (SELECT id FROM engram WHERE domain_id IN (...))` clause
         // so a non-host embeds only the chunks it owns. An empty scope matches
-        // nothing (this instance hosts nothing embeddable).
+        // nothing (this instance hosts nothing embeddable). The keyset cursor
+        // and the page limit ride on top of the same ordering the query always
+        // had, so a paged pass sees the same jobs in the same order.
         let mut sql = String::from(
             "SELECT id, engram_id, seq, text, text_hash FROM chunk \
              WHERE (embedding IS NULL OR model IS NULL OR model != $1)",
         );
         let mut params = vec![Param::Text(model.to_string())];
+        let mut n = 2;
         if let Some(ids) = domains {
             if ids.is_empty() {
                 return Ok(Vec::new());
             }
-            let mut n = 2;
             let placeholders: Vec<String> = ids
                 .iter()
                 .map(|id| {
@@ -1486,7 +1490,19 @@ impl Store for PostgresStore {
                 placeholders.join(",")
             ));
         }
-        sql.push_str(" ORDER BY engram_id, seq");
+        if let Some((engram_id, seq)) = after {
+            sql.push_str(&format!(
+                " AND (engram_id > ${n} OR (engram_id = ${} AND seq > ${}))",
+                n + 1,
+                n + 2
+            ));
+            params.push(Param::Int(engram_id));
+            params.push(Param::Int(engram_id));
+            params.push(Param::Int(seq));
+            n += 3;
+        }
+        sql.push_str(&format!(" ORDER BY engram_id, seq LIMIT ${n}"));
+        params.push(Param::Int(i64::try_from(limit).unwrap_or(i64::MAX)));
         let mut conn = self.acquire().await?;
         let rows = query_all(conn.as_mut(), &sql, params).await?;
         Ok(rows

--- a/crates/index/src/store.rs
+++ b/crates/index/src/store.rs
@@ -1129,10 +1129,19 @@ pub trait Store: Send + Sync {
     /// standalone default). Duplicate embedding across instances is always safe
     /// (the chunk fingerprint folds in the model id, so two instances converge
     /// on the same vector), just wasteful, and this filter avoids the waste.
+    ///
+    /// The result is one page: at most `limit` jobs ordered by
+    /// `(engram_id, seq)`, starting past the `after` key when it is given. A
+    /// caller pages the backlog with the last row of the previous page as the
+    /// next cursor rather than holding every job's text at once, and stops when
+    /// a page comes back short. Rows that gain an embedding mid-pass drop out of
+    /// the predicate behind the cursor, so paging never skips or repeats a job.
     async fn chunks_needing_embedding(
         &self,
         model: &str,
         domains: Option<&[DomainId]>,
+        limit: usize,
+        after: Option<(i64, i64)>,
     ) -> Result<Vec<ChunkJob>>;
 
     /// Store a batch of embeddings against their chunks for the given model.

--- a/crates/index/src/turso/mod.rs
+++ b/crates/index/src/turso/mod.rs
@@ -1232,21 +1232,25 @@ impl Store for TursoStore {
         &self,
         model: &str,
         domains: Option<&[DomainId]>,
+        limit: usize,
+        after: Option<(i64, i64)>,
     ) -> Result<Vec<ChunkJob>> {
         // The base predicate is unchanged; an optional domain scope adds an
         // `engram_id IN (SELECT id FROM engram WHERE domain_id IN (...))` clause
         // so a non-host embeds only the chunks it owns. An empty scope matches
-        // nothing (this instance hosts nothing embeddable).
+        // nothing (this instance hosts nothing embeddable). The keyset cursor
+        // and the page limit ride on top of the same ordering the query always
+        // had, so a paged pass sees the same jobs in the same order.
         let mut sql = String::from(
             "SELECT id, engram_id, seq, text, text_hash FROM chunk \
              WHERE (embedding IS NULL OR model IS NULL OR model != ?1)",
         );
         let mut params = vec![Value::Text(model.to_string())];
+        let mut n = 2;
         if let Some(ids) = domains {
             if ids.is_empty() {
                 return Ok(Vec::new());
             }
-            let mut n = 2;
             let placeholders: Vec<String> = ids
                 .iter()
                 .map(|id| {
@@ -1261,7 +1265,19 @@ impl Store for TursoStore {
                 placeholders.join(",")
             ));
         }
-        sql.push_str(" ORDER BY engram_id, seq");
+        if let Some((engram_id, seq)) = after {
+            sql.push_str(&format!(
+                " AND (engram_id > ?{n} OR (engram_id = ?{} AND seq > ?{}))",
+                n + 1,
+                n + 2
+            ));
+            params.push(Value::Integer(engram_id));
+            params.push(Value::Integer(engram_id));
+            params.push(Value::Integer(seq));
+            n += 3;
+        }
+        sql.push_str(&format!(" ORDER BY engram_id, seq LIMIT ?{n}"));
+        params.push(Value::Integer(i64::try_from(limit).unwrap_or(i64::MAX)));
         let rows = query_all(&self.conn, &sql, params).await?;
         Ok(rows
             .iter()

--- a/crates/index/tests/embed.rs
+++ b/crates/index/tests/embed.rs
@@ -8,8 +8,9 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 use crystalline_index::embed::estimate_tokens;
 use crystalline_index::{
-    ChunkJob, ChunkParams, EmbeddingProvider, IndexError, Result, SearchMode, SearchQuery, Store,
-    TursoStore, chunk_engram, order_jobs_for_batching, run_embedding_pass, sync_domain_with,
+    ChunkJob, ChunkParams, EMBED_PAGE_SIZE, EmbeddingProvider, IndexError, Result, SearchMode,
+    SearchQuery, Store, TursoStore, chunk_engram, order_jobs_for_batching, run_embedding_pass,
+    run_embedding_pass_with_page, sync_domain_with,
 };
 
 // --- chunking (no store) -----------------------------------------------------
@@ -51,21 +52,27 @@ fn code_fence_stays_one_unit() {
     assert!(joined.contains("line one"));
     assert!(joined.contains("line two after a blank"));
 
-    // With a tiny budget the fence is its own chunk and is never cut in half.
+    // A budget too small to hold the fence is the one case that cuts it: the
+    // pieces stay within the budget and every line survives, because one
+    // unbounded chunk is worse than an embedded fragment of a code block.
     let small = ChunkParams {
         model_id: "m".into(),
         max_tokens: 4,
     };
     let chunks = chunk_engram("", None, body, &small);
-    let fence_chunk = chunks
+    for c in &chunks {
+        assert!(
+            estimate_tokens(&c.text) <= 4,
+            "every chunk fits the budget: {:?}",
+            c.text
+        );
+    }
+    let joined = chunks
         .iter()
-        .find(|c| c.text.contains("line one"))
-        .expect("a chunk holds the fence");
-    assert!(
-        fence_chunk.text.contains("line two after a blank"),
-        "the fence is kept whole: {:?}",
-        fence_chunk.text
-    );
+        .map(|c| c.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert_eq!(squeezed(&joined), squeezed(body));
 }
 
 #[test]
@@ -94,6 +101,122 @@ fn fingerprints_are_stable_and_model_scoped() {
     assert_ne!(
         ca1[0].text_hash, cb[0].text_hash,
         "the model id namespaces the fingerprint"
+    );
+}
+
+/// The text with runs of whitespace collapsed to one space, so a chunk set can
+/// be compared against its source without caring where the cuts fell. Words
+/// survive the comparison only if no cut landed inside one.
+fn squeezed(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[test]
+fn an_oversized_paragraph_is_split_within_the_budget() {
+    // A body with no blank line anywhere (a log dump, a minified export) is one
+    // paragraph: without the cap it became a single chunk of the file's whole
+    // size and everything past the model's input limit went unembedded.
+    let body = "alpha bravo charlie delta ".repeat(400);
+    let params = ChunkParams {
+        model_id: "m".into(),
+        max_tokens: 50,
+    };
+    let chunks = chunk_engram("", None, &body, &params);
+    assert!(
+        chunks.len() > 10,
+        "the paragraph is cut into pieces: {}",
+        chunks.len()
+    );
+    for c in &chunks {
+        assert!(
+            estimate_tokens(&c.text) <= 50,
+            "every chunk fits the budget: {} tokens",
+            estimate_tokens(&c.text)
+        );
+    }
+    // Every word survives, in order and whole: the cuts prefer whitespace.
+    let joined = chunks
+        .iter()
+        .map(|c| c.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert_eq!(squeezed(&joined), squeezed(&body));
+}
+
+#[test]
+fn an_oversized_fence_is_split_within_the_budget() {
+    // A fence is kept whole only up to the budget: embedding parts of a huge
+    // code block beats holding it all in one chunk.
+    let inner = "let value = compute(alpha, bravo);\n".repeat(300);
+    let body = format!("intro paragraph\n\n```rust\n{inner}```\n");
+    let params = ChunkParams {
+        model_id: "m".into(),
+        max_tokens: 40,
+    };
+    let chunks = chunk_engram("", None, &body, &params);
+    assert!(chunks.len() > 10, "the fence is cut into pieces");
+    for c in &chunks {
+        assert!(
+            estimate_tokens(&c.text) <= 40,
+            "every chunk fits the budget: {} tokens",
+            estimate_tokens(&c.text)
+        );
+    }
+    let joined = chunks
+        .iter()
+        .map(|c| c.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert_eq!(squeezed(&joined), squeezed(&body));
+}
+
+#[test]
+fn a_cut_never_lands_inside_a_character() {
+    // Multi-byte text with no whitespace at all: the whitespace preference
+    // cannot apply, so every cut is a raw char-boundary cut. Slicing a byte
+    // index inside a character would panic, and the round trip proves nothing
+    // was dropped either.
+    let body = "漢字テスト".repeat(1000);
+    let params = ChunkParams {
+        model_id: "m".into(),
+        max_tokens: 30,
+    };
+    let chunks = chunk_engram("", None, &body, &params);
+    assert!(chunks.len() > 10, "the paragraph is cut into pieces");
+    for c in &chunks {
+        assert!(estimate_tokens(&c.text) <= 30);
+    }
+    let rejoined: String = chunks
+        .iter()
+        .flat_map(|c| c.text.chars())
+        .filter(|c| !c.is_whitespace())
+        .collect();
+    assert_eq!(rejoined, body);
+}
+
+#[test]
+fn an_ordinary_document_chunks_exactly_as_it_always_has() {
+    // Pins the packing of a body whose every paragraph fits the budget: the
+    // oversize cut must not perturb it. Expected texts are spelled out rather
+    // than derived, so a change in packing fails here.
+    let body =
+        "alpha beta gamma\n\ndelta epsilon\n\n```\nfn main() {}\n```\n\nzeta eta theta iota\n";
+    let params = ChunkParams {
+        model_id: "m".into(),
+        max_tokens: 6,
+    };
+    let texts: Vec<String> = chunk_engram("", None, body, &params)
+        .into_iter()
+        .map(|c| c.text)
+        .collect();
+    assert_eq!(
+        texts,
+        vec![
+            "alpha beta gamma".to_string(),
+            "delta epsilon".to_string(),
+            "```\nfn main() {}\n```".to_string(),
+            "zeta eta theta iota".to_string(),
+        ]
     );
 }
 
@@ -261,7 +384,7 @@ async fn store_and_retrieve_roundtrip() {
     // Nothing left to embed.
     assert!(
         store
-            .chunks_needing_embedding("fake-8", None)
+            .chunks_needing_embedding("fake-8", None, EMBED_PAGE_SIZE, None)
             .await
             .unwrap()
             .is_empty()
@@ -497,7 +620,7 @@ async fn unchanged_files_do_zero_reembedding_work() {
     assert_eq!(report.unchanged, 5);
     assert!(
         store
-            .chunks_needing_embedding("fake-8", None)
+            .chunks_needing_embedding("fake-8", None, EMBED_PAGE_SIZE, None)
             .await
             .unwrap()
             .is_empty(),
@@ -524,7 +647,7 @@ async fn editing_one_paragraph_only_reembeds_that_chunk() {
     run_embedding_pass(&store, &fake, |_, _| {}).await.unwrap();
     assert!(
         store
-            .chunks_needing_embedding("fake-8", None)
+            .chunks_needing_embedding("fake-8", None, EMBED_PAGE_SIZE, None)
             .await
             .unwrap()
             .is_empty()
@@ -540,7 +663,7 @@ async fn editing_one_paragraph_only_reembeds_that_chunk() {
     // Only the changed chunk (and the title-bearing first chunk if it moved) lost
     // its embedding; the fingerprint carry-over kept the untouched ones.
     let pending = store
-        .chunks_needing_embedding("fake-8", None)
+        .chunks_needing_embedding("fake-8", None, EMBED_PAGE_SIZE, None)
         .await
         .unwrap();
     assert!(
@@ -629,4 +752,129 @@ async fn run_embedding_pass_batches_jobs_length_ordered() {
             "batches are length-ordered across the whole pass: {flattened:?}"
         );
     }
+}
+
+#[tokio::test]
+async fn a_paged_embed_pass_embeds_every_chunk_exactly_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // Twenty-five one-chunk engrams driven with a page size of four, so the
+    // pass spans several full pages and ends on a short one.
+    for i in 0..25 {
+        write(
+            root,
+            &format!("e{i:02}.md"),
+            &engram(
+                &format!("E{i:02}"),
+                &format!("e{i:02}"),
+                "",
+                &format!("body of engram number {i:02}"),
+            ),
+        );
+    }
+    let store = open().await;
+    let provider = RecordingProvider::new("fake-8");
+    let params = ChunkParams::for_model(provider.model_id());
+    sync_domain_with(&store, "d", root, &params).await.unwrap();
+
+    let mut last_progress = (0usize, 0usize);
+    let report = run_embedding_pass_with_page(&store, &provider, 4, |done, total| {
+        last_progress = (done, total);
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(report.chunks, 25, "every chunk embedded");
+    assert_eq!(
+        last_progress,
+        (25, 25),
+        "the final progress call reports the true total"
+    );
+    // Every text went to the provider exactly once: paging neither skips a job
+    // nor hands one back on a later page.
+    let mut seen: Vec<String> = provider
+        .calls
+        .lock()
+        .unwrap()
+        .iter()
+        .flatten()
+        .cloned()
+        .collect();
+    assert_eq!(seen.len(), 25);
+    seen.sort();
+    seen.dedup();
+    assert_eq!(seen.len(), 25, "no chunk was embedded twice");
+    assert!(
+        store
+            .chunks_needing_embedding("fake-8", None, EMBED_PAGE_SIZE, None)
+            .await
+            .unwrap()
+            .is_empty(),
+        "the paged pass drains the backlog"
+    );
+}
+
+/// A provider that rejects any batch holding a text with the poison marker, the
+/// shape of a chunk the real provider chokes on.
+struct PoisonProvider {
+    model: String,
+}
+
+#[async_trait]
+impl EmbeddingProvider for PoisonProvider {
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        if texts.iter().any(|t| t.contains("POISON")) {
+            return Err(IndexError::Embedding("this batch is poisoned".into()));
+        }
+        Ok(texts.iter().map(|t| embed_one(t)).collect())
+    }
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+    fn dims(&self) -> usize {
+        8
+    }
+    fn max_input_tokens(&self) -> usize {
+        512
+    }
+}
+
+#[tokio::test]
+async fn a_rejected_batch_is_skipped_and_the_pass_continues() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // Ten one-chunk engrams, one of them poisoned. A page size of one makes
+    // every batch a single chunk, so exactly the poisoned chunk is skipped.
+    for i in 0..10 {
+        let body = if i == 7 {
+            "body of engram POISON seven".to_string()
+        } else {
+            format!("body of engram number {i:02}")
+        };
+        write(
+            root,
+            &format!("e{i:02}.md"),
+            &engram(&format!("E{i:02}"), &format!("e{i:02}"), "", &body),
+        );
+    }
+    let store = open().await;
+    let provider = PoisonProvider {
+        model: "fake-8".to_string(),
+    };
+    let params = ChunkParams::for_model(provider.model_id());
+    sync_domain_with(&store, "d", root, &params).await.unwrap();
+
+    let report = run_embedding_pass_with_page(&store, &provider, 1, |_, _| {})
+        .await
+        .unwrap();
+    assert_eq!(report.chunks, 9, "every healthy chunk embedded");
+
+    // The poisoned chunk kept no embedding, so it stays in the backlog for a
+    // later pass rather than blocking the nine behind it.
+    let pending = store
+        .chunks_needing_embedding("fake-8", None, EMBED_PAGE_SIZE, None)
+        .await
+        .unwrap();
+    assert_eq!(pending.len(), 1, "exactly the poisoned chunk is left");
+    assert!(pending[0].text.contains("POISON"));
 }

--- a/crates/index/tests/embed_model.rs
+++ b/crates/index/tests/embed_model.rs
@@ -14,7 +14,7 @@ use std::time::Instant;
 
 use crystalline_core::config::EmbeddingsConfig;
 use crystalline_index::{
-    ChunkParams, SearchMode, SearchQuery, Store, TursoStore, download_local_model,
+    ChunkParams, EMBED_PAGE_SIZE, SearchMode, SearchQuery, Store, TursoStore, download_local_model,
     provider_from_config, run_embedding_pass, sync_domain_with,
 };
 
@@ -172,7 +172,7 @@ async fn semantic_query_without_term_overlap_ranks_related_engram_top_three() {
     // Re-syncing the unchanged corpus embeds nothing.
     sync_domain_with(&store, "d", root, &params).await.unwrap();
     let pending = store
-        .chunks_needing_embedding(provider.model_id(), None)
+        .chunks_needing_embedding(provider.model_id(), None, EMBED_PAGE_SIZE, None)
         .await
         .unwrap();
     assert!(pending.is_empty(), "a warm resync re-embeds nothing");

--- a/crates/index/tests/store.rs
+++ b/crates/index/tests/store.rs
@@ -12,9 +12,9 @@
 use std::path::Path;
 
 use crystalline_index::{
-    DomainId, DomainKind, EdgeKind, EmbeddingCoverage, EmbeddingRow, EngramId, EngramRecord,
-    FileStamp, FilterOp, HostClaim, IndexError, MetadataFilter, NamedCount, NewChunk, RecentFilter,
-    SearchMode, SearchQuery, Store, TursoStore, Vocabulary, sync_domain,
+    DomainId, DomainKind, EMBED_PAGE_SIZE, EdgeKind, EmbeddingCoverage, EmbeddingRow, EngramId,
+    EngramRecord, FileStamp, FilterOp, HostClaim, IndexError, MetadataFilter, NamedCount, NewChunk,
+    RecentFilter, SearchMode, SearchQuery, Store, TursoStore, Vocabulary, sync_domain,
 };
 
 fn write(dir: &Path, rel: &str, content: &str) {
@@ -2469,7 +2469,7 @@ async fn embedding_width_follows_provider(store: &dyn Store) {
     // A narrow provider stores fine even though the column starts at 384: no
     // error surfaces on either backend.
     let jobs = store
-        .chunks_needing_embedding("narrow-8", None)
+        .chunks_needing_embedding("narrow-8", None, EMBED_PAGE_SIZE, None)
         .await
         .unwrap();
     assert!(!jobs.is_empty(), "chunks await embedding after sync");
@@ -2496,7 +2496,7 @@ async fn embedding_width_follows_provider(store: &dyn Store) {
     // A 384-dim provider resizes the column back and stores fine too. The
     // model swap makes every chunk pending again, dims aside.
     let jobs = store
-        .chunks_needing_embedding("wide-384", None)
+        .chunks_needing_embedding("wide-384", None, EMBED_PAGE_SIZE, None)
         .await
         .unwrap();
     assert_eq!(
@@ -2524,7 +2524,7 @@ async fn embedding_width_follows_provider(store: &dyn Store) {
     );
     assert!(
         store
-            .chunks_needing_embedding("wide-384", None)
+            .chunks_needing_embedding("wide-384", None, EMBED_PAGE_SIZE, None)
             .await
             .unwrap()
             .is_empty(),
@@ -2567,7 +2567,10 @@ async fn width_flip_survives_replace_chunks(store: &dyn Store) {
 
     // First width: 8 dims. Embeds every chunk, driving ensure_embedding_width's
     // ALTER for the first time.
-    let jobs = store.chunks_needing_embedding("m8", None).await.unwrap();
+    let jobs = store
+        .chunks_needing_embedding("m8", None, EMBED_PAGE_SIZE, None)
+        .await
+        .unwrap();
     assert!(
         !jobs.is_empty(),
         "chunks await embedding after the first sync"
@@ -2605,7 +2608,10 @@ async fn width_flip_survives_replace_chunks(store: &dyn Store) {
     // Second width: 16 dims, driving a second ALTER, then re-sync once more so
     // the carry SELECT runs again against a column that just changed shape a
     // second time.
-    let jobs = store.chunks_needing_embedding("m16", None).await.unwrap();
+    let jobs = store
+        .chunks_needing_embedding("m16", None, EMBED_PAGE_SIZE, None)
+        .await
+        .unwrap();
     let rows: Vec<EmbeddingRow> = jobs
         .iter()
         .map(|j| EmbeddingRow {
@@ -2655,7 +2661,10 @@ async fn store_embeddings_mid_batch_mismatch_leaves_nothing(store: &dyn Store) {
     );
     sync_domain(store, "d", root).await.unwrap();
 
-    let jobs = store.chunks_needing_embedding("m8", None).await.unwrap();
+    let jobs = store
+        .chunks_needing_embedding("m8", None, EMBED_PAGE_SIZE, None)
+        .await
+        .unwrap();
     assert!(
         jobs.len() >= 2,
         "need at least two chunks to exercise a mid-batch failure, got {}",
@@ -2713,12 +2722,12 @@ parity!(
 /// independent ground truth for a store whose only embeddings use `model`.
 async fn recomputed_coverage(store: &dyn Store, model: &str) -> (usize, usize) {
     let total = store
-        .chunks_needing_embedding("no-model-ever-embedded-this", None)
+        .chunks_needing_embedding("no-model-ever-embedded-this", None, EMBED_PAGE_SIZE, None)
         .await
         .unwrap()
         .len();
     let pending = store
-        .chunks_needing_embedding(model, None)
+        .chunks_needing_embedding(model, None, EMBED_PAGE_SIZE, None)
         .await
         .unwrap()
         .len();
@@ -2784,7 +2793,10 @@ async fn seed_two_chunks(store: &dyn Store) -> DomainId {
 
 /// Embed every currently-pending chunk with `model` at width 8.
 async fn embed_all(store: &dyn Store, model: &str) {
-    let jobs = store.chunks_needing_embedding(model, None).await.unwrap();
+    let jobs = store
+        .chunks_needing_embedding(model, None, EMBED_PAGE_SIZE, None)
+        .await
+        .unwrap();
     let rows: Vec<EmbeddingRow> = jobs
         .iter()
         .map(|j| EmbeddingRow {

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -34,10 +34,11 @@ use crystalline_core::{
 };
 use crystalline_index::{
     ChunkParams, DEFAULT_RETIRED_WEIGHT, DEFAULT_SALIENCE_WEIGHT, DomainHost, DomainId, DomainKind,
-    EdgeKind, EmbeddingProvider, EngramDescriptor, EngramId, EngramRecord, FileStamp, GraphNode,
-    GraphSlice, HostClaim, RecentFilter, SearchMode, SearchQuery, Store, SyncReport, apply_scan,
-    chunk_engram, configured_model_id, order_jobs_for_batching, parse_metadata_filters,
-    provider_from_config, retired_factor, salience_prior, scan_domain, scan_paths,
+    EMBED_PAGE_SIZE, EdgeKind, EmbeddingProvider, EngramDescriptor, EngramId, EngramRecord,
+    FileStamp, GraphNode, GraphSlice, HostClaim, RecentFilter, SearchMode, SearchQuery, Store,
+    SyncReport, apply_scan, chunk_engram, configured_model_id, order_jobs_for_batching,
+    parse_metadata_filters, provider_from_config, retired_factor, salience_prior, scan_domain,
+    scan_paths,
 };
 use crystalline_remote::ops;
 use crystalline_remote::{
@@ -3262,54 +3263,98 @@ impl Engine {
     /// the store only to pull jobs and to store vectors so long embeds do not
     /// block searches. Returns the number of chunks embedded.
     pub async fn embed_pending(&self) -> Result<usize> {
+        self.embed_pending_with_page(EMBED_PAGE_SIZE).await
+    }
+
+    /// [`Self::embed_pending`] with an explicit backlog page size. Production
+    /// callers take [`EMBED_PAGE_SIZE`] through the wrapper; the parameter lets
+    /// a test drive several pages over a small corpus.
+    ///
+    /// A batch the provider rejects is logged and skipped, not fatal: its chunks
+    /// keep no embedding and stay in the backlog, visible in `status`, for a
+    /// later pass, so one poisoned batch cannot starve the whole queue. Only
+    /// store errors abort the pass.
+    pub async fn embed_pending_with_page(&self, page_size: usize) -> Result<usize> {
         let Some(provider) = self.provider() else {
             return Ok(0);
         };
         let model = self.model_id.clone();
-        // One snapshot of outstanding chunks; the store lock is held only to pull
-        // jobs and to write vectors, never across the embed call. In
-        // collaboration mode the scan is scoped to the file domains this instance
-        // hosts plus all virtual domains, so a non-host does not wastefully
-        // re-embed a chunk another instance owns; standalone it embeds everything.
-        let mut jobs = {
+        let page_size = page_size.max(1);
+        // In collaboration mode the scan is scoped to the file domains this
+        // instance hosts plus all virtual domains, so a non-host does not
+        // wastefully re-embed a chunk another instance owns; standalone it
+        // embeds everything. The scope holds for the whole pass.
+        let scope = {
             let store = self.store.lock().await;
-            let scope = self.embed_scope(&*store).await?;
-            store
-                .chunks_needing_embedding(&model, scope.as_deref())
-                .await?
+            self.embed_scope(&*store).await?
         };
-        if jobs.is_empty() {
-            return Ok(0);
-        }
-        // Length-sort so batches pay for their longest member once instead of
-        // padding every short chunk out to whatever long one happened to land
-        // in the same batch.
-        order_jobs_for_batching(&mut jobs);
-        let _activity = ActivityState::begin(&self.activity, "embed", None);
+        // The backlog is walked one keyset page at a time so a large first index
+        // never holds every chunk's text at once. The store lock is held only to
+        // pull a page and to write vectors, never across the embed call.
         let mut embedded = 0usize;
-        for batch in jobs.chunks(EMBED_BATCH) {
-            let texts: Vec<String> = batch.iter().map(|j| j.text.clone()).collect();
-            let vectors = provider
-                .embed(&texts)
-                .await
-                .map_err(|e| EngineError::Internal(e.to_string()))?;
-            if vectors.len() != batch.len() {
-                return Err(EngineError::Internal(
-                    "embedding provider returned a mismatched vector count".into(),
-                ));
+        let mut cursor: Option<(i64, i64)> = None;
+        let mut activity: Option<ActivityGuard> = None;
+        loop {
+            let mut jobs = {
+                let store = self.store.lock().await;
+                store
+                    .chunks_needing_embedding(&model, scope.as_deref(), page_size, cursor)
+                    .await?
+            };
+            if jobs.is_empty() {
+                break;
             }
-            let rows: Vec<crystalline_index::EmbeddingRow> = batch
-                .iter()
-                .zip(vectors)
-                .map(|(job, embedding)| crystalline_index::EmbeddingRow {
-                    chunk_id: job.chunk_id,
-                    dims: embedding.len(),
-                    embedding,
-                })
-                .collect();
-            let store = self.store.lock().await;
-            store.store_embeddings(&rows, &model).await?;
-            embedded += batch.len();
+            // A short page is the last one. The cursor is taken from the store's
+            // ordering, before the length sort reorders the page.
+            let last_page = jobs.len() < page_size;
+            cursor = jobs.last().map(|j| (j.engram_id, j.seq));
+            // Length-sort so batches pay for their longest member once instead
+            // of padding every short chunk out to whatever long one happened to
+            // land in the same batch.
+            order_jobs_for_batching(&mut jobs);
+            if activity.is_none() {
+                activity = Some(ActivityState::begin(&self.activity, "embed", None));
+            }
+            for batch in jobs.chunks(EMBED_BATCH) {
+                let texts: Vec<String> = batch.iter().map(|j| j.text.clone()).collect();
+                // A batch the provider cannot handle is logged and skipped: its
+                // chunks keep no embedding, so they stay in the backlog for a
+                // later pass instead of starving every batch behind them.
+                let vectors = match provider.embed(&texts).await {
+                    Ok(v) if v.len() == batch.len() => v,
+                    Ok(v) => {
+                        tracing::warn!(
+                            chunks = ?batch.iter().map(|j| j.chunk_id).collect::<Vec<_>>(),
+                            "skipping an embed batch: the provider returned {} vectors for {} inputs",
+                            v.len(),
+                            batch.len()
+                        );
+                        continue;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            chunks = ?batch.iter().map(|j| j.chunk_id).collect::<Vec<_>>(),
+                            "skipping an embed batch the provider rejected: {e}"
+                        );
+                        continue;
+                    }
+                };
+                let rows: Vec<crystalline_index::EmbeddingRow> = batch
+                    .iter()
+                    .zip(vectors)
+                    .map(|(job, embedding)| crystalline_index::EmbeddingRow {
+                        chunk_id: job.chunk_id,
+                        dims: embedding.len(),
+                        embedding,
+                    })
+                    .collect();
+                let store = self.store.lock().await;
+                store.store_embeddings(&rows, &model).await?;
+                embedded += batch.len();
+            }
+            if last_page {
+                break;
+            }
         }
         Ok(embedded)
     }

--- a/crates/service/tests/embed_tick.rs
+++ b/crates/service/tests/embed_tick.rs
@@ -1,7 +1,9 @@
 //! The daemon's embed self-heal tick. The embed worker is event-driven: a
 //! transient provider failure consumes its signal and strands the backlog until
 //! the next write. This periodic tick re-fires the worker while a backlog
-//! remains and stays silent when there is none, and exits on shutdown.
+//! remains and stays silent when there is none, and exits on shutdown. The
+//! engine's own pass is covered here too: it pages the backlog and skips a
+//! batch the provider rejects instead of stranding the rest.
 
 mod support;
 
@@ -212,5 +214,103 @@ async fn embed_worker_checkpoints_the_wal_after_a_pass() {
         "the embed worker never checkpointed the WAL after its pass: embed calls={}, wal={:?}",
         embedder.calls.load(std::sync::atomic::Ordering::SeqCst),
         std::fs::metadata(wal_path(&db)).map(|m| m.len())
+    );
+}
+
+#[tokio::test]
+async fn embed_pending_pages_the_backlog_and_embeds_each_chunk_once() {
+    // Ten one-chunk engrams driven with a page size of three, so the pass spans
+    // several full pages and ends on a short one. The backlog is walked by
+    // keyset cursor, so a paged pass must embed every chunk exactly once.
+    let store = TursoStore::open_in_memory().await.unwrap();
+    let store: Arc<Mutex<dyn Store>> = Arc::new(Mutex::new(store));
+    let engine = Arc::new(virtual_engine(store));
+    let embedder = Arc::new(CountingEmbedder::new());
+    engine.set_provider(embedder.clone());
+
+    for i in 0..10 {
+        engine
+            .write_engram(&write_params(
+                &format!("Note {i:02}"),
+                &format!("the body of note number {i:02}"),
+            ))
+            .await
+            .unwrap();
+    }
+    let backlog = engine.embedding_backlog().await.unwrap();
+    assert_eq!(backlog, 10, "one chunk per note is outstanding");
+
+    let embedded = engine.embed_pending_with_page(3).await.unwrap();
+    assert_eq!(embedded, backlog, "every chunk embedded exactly once");
+    assert_eq!(
+        engine.embedding_backlog().await.unwrap(),
+        0,
+        "the paged pass drains the backlog"
+    );
+    // One provider call per page (a page is well under the batch size), so the
+    // pass really did span four pages rather than one snapshot.
+    assert_eq!(
+        embedder.calls.load(std::sync::atomic::Ordering::SeqCst),
+        4,
+        "ten chunks at a page size of three is four pages"
+    );
+    // A second pass has nothing left to do.
+    assert_eq!(engine.embed_pending_with_page(3).await.unwrap(), 0);
+}
+
+/// An embedder that rejects any batch holding a text with the poison marker,
+/// the shape of a chunk the real provider chokes on.
+struct PoisonEmbedder;
+
+#[async_trait::async_trait]
+impl crystalline_index::EmbeddingProvider for PoisonEmbedder {
+    async fn embed(&self, texts: &[String]) -> crystalline_index::Result<Vec<Vec<f32>>> {
+        if texts.iter().any(|t| t.contains("POISON")) {
+            return Err(crystalline_index::IndexError::Embedding(
+                "this batch is poisoned".into(),
+            ));
+        }
+        Ok(vec![vec![0.1_f32; 4]; texts.len()])
+    }
+    fn model_id(&self) -> &str {
+        "test-model"
+    }
+    fn dims(&self) -> usize {
+        4
+    }
+    fn max_input_tokens(&self) -> usize {
+        512
+    }
+}
+
+#[tokio::test]
+async fn a_rejected_batch_never_starves_the_backlog() {
+    // A chunk the provider chokes on must not strand everything queued behind
+    // it: the field symptom this guards is a backlog stuck at a handful of
+    // chunks for days. A page size of one makes every batch a single chunk, so
+    // exactly the poisoned chunk survives the pass unembedded.
+    let store = TursoStore::open_in_memory().await.unwrap();
+    let store: Arc<Mutex<dyn Store>> = Arc::new(Mutex::new(store));
+    let engine = Arc::new(virtual_engine(store));
+    engine.set_provider(Arc::new(PoisonEmbedder));
+
+    for i in 0..6 {
+        let body = if i == 3 {
+            "a POISON body the provider rejects".to_string()
+        } else {
+            format!("the body of note number {i:02}")
+        };
+        engine
+            .write_engram(&write_params(&format!("Note {i:02}"), &body))
+            .await
+            .unwrap();
+    }
+
+    let embedded = engine.embed_pending_with_page(1).await.unwrap();
+    assert_eq!(embedded, 5, "every healthy chunk embedded");
+    assert_eq!(
+        engine.embedding_backlog().await.unwrap(),
+        1,
+        "the poisoned chunk stays in the backlog, visible for a later pass"
     );
 }


### PR DESCRIPTION
First of three PRs from research/2026-07-27-memory-leak-review.md (the ~70 GB sighting + the stuck `embedding backlog: 13`).

**F1 chunk cap**: `pack()` hard-splits a paragraph exceeding the token budget (fences included, kept whole only up to the budget) at char boundaries preferring whitespace. Previously a blank-line-free `.md` became ONE chunk of unbounded size; the tokenizer encodes the full text before truncating (~80 B/token of Encoding overhead) and the length sort concentrated the worst chunks into a single batch - tens of GB from one file. Splitting strictly improves semantic coverage: text past 512 tokens of a giant paragraph was silently unembedded before. Ordinary documents chunk byte-identically (pinned by a test verified against the pre-change implementation).

**F1 defense in depth**: the local provider caps every input at `MAX_INPUT_TOKENS * 6` chars before `encode_batch` - this also bounds already-stored oversized chunk rows, so machines with a stuck backlog heal on upgrade with no resync.

**F2 backlog pagination**: `chunks_needing_embedding` gains keyset pagination (`(engram_id, seq)` cursor + LIMIT, identical in turso and postgres); both embed passes walk `EMBED_PAGE_SIZE = 512` pages, so a first index never snapshots the whole backlog's text.

**F1b batch resilience**: a provider error or vector-count mismatch skips that batch (warn with chunk ids) and continues; skipped chunks stay visible in the status backlog and retry next pass. This is the fix for the field symptom of a backlog stuck at 13 for days: the oversized chunks land in the final batch via the length sort and the old abort-on-error pass died there every time.

Verification: workspace nextest green (one run had 2 failures in `github_auth` device-flow polling tests - load flakes at 35 s vs their normal 10 ms, pass in isolation with and without this diff, untouched by it); doctests, clippy -D warnings, fmt, style-lint green; postgres parity suite run locally 3x against postgresql@18, all green. 10 new tests incl. UTF-8 boundary, page-exactness and poisoned-batch coverage.