### PR TITLE
Cap the lexical prefilter and bound the watcher queue

### DIFF
--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -37,9 +37,10 @@ pub use store::{
     ChunkJob, ChunkModelCount, DEFAULT_RETIRED_WEIGHT, DEFAULT_SALIENCE_WEIGHT, DomainHost,
     DomainId, DomainKind, DomainStats, EdgeKind, EmbeddingCoverage, EmbeddingRow, EngramDescriptor,
     EngramId, EngramRecord, EngramSummary, FileStamp, FilterOp, FtsMode, GraphEdge, GraphNode,
-    GraphSlice, HitKind, HostClaim, InboundRef, MetadataFilter, NamedCount, NewChunk, OutboundRef,
-    Page, RecentFilter, SearchHit, SearchMode, SearchQuery, Store, StoreInfo, StoredEngram,
-    TagAlias, TagCount, Vocabulary, parse_metadata_filters, retired_factor, salience_prior,
+    GraphSlice, HitKind, HostClaim, InboundRef, LEXICAL_CANDIDATE_CAP, MetadataFilter, NamedCount,
+    NewChunk, OutboundRef, Page, RecentFilter, SearchHit, SearchMode, SearchQuery, Store,
+    StoreInfo, StoredEngram, TagAlias, TagCount, Vocabulary, parse_metadata_filters,
+    retired_factor, salience_prior,
 };
 pub use sync::{
     DomainScan, SyncReport, apply_scan, apply_scan_with_slab, refresh_tag_aliases, scan_domain,

--- a/crates/index/src/postgres/mod.rs
+++ b/crates/index/src/postgres/mod.rs
@@ -1266,7 +1266,11 @@ impl Store for PostgresStore {
         Ok(rows.iter().map(outbound_ref_from_row).collect())
     }
 
-    async fn search(&self, query: &SearchQuery) -> Result<Page<SearchHit>> {
+    async fn search_with_candidate_cap(
+        &self,
+        query: &SearchQuery,
+        candidate_cap: usize,
+    ) -> Result<Page<SearchHit>> {
         // Compute the coverage snapshot for the semantic and hybrid modes (which
         // gate on embedding staleness) BEFORE acquiring the search connection:
         // embedding_coverage() acquires its own connection, and holding two
@@ -1289,7 +1293,14 @@ impl Store for PostgresStore {
             AliasMap::default()
         };
         let mut conn = self.acquire().await?;
-        search::run_search(conn.as_mut(), query, coverage.as_ref(), &aliases).await
+        search::run_search(
+            conn.as_mut(),
+            query,
+            coverage.as_ref(),
+            &aliases,
+            candidate_cap,
+        )
+        .await
     }
 
     async fn neighbors(&self, ids: &[EngramId], depth: u8) -> Result<GraphSlice> {

--- a/crates/index/src/postgres/search.rs
+++ b/crates/index/src/postgres/search.rs
@@ -44,18 +44,30 @@ const SINGLE_SOURCE_PENALTY: f64 = 0.85;
 /// Run a search and return one page of hits plus the total match count. The
 /// `coverage` snapshot is supplied by the store for the semantic and hybrid modes
 /// (which gate on embedding staleness) and is `None` for the lexical modes.
+/// `candidate_cap` bounds the lexical prefilter; production passes
+/// [`crate::store::LEXICAL_CANDIDATE_CAP`].
 pub(super) async fn run_search(
     conn: &mut PgConnection,
     query: &SearchQuery,
     coverage: Option<&EmbeddingCoverage>,
     aliases: &AliasMap,
+    candidate_cap: usize,
 ) -> Result<Page<SearchHit>> {
     match query.mode {
         SearchMode::Semantic => {
             run_semantic(conn, query, require_coverage(coverage)?, aliases).await
         }
-        SearchMode::Hybrid => run_hybrid(conn, query, require_coverage(coverage)?, aliases).await,
-        _ => run_lexical(conn, query, aliases).await,
+        SearchMode::Hybrid => {
+            run_hybrid(
+                conn,
+                query,
+                require_coverage(coverage)?,
+                aliases,
+                candidate_cap,
+            )
+            .await
+        }
+        _ => run_lexical(conn, query, aliases, candidate_cap).await,
     }
 }
 
@@ -128,6 +140,7 @@ async fn run_lexical(
     conn: &mut PgConnection,
     query: &SearchQuery,
     aliases: &AliasMap,
+    candidate_cap: usize,
 ) -> Result<Page<SearchHit>> {
     let limit = if query.limit == 0 { 10 } else { query.limit };
     let page = query.page.max(1);
@@ -147,7 +160,7 @@ async fn run_lexical(
         return filter_only(conn, &where_sql, params, limit, page).await;
     }
 
-    let mut scored = scored_lexical(conn, query, &terms, aliases).await?;
+    let mut scored = scored_lexical(conn, query, &terms, aliases, candidate_cap).await?;
     let retired_weight = query.retired_weight.unwrap_or(DEFAULT_RETIRED_WEIGHT);
     for entry in &mut scored {
         entry.0 *= retired_factor(&entry.1.status, retired_weight);
@@ -172,11 +185,17 @@ async fn run_lexical(
 /// fade is applied by each of those callers exactly once, over this function's
 /// returned scores, never in here - applying it here would double-fade the
 /// hybrid path and distort its `max_text` normalization.
+///
+/// `candidate_cap` bounds how many candidate rows the prefilter loads: the query
+/// orders by engram id and takes at most that many, so a common term over a huge
+/// domain can never pull the whole matched corpus into memory. See
+/// [`crate::store::LEXICAL_CANDIDATE_CAP`] for what the cut means for ranking.
 async fn scored_lexical(
     conn: &mut PgConnection,
     query: &SearchQuery,
     terms: &[String],
     aliases: &AliasMap,
+    candidate_cap: usize,
 ) -> Result<Vec<(f64, Candidate)>> {
     let mut clauses: Vec<String> = Vec::new();
     let mut params: Vec<Param> = Vec::new();
@@ -206,13 +225,21 @@ async fn scored_lexical(
     let sql = format!(
         "SELECT e.id, d.name, e.permalink, e.title, e.engram_type, e.status, e.description, e.content, \
          CASE WHEN jsonb_typeof(e.metadata -> 'salience') = 'number' THEN (e.metadata ->> 'salience')::double precision END \
-         FROM engram e JOIN domain d ON d.id=e.domain_id {where_sql}"
+         FROM engram e JOIN domain d ON d.id=e.domain_id {where_sql} \
+         ORDER BY e.id LIMIT {candidate_cap}"
     );
     let rows = query_all(conn, &sql, params).await?;
 
+    // Consume the raw rows by value so each row's buffers are freed as its
+    // candidate is built: peak memory is one copy of the matched bytes in the
+    // candidates plus one lowered copy, never a third live copy in the rows.
+    // The lowered copy stays: snippets are cut from the original body and
+    // Unicode lowercasing can shift byte offsets, so scoring against a lowered
+    // copy is the only offset-safe way to keep snippets correct.
     let mut scored: Vec<(f64, Candidate)> = Vec::with_capacity(rows.len());
-    for r in &rows {
-        let mut c = Candidate::from_row(r);
+    for r in rows {
+        let mut c = Candidate::from_row(&r);
+        drop(r);
         c.lower();
         let score = c.score(terms);
         scored.push((score, c));
@@ -341,6 +368,7 @@ async fn run_hybrid(
     query: &SearchQuery,
     coverage: &EmbeddingCoverage,
     aliases: &AliasMap,
+    candidate_cap: usize,
 ) -> Result<Page<SearchHit>> {
     let qvec = query
         .query_embedding
@@ -363,7 +391,7 @@ async fn run_hybrid(
     let text_scored = if terms.is_empty() {
         Vec::new()
     } else {
-        scored_lexical(conn, query, &terms, aliases).await?
+        scored_lexical(conn, query, &terms, aliases, candidate_cap).await?
     };
     let mut sem = semantic_candidates(conn, query, qvec, active, dims, aliases).await?;
     sem.retain(|(sim, _)| *sim >= min_sim);

--- a/crates/index/src/store.rs
+++ b/crates/index/src/store.rs
@@ -540,6 +540,17 @@ pub fn salience_prior(salience: Option<f64>, weight: f64) -> f64 {
     weight * (s / SALIENCE_SCALE).clamp(0.0, 1.0)
 }
 
+/// How many LIKE candidates the lexical prefilter loads before it ranks them in
+/// Rust, in both backends. The cut is deterministic: the candidate query orders
+/// by engram id, so the same corpus and the same query always yield the same
+/// candidate set. A term that matches more engrams than the cap is ranked within
+/// the first `LEXICAL_CANDIDATE_CAP` matches by id rather than over the whole
+/// match set, and the reported total is capped with it. The value is generous
+/// enough that a realistic corpus never reaches it; it exists so a filter-only
+/// or very common term over a huge domain cannot pull the whole matched corpus
+/// into memory at once.
+pub const LEXICAL_CANDIDATE_CAP: usize = 5000;
+
 /// Statuses that mark knowledge as retired. Exact lowercase match, the same
 /// stance as the canonical `e.status = 'current'` filter.
 const RETIRED_STATUSES: [&str; 4] = ["deprecated", "superseded", "archived", "legacy"];
@@ -1105,7 +1116,21 @@ pub trait Store: Send + Sync {
     async fn outbound_refs(&self, engram_id: EngramId) -> Result<Vec<OutboundRef>>;
 
     /// Run a search and return one page of hits plus the total match count.
-    async fn search(&self, query: &SearchQuery) -> Result<Page<SearchHit>>;
+    async fn search(&self, query: &SearchQuery) -> Result<Page<SearchHit>> {
+        self.search_with_candidate_cap(query, LEXICAL_CANDIDATE_CAP)
+            .await
+    }
+
+    /// [`Store::search`] with an explicit lexical candidate cap, so a test can
+    /// exercise the cap boundary over a handful of engrams. `candidate_cap` only
+    /// bounds how many LIKE candidates the lexical prefilter loads and ranks; it
+    /// never changes the shape of a hit. Production always goes through
+    /// [`Store::search`], which passes [`LEXICAL_CANDIDATE_CAP`].
+    async fn search_with_candidate_cap(
+        &self,
+        query: &SearchQuery,
+        candidate_cap: usize,
+    ) -> Result<Page<SearchHit>>;
 
     /// Return the neighborhood of a set of seed engrams up to `depth` hops
     /// (`1..=3`), following relations and links across domain boundaries.

--- a/crates/index/src/turso/mod.rs
+++ b/crates/index/src/turso/mod.rs
@@ -1060,7 +1060,11 @@ impl Store for TursoStore {
         Ok(rows.iter().map(outbound_ref_from_row).collect())
     }
 
-    async fn search(&self, query: &SearchQuery) -> Result<Page<SearchHit>> {
+    async fn search_with_candidate_cap(
+        &self,
+        query: &SearchQuery,
+        candidate_cap: usize,
+    ) -> Result<Page<SearchHit>> {
         // The semantic and hybrid modes gate on embedding staleness, which reads
         // the coverage snapshot; the cache makes that essentially free once
         // effective_mode has warmed it, and folds the old second aggregate scan
@@ -1078,7 +1082,14 @@ impl Store for TursoStore {
         } else {
             AliasMap::default()
         };
-        search::run_search(&self.conn, query, coverage.as_ref(), &aliases).await
+        search::run_search(
+            &self.conn,
+            query,
+            coverage.as_ref(),
+            &aliases,
+            candidate_cap,
+        )
+        .await
     }
 
     async fn neighbors(&self, ids: &[EngramId], depth: u8) -> Result<GraphSlice> {

--- a/crates/index/src/turso/search.rs
+++ b/crates/index/src/turso/search.rs
@@ -39,18 +39,30 @@ const SINGLE_SOURCE_PENALTY: f64 = 0.85;
 /// Run a search and return one page of hits plus the total match count. The
 /// `coverage` snapshot is supplied by the store for the semantic and hybrid modes
 /// (which gate on embedding staleness) and is `None` for the lexical modes.
+/// `candidate_cap` bounds the lexical prefilter; production passes
+/// [`crate::store::LEXICAL_CANDIDATE_CAP`].
 pub(super) async fn run_search(
     conn: &Connection,
     query: &SearchQuery,
     coverage: Option<&EmbeddingCoverage>,
     aliases: &AliasMap,
+    candidate_cap: usize,
 ) -> Result<Page<SearchHit>> {
     match query.mode {
         SearchMode::Semantic => {
             run_semantic(conn, query, require_coverage(coverage)?, aliases).await
         }
-        SearchMode::Hybrid => run_hybrid(conn, query, require_coverage(coverage)?, aliases).await,
-        _ => run_lexical(conn, query, aliases).await,
+        SearchMode::Hybrid => {
+            run_hybrid(
+                conn,
+                query,
+                require_coverage(coverage)?,
+                aliases,
+                candidate_cap,
+            )
+            .await
+        }
+        _ => run_lexical(conn, query, aliases, candidate_cap).await,
     }
 }
 
@@ -123,6 +135,7 @@ async fn run_lexical(
     conn: &Connection,
     query: &SearchQuery,
     aliases: &AliasMap,
+    candidate_cap: usize,
 ) -> Result<Page<SearchHit>> {
     let limit = if query.limit == 0 { 10 } else { query.limit };
     let page = query.page.max(1);
@@ -142,7 +155,7 @@ async fn run_lexical(
         return filter_only(conn, &where_sql, params, limit, page).await;
     }
 
-    let mut scored = scored_lexical(conn, query, &terms, aliases).await?;
+    let mut scored = scored_lexical(conn, query, &terms, aliases, candidate_cap).await?;
     let retired_weight = query.retired_weight.unwrap_or(DEFAULT_RETIRED_WEIGHT);
     for entry in &mut scored {
         entry.0 *= retired_factor(&entry.1.status, retired_weight);
@@ -167,11 +180,17 @@ async fn run_lexical(
 /// fade is applied by each of those callers exactly once, over this function's
 /// returned scores, never in here - applying it here would double-fade the
 /// hybrid path and distort its `max_text` normalization.
+///
+/// `candidate_cap` bounds how many candidate rows the prefilter loads: the query
+/// orders by engram id and takes at most that many, so a common term over a huge
+/// domain can never pull the whole matched corpus into memory. See
+/// [`crate::store::LEXICAL_CANDIDATE_CAP`] for what the cut means for ranking.
 async fn scored_lexical(
     conn: &Connection,
     query: &SearchQuery,
     terms: &[String],
     aliases: &AliasMap,
+    candidate_cap: usize,
 ) -> Result<Vec<(f64, Candidate)>> {
     let mut clauses: Vec<String> = Vec::new();
     let mut params: Vec<Value> = Vec::new();
@@ -201,13 +220,21 @@ async fn scored_lexical(
     let sql = format!(
         "SELECT e.id, d.name, e.permalink, e.title, e.engram_type, e.status, e.description, e.content, \
          CAST(json_extract(e.metadata, '$.salience') AS REAL) \
-         FROM engram e JOIN domain d ON d.id=e.domain_id {where_sql}"
+         FROM engram e JOIN domain d ON d.id=e.domain_id {where_sql} \
+         ORDER BY e.id LIMIT {candidate_cap}"
     );
     let rows = query_all(conn, &sql, params).await?;
 
+    // Consume the raw rows by value so each row's buffers are freed as its
+    // candidate is built: peak memory is one copy of the matched bytes in the
+    // candidates plus one lowered copy, never a third live copy in the rows.
+    // The lowered copy stays: snippets are cut from the original body and
+    // Unicode lowercasing can shift byte offsets, so scoring against a lowered
+    // copy is the only offset-safe way to keep snippets correct.
     let mut scored: Vec<(f64, Candidate)> = Vec::with_capacity(rows.len());
-    for r in &rows {
-        let mut c = Candidate::from_row(r);
+    for r in rows {
+        let mut c = Candidate::from_row(&r);
+        drop(r);
         c.lower();
         let score = c.score(terms);
         scored.push((score, c));
@@ -359,6 +386,7 @@ async fn run_hybrid(
     query: &SearchQuery,
     coverage: &EmbeddingCoverage,
     aliases: &AliasMap,
+    candidate_cap: usize,
 ) -> Result<Page<SearchHit>> {
     let qvec = query
         .query_embedding
@@ -381,7 +409,7 @@ async fn run_hybrid(
     let text_scored = if terms.is_empty() {
         Vec::new()
     } else {
-        scored_lexical(conn, query, &terms, aliases).await?
+        scored_lexical(conn, query, &terms, aliases, candidate_cap).await?
     };
     let mut sem = semantic_candidates(conn, query, qvec, active, dims, aliases).await?;
     sem.retain(|(sim, _)| *sim >= min_sim);

--- a/crates/index/tests/store.rs
+++ b/crates/index/tests/store.rs
@@ -3019,3 +3019,119 @@ fn metadata_filters_accept_a_json_encoded_object() {
         );
     }
 }
+
+/// The lexical candidate cap bounds how many LIKE matches the prefilter loads
+/// and ranks. Production uses `LEXICAL_CANDIDATE_CAP`; this drives the same code
+/// with a tiny injected cap over a corpus that exceeds it, so the boundary is
+/// exercised on a handful of engrams. The cut is by engram id, so which engrams
+/// land in the capped set is not asserted (the scan walks in filesystem order);
+/// what is asserted is that the cap holds, that the survivors are ranked
+/// correctly among themselves and that paging through them is consistent.
+async fn lexical_candidate_cap(store: &dyn Store) {
+    const CORPUS: usize = 12;
+    const CAP: usize = 5;
+
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // Engram n mentions the term n+1 times, so a hit's score is recoverable from
+    // its permalink and any correctly ranked page is strictly descending in n.
+    for n in 0..CORPUS {
+        let body = std::iter::repeat_n("widgetterm", n + 1)
+            .collect::<Vec<_>>()
+            .join(" ");
+        write(
+            root,
+            &format!("e{n:02}.md"),
+            &engram(
+                &format!("Engram {n:02}"),
+                &format!("e{n:02}"),
+                "engram",
+                "",
+                &body,
+            ),
+        );
+    }
+    sync_domain(store, "d", root).await.unwrap();
+
+    /// The mention count encoded in a permalink like `e07`.
+    fn rank_key(permalink: &str) -> usize {
+        permalink.trim_start_matches('e').parse::<usize>().unwrap()
+    }
+
+    // Uncapped: every match is a candidate and the most-mentioning engram leads.
+    let all = store
+        .search(&SearchQuery {
+            limit: CORPUS,
+            ..SearchQuery::text("widgetterm")
+        })
+        .await
+        .unwrap();
+    assert_eq!(all.total, CORPUS, "no cap reached at the production value");
+    assert_eq!(all.items[0].permalink, format!("e{:02}", CORPUS - 1));
+
+    // Capped: the total and the returned set both stop at the cap.
+    let capped = store
+        .search_with_candidate_cap(
+            &SearchQuery {
+                limit: CORPUS,
+                ..SearchQuery::text("widgetterm")
+            },
+            CAP,
+        )
+        .await
+        .unwrap();
+    assert_eq!(capped.total, CAP, "the cap bounds the reported total");
+    assert_eq!(capped.items.len(), CAP);
+
+    // Ranking within the capped set is still by score, best first.
+    let keys: Vec<usize> = capped
+        .items
+        .iter()
+        .map(|h| rank_key(&h.permalink))
+        .collect();
+    assert!(
+        keys.windows(2).all(|w| w[0] > w[1]),
+        "the capped page is not ranked best first: {keys:?}"
+    );
+    assert!(
+        capped.items.windows(2).all(|w| w[0].score >= w[1].score),
+        "scores are not descending"
+    );
+
+    // The cut is deterministic: the same query yields the same candidates.
+    let again = store
+        .search_with_candidate_cap(
+            &SearchQuery {
+                limit: CORPUS,
+                ..SearchQuery::text("widgetterm")
+            },
+            CAP,
+        )
+        .await
+        .unwrap();
+    let again_keys: Vec<usize> = again.items.iter().map(|h| rank_key(&h.permalink)).collect();
+    assert_eq!(again_keys, keys, "the capped candidate set is not stable");
+
+    // Paging through the capped set walks the same ranking, page by page.
+    let mut paged: Vec<usize> = Vec::new();
+    for page in 1..=3 {
+        let p = store
+            .search_with_candidate_cap(
+                &SearchQuery {
+                    limit: 2,
+                    page,
+                    ..SearchQuery::text("widgetterm")
+                },
+                CAP,
+            )
+            .await
+            .unwrap();
+        assert_eq!(p.total, CAP, "every page reports the capped total");
+        paged.extend(p.items.iter().map(|h| rank_key(&h.permalink)));
+    }
+    assert_eq!(paged, keys, "paging does not reproduce the capped ranking");
+}
+parity!(
+    lexical_candidate_cap_bounds_and_ranks,
+    lexical_candidate_cap
+);

--- a/crates/service/src/client.rs
+++ b/crates/service/src/client.rs
@@ -307,6 +307,17 @@ impl RelayState {
             (Some("notifications/initialized"), _) => {
                 self.initialized_note = Some(line.to_string());
             }
+            // A cancellation settles its request as far as the client is
+            // concerned: the daemon may never answer it, so the entry is
+            // dropped here rather than waiting for a response that will not
+            // come. Without this a cancelled-and-unanswered request would keep
+            // its entry for the whole relay lifetime, and a restart would send
+            // an error answer for a request the client already abandoned.
+            (Some("notifications/cancelled"), _) => {
+                if let Some(id) = msg.get("params").and_then(|p| p.get("requestId")) {
+                    self.outstanding.remove(&id.to_string());
+                }
+            }
             (Some(_), Some(id)) => {
                 self.outstanding.insert(id.to_string(), id.clone());
             }
@@ -1305,6 +1316,37 @@ mod tests {
         assert!(
             relay.outstanding.contains_key("0"),
             "a server request never settles an id"
+        );
+    }
+
+    #[test]
+    fn relay_state_drops_a_cancelled_request() {
+        let mut relay = RelayState::default();
+        relay.note_client_line(r#"{"jsonrpc":"2.0","id":0,"method":"initialize","params":{}}"#);
+        relay.note_client_line(r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{}}"#);
+        relay.note_client_line(r#"{"jsonrpc":"2.0","id":"a2","method":"tools/call","params":{}}"#);
+        assert!(relay.outstanding.contains_key("1"));
+
+        relay.note_client_line(
+            r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":1,"reason":"user"}}"#,
+        );
+        assert!(
+            !relay.outstanding.contains_key("1"),
+            "a cancelled request no longer waits for a response"
+        );
+        // A string id cancels the same way, and an unknown or malformed
+        // cancellation leaves the rest of the map alone.
+        relay.note_client_line(
+            r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":"a2"}}"#,
+        );
+        assert!(!relay.outstanding.contains_key("\"a2\""));
+        relay.note_client_line(r#"{"jsonrpc":"2.0","method":"notifications/cancelled"}"#);
+        relay.note_client_line(
+            r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":42}}"#,
+        );
+        assert!(
+            relay.outstanding.contains_key("0"),
+            "the handshake id survives an unrelated cancellation"
         );
     }
 

--- a/crates/service/src/daemon.rs
+++ b/crates/service/src/daemon.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
 
 use crystalline_core::config::{self, GlobalConfig, HttpSetting};
@@ -462,6 +462,31 @@ enum WatchTick {
     Rescan,
 }
 
+/// How many watcher ticks may queue between debounce flushes. The notify
+/// callback is synchronous and must never block a notify thread, so it pushes
+/// with `try_send`; a burst larger than this sets the overflow flag instead of
+/// queueing without limit (see [`drain_overflow`]), which bounds what one churn
+/// storm during a slow sync can hold. Generous enough that an ordinary editor
+/// save storm never reaches it.
+const WATCH_TICK_CAPACITY: usize = 4096;
+
+/// Fold a set overflow flag into this flush: an overflowing burst means ticks
+/// were dropped and which paths they carried is unknown, exactly the situation
+/// the watcher's rescan signal already covers, so every watched domain escalates
+/// to a full rescan. The flag is cleared as it is read, so one overflow escalates
+/// one flush. Returns whether an escalation happened.
+fn drain_overflow(
+    overflow: &AtomicBool,
+    dirty: &mut HashMap<String, DirtyPaths>,
+    domains: &[(String, PathBuf)],
+) -> bool {
+    if !overflow.swap(false, Ordering::Relaxed) {
+        return false;
+    }
+    accumulate_tick(dirty, WatchTick::Rescan, domains);
+    true
+}
+
 /// Watch every domain root, debounce bursts by ~300ms and sync the touched
 /// domains, then schedule an embedding pass on the worker (falling back to an
 /// inline pass only if the worker channel is unwired or its receiver already
@@ -502,17 +527,24 @@ async fn run_watcher(
     mut new_roots: tokio::sync::mpsc::UnboundedReceiver<WatchEvent>,
     watches_ready: tokio::sync::oneshot::Sender<()>,
 ) -> anyhow::Result<()> {
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<WatchTick>();
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<WatchTick>(WATCH_TICK_CAPACITY);
+    // Set when a tick could not be queued. The callback never blocks and never
+    // drops a change silently: the flag escalates the next flush to a full
+    // rescan, so a full queue only costs coalescing, never a missed edit.
+    let overflow = Arc::new(AtomicBool::new(false));
+    let cb_overflow = overflow.clone();
     let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
         if let Ok(event) = res {
             // A rescan/overflow notice (an inotify IN_Q_OVERFLOW, an fsevents
             // rescan) means events were dropped, so which paths changed is
             // unknown: signal a full rescan rather than trust a partial stream.
-            if event.need_rescan() {
-                let _ = tx.send(WatchTick::Rescan);
+            if event.need_rescan() && tx.try_send(WatchTick::Rescan).is_err() {
+                cb_overflow.store(true, Ordering::Relaxed);
             }
             for path in event.paths {
-                let _ = tx.send(WatchTick::Path(path));
+                if tx.try_send(WatchTick::Path(path)).is_err() {
+                    cb_overflow.store(true, Ordering::Relaxed);
+                }
             }
         }
     })?;
@@ -623,6 +655,14 @@ async fn run_watcher(
                     tokio::time::timeout(Duration::from_millis(300), rx.recv()).await
                 {
                     accumulate_tick(&mut dirty, tick, &domains);
+                }
+                // A burst that outran the channel escalates this flush to a full
+                // rescan of every watched domain, so nothing the callback could
+                // not queue is lost.
+                if drain_overflow(&overflow, &mut dirty, &domains) {
+                    tracing::warn!(
+                        "watcher event queue overflowed ({WATCH_TICK_CAPACITY} ticks); falling back to a full rescan"
+                    );
                 }
                 let touched = !dirty.is_empty();
                 for (name, work) in dirty {
@@ -1381,6 +1421,63 @@ mod tests {
         accumulate_tick(&mut dirty, WatchTick::Rescan, &domains);
         assert!(dirty["a"].full);
         assert!(dirty["b"].full);
+    }
+
+    // drain_overflow: a set flag escalates the flush to a full rescan of every
+    // watched domain and clears itself; an unset flag leaves the flush alone.
+
+    #[test]
+    fn overflow_escalates_the_flush_to_a_full_rescan() {
+        let domains = vec![
+            ("a".to_string(), PathBuf::from("/roots/a")),
+            ("b".to_string(), PathBuf::from("/roots/b")),
+        ];
+        let mut dirty: HashMap<String, DirtyPaths> = HashMap::new();
+        // One targeted path was queued before the burst overflowed.
+        accumulate_tick(
+            &mut dirty,
+            WatchTick::Path(PathBuf::from("/roots/a/note.md")),
+            &domains,
+        );
+        let overflow = AtomicBool::new(true);
+
+        assert!(drain_overflow(&overflow, &mut dirty, &domains));
+        assert!(dirty["a"].full, "the domain with queued paths goes full");
+        assert!(dirty["b"].full, "every watched domain goes full");
+        assert!(dirty["a"].paths.is_empty(), "targeted paths are dropped");
+        assert!(
+            !overflow.load(Ordering::Relaxed),
+            "the flag is cleared as it is read"
+        );
+
+        // A following flush with no new overflow stays targeted.
+        let mut next: HashMap<String, DirtyPaths> = HashMap::new();
+        accumulate_tick(
+            &mut next,
+            WatchTick::Path(PathBuf::from("/roots/a/note.md")),
+            &domains,
+        );
+        assert!(!drain_overflow(&overflow, &mut next, &domains));
+        assert!(!next["a"].full);
+        assert!(next["a"].paths.contains("note.md"));
+        assert!(!next.contains_key("b"), "untouched domains stay untouched");
+    }
+
+    #[test]
+    fn a_full_watch_channel_sets_the_overflow_flag() {
+        // The capacity is what the callback pushes into; a burst past it must set
+        // the flag rather than block a notify thread or drop a change silently.
+        let (tx, _rx) = tokio::sync::mpsc::channel::<WatchTick>(2);
+        let overflow = AtomicBool::new(false);
+        for i in 0..3 {
+            if tx
+                .try_send(WatchTick::Path(PathBuf::from(format!("/x/{i}.md"))))
+                .is_err()
+            {
+                overflow.store(true, Ordering::Relaxed);
+            }
+        }
+        assert!(overflow.load(Ordering::Relaxed), "the third push overflows");
     }
 
     #[test]

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -4582,7 +4582,7 @@ impl Engine {
         if self.read_only {
             return Err(EngineError::ReadOnly);
         }
-        let lock = self.origin_lock(domain);
+        let lock = self.origin_lock_registered(domain)?;
         let _guard = lock.lock().await;
         let (spec, root, state_dir) = self.origin_spec_for_domain(domain)?;
         let provider = self.resolve_origin_provider()?;
@@ -4629,7 +4629,7 @@ impl Engine {
         if self.read_only {
             return Err(EngineError::ReadOnly);
         }
-        let lock = self.origin_lock(domain);
+        let lock = self.origin_lock_registered(domain)?;
         let _guard = lock.lock().await;
         let (_, root, state_dir) = self.origin_spec_for_domain(domain)?;
         let report = ops::discard(&root, &state_dir, proposal_number)?;
@@ -4672,7 +4672,7 @@ impl Engine {
             return Err(EngineError::ReadOnly);
         }
         let resolution = origin::resolution_from(keep, content)?;
-        let lock = self.origin_lock(domain);
+        let lock = self.origin_lock_registered(domain)?;
         let _guard = lock.lock().await;
         let (_, root, state_dir) = self.origin_spec_for_domain(domain)?;
         let report = ops::resolve(&root, &state_dir, path, resolution)?;
@@ -4762,8 +4762,22 @@ impl Engine {
         Ok((spec, root, state_dir))
     }
 
+    /// [`Engine::origin_lock`] for the single-domain operations whose next step
+    /// requires a registered domain: the name is checked first, so a lock entry
+    /// is never created for a name that is about to fail anyway. The error is
+    /// exactly the `UnknownDomain` [`Engine::origin_spec_for_domain`] would
+    /// raise a line later, so a registered name behaves identically and an
+    /// unregistered one answers the same, only without leaving an entry behind.
+    fn origin_lock_registered(&self, domain: &str) -> Result<Arc<tokio::sync::Mutex<()>>> {
+        self.domain_entry(domain)?;
+        Ok(self.origin_lock(domain))
+    }
+
     /// The per-domain lock serializing origin operations for one domain
-    /// name, created lazily on first use.
+    /// name, created lazily on first use. Callers that already hold a
+    /// `DomainEntry`, and `origin_add` (whose domain may not be registered
+    /// yet), use this directly; every other single-domain caller goes through
+    /// [`Engine::origin_lock_registered`].
     fn origin_lock(&self, domain: &str) -> Arc<tokio::sync::Mutex<()>> {
         let mut locks = self.origin_locks.lock().unwrap();
         locks
@@ -6188,5 +6202,49 @@ mod context_rank_tests {
         let first = context_rank(&forward, &seeds(&[1, 2]));
         let second = context_rank(&reversed, &seeds(&[1, 2]));
         assert_eq!(first, second);
+    }
+}
+
+#[cfg(test)]
+mod origin_lock_tests {
+    use super::*;
+    use crystalline_core::config::DomainEntry;
+    use crystalline_index::TursoStore;
+
+    /// An engine over an in-memory store whose config registers `domains`.
+    async fn engine_with_domains(domains: &[&str]) -> Engine {
+        let store = TursoStore::open_in_memory().await.unwrap();
+        let mut config = GlobalConfig::default();
+        for name in domains {
+            config.domains.insert(
+                (*name).to_string(),
+                DomainEntry::file(format!("/roots/{name}")),
+            );
+        }
+        Engine::new(Arc::new(Mutex::new(store)), config, None, None)
+    }
+
+    /// The single-domain origin operations take a caller-supplied name, so an
+    /// unregistered one must not leave a lock entry behind: the map is keyed by
+    /// name and never pruned, so every unchecked name would be retained for the
+    /// life of the process. The error is the same `UnknownDomain` the operation
+    /// answered before the check moved ahead of the lock.
+    #[tokio::test]
+    async fn an_unregistered_name_never_gets_a_lock_entry() {
+        let engine = engine_with_domains(&["known"]).await;
+
+        let err = engine.origin_lock_registered("nope").unwrap_err();
+        assert!(matches!(err, EngineError::UnknownDomain { .. }), "{err}");
+        assert!(
+            engine.origin_locks.lock().unwrap().is_empty(),
+            "a failing name must not be retained"
+        );
+
+        // A registered name behaves exactly as before: one lazily created entry,
+        // reused on the next call.
+        let first = engine.origin_lock_registered("known").unwrap();
+        let second = engine.origin_lock_registered("known").unwrap();
+        assert!(Arc::ptr_eq(&first, &second), "the lock is created once");
+        assert_eq!(engine.origin_locks.lock().unwrap().len(), 1);
     }
 }


### PR DESCRIPTION
Third and last PR from research/2026-07-27-memory-leak-review.md (F4 + F5 + the two theoretical retention items).

**F4**: the lexical candidate SELECT (both backends) gains `ORDER BY e.id LIMIT LEXICAL_CANDIDATE_CAP` (5000, shared const beside the other cross-backend search consts; `Store::search` delegates to a new `search_with_candidate_cap` so tests inject small caps). Row buffers are consumed by value as candidates build: peak drops from ~3x to ~2x of matched bytes. The lowered-copy scan stays - snippets cut from the original body and non-ASCII lowercasing shifts byte offsets, so correctness beats the last allocation (commented at the loop). `filter_only` verified to already page in SQL.

**F5**: the watcher tick channel is bounded (4096); the synchronous notify callback uses `try_send` and on Full sets an overflow flag; each flush drains the flag into the existing `WatchTick::Rescan` escalation (the same path an inotify queue overflow takes), so overflow coalesces into one full rescan and never loses a change. No stall risk: a full channel implies pending ticks, so the loop wakes immediately.

**Retention cleanups**: the stdio relay removes a request's outstanding entry when a `notifications/cancelled` for it passes through; `origin_share`/`origin_discard`/`origin_resolve` validate the domain name before creating an `origin_locks` entry.

Verification: workspace nextest 1354/1356 (the two failures are the known load-flaky `github_auth` device-flow pollers, 16/16 in isolation); doctests, clippy -D warnings (incl. `--all-features` for the postgres leg), fmt, style-lint green; postgres parity run locally 3x against postgresql@18 (68/68 each, leg verified genuine against a bogus URL). New tests: capped-ranking parity test, overflow escalation, full-channel flag, cancelled-relay cleanup, unregistered-name lock guard.