### PR TITLE
Harden the two flaky tests against load and Windows tempdir races

### DIFF
--- a/crates/index/tests/sync_phases.rs
+++ b/crates/index/tests/sync_phases.rs
@@ -89,27 +89,83 @@ fn unique_schema() -> String {
     format!("cp_{}_{}", std::process::id(), n)
 }
 
+/// The failure signature of the one flake this harness has seen: a query
+/// that spills a sorter or a hash join asks the database engine for a
+/// scratch directory, which it creates fresh under the OS temp directory
+/// (`%TEMP%` on Windows) per spill. On a busy Windows runner that create can
+/// come back `permission denied` instead of succeeding, because a name a
+/// process just deleted stays delete-pending until the last handle on it
+/// closes and Windows answers a recreate of a delete-pending name with
+/// ACCESS_DENIED. It is transient, environmental and entirely outside this
+/// crate: nothing in the store or in a test's own tempdir is involved (every
+/// body here runs against an in-memory database).
+const TRANSIENT_TEMPDIR_FAILURE: &str = "I/O error (tempdir)";
+
+/// How many times a body is re-run after a [`TRANSIENT_TEMPDIR_FAILURE`],
+/// and how long to wait first: a delete-pending name clears as soon as the
+/// last handle closes, so a couple of short retries is plenty and a real
+/// failure still surfaces on the last attempt.
+const TRANSIENT_RETRIES: u32 = 3;
+const TRANSIENT_RETRY_WAIT: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// Runs one parity attempt, re-running it on a whole fresh store and
+/// tempdir when it failed on the transient scratch-directory create above.
+/// Every body is self-contained (its own tempdir, its own store), so a
+/// re-run is exactly the same test again; any other panic is re-raised
+/// unchanged, on the first attempt, with its original message.
+async fn run_attempt<F, Fut>(mut attempt: F)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = ()> + Send + 'static,
+{
+    for remaining in (0..TRANSIENT_RETRIES).rev() {
+        let Err(join) = tokio::spawn(attempt()).await else {
+            return;
+        };
+        assert!(join.is_panic(), "the parity body was cancelled: {join}");
+        let panic = join.into_panic();
+        let message = panic
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| panic.downcast_ref::<&str>().copied())
+            .unwrap_or_default();
+        if remaining == 0 || !message.contains(TRANSIENT_TEMPDIR_FAILURE) {
+            std::panic::resume_unwind(panic);
+        }
+        eprintln!("note: retrying after a transient scratch-directory failure: {message}");
+        tokio::time::sleep(TRANSIENT_RETRY_WAIT).await;
+    }
+}
+
 /// Run a parity body against Turso (always) and Postgres (when configured).
 macro_rules! parity {
     ($name:ident, $body:path) => {
         #[tokio::test]
         async fn $name() {
-            {
+            run_attempt(|| async {
                 let store = TursoStore::open_in_memory().await.unwrap();
                 $body(&store).await;
-            }
+            })
+            .await;
             #[cfg(feature = "postgres")]
             {
                 if let Some(url) = pg_url() {
-                    let schema = unique_schema();
-                    let store = crystalline_index::PostgresStore::open_in_schema(&url, &schema)
-                        .await
-                        .expect("open the postgres test schema");
-                    $body(&store).await;
-                    store
-                        .drop_schema()
-                        .await
-                        .expect("drop the postgres test schema");
+                    run_attempt(|| {
+                        let url = url.clone();
+                        async move {
+                            let schema = unique_schema();
+                            let store =
+                                crystalline_index::PostgresStore::open_in_schema(&url, &schema)
+                                    .await
+                                    .expect("open the postgres test schema");
+                            $body(&store).await;
+                            store
+                                .drop_schema()
+                                .await
+                                .expect("drop the postgres test schema");
+                        }
+                    })
+                    .await;
                 }
             }
         }

--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -32,3 +32,6 @@ walkdir = { workspace = true }
 [dev-dependencies]
 axum = { workspace = true }
 tempfile = { workspace = true }
+# `test-util` adds the paused clock the device flow's cadence tests run on;
+# a test-only feature on a dependency the crate already has.
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/remote/src/github/auth.rs
+++ b/crates/remote/src/github/auth.rs
@@ -12,6 +12,7 @@
 //! [`super::GitHubProvider::current_user`] instead of duplicating that
 //! request.
 
+use std::future::Future;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -240,23 +241,28 @@ pub async fn run_device_flow(
     client_id: &str,
     start: &DeviceFlowStart,
 ) -> Result<String, RemoteError> {
-    run_device_flow_with_backoff(auth_base, client_id, start, SLOW_DOWN_BACKOFF).await
+    poll_until_token(start, SLOW_DOWN_BACKOFF, move || {
+        poll_device_flow_once(auth_base, client_id, &start.device_code)
+    })
+    .await
 }
 
-/// The device flow loop behind [`run_device_flow`], with the slow-down
-/// backoff taken as a parameter instead of hardcoded, so the test suite can
-/// shrink it and keep its `slow_down` coverage sub-second without pausing
-/// the tokio clock (which races ahead of the real HTTP round-trips the
-/// mock-server tests make, once verified against this crate's suite).
-/// [`run_device_flow`] always calls this with the real
-/// [`SLOW_DOWN_BACKOFF`]; not meant to be called directly outside tests.
-#[doc(hidden)]
-pub async fn run_device_flow_with_backoff(
-    auth_base: &str,
-    client_id: &str,
+/// The waiting-and-backoff loop behind [`run_device_flow`], with the one
+/// poll taken as a parameter so the cadence (the initial interval, the
+/// `slow_down` backoff growth and the expiry deadline) can be tested on a
+/// paused tokio clock, without a socket or a real HTTP round-trip to race
+/// the auto-advanced time against. [`run_device_flow`] passes
+/// [`poll_device_flow_once`] and the real [`SLOW_DOWN_BACKOFF`], so the
+/// shipped flow is exactly this loop.
+async fn poll_until_token<P, F>(
     start: &DeviceFlowStart,
     slow_down_backoff: Duration,
-) -> Result<String, RemoteError> {
+    mut poll: P,
+) -> Result<String, RemoteError>
+where
+    P: FnMut() -> F,
+    F: Future<Output = Result<DevicePoll, RemoteError>>,
+{
     let started = tokio::time::Instant::now();
     let expires_in = Duration::from_secs(start.expires_in_secs);
     let mut interval = Duration::from_secs(start.interval_secs);
@@ -265,7 +271,7 @@ pub async fn run_device_flow_with_backoff(
         if started.elapsed() >= expires_in {
             return Err(RemoteError::AuthExpired);
         }
-        match poll_device_flow_once(auth_base, client_id, &start.device_code).await? {
+        match poll().await? {
             DevicePoll::Token(token) => return Ok(token),
             DevicePoll::Pending => {}
             DevicePoll::SlowDown => interval += slow_down_backoff,
@@ -317,7 +323,128 @@ async fn parse_auth_json<T: serde::de::DeserializeOwned>(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
     use super::*;
+
+    /// A [`DeviceFlowStart`] with the polling cadence under test; the codes
+    /// and urls never matter to [`poll_until_token`], which only reads the
+    /// two timing fields.
+    fn start_with(interval_secs: u64, expires_in_secs: u64) -> DeviceFlowStart {
+        DeviceFlowStart {
+            device_code: "devicecode".to_string(),
+            user_code: "WDJB-MJHT".to_string(),
+            verification_url: "https://github.com/login/device".to_string(),
+            interval_secs,
+            expires_in_secs,
+        }
+    }
+
+    // The loop tests below run on a paused tokio clock, so every
+    // `sleep` resolves instantly and `Instant::now()` reports exactly the
+    // waits the loop asked for. Each records the virtual moment of every
+    // poll, which makes the assertion the interval SEQUENCE itself: no wall
+    // clock, no socket and no dependency on how loaded the machine is. The
+    // HTTP side of a poll is covered separately by the `poll_device_flow_once`
+    // tests in `tests/github_auth.rs`.
+
+    #[tokio::test(start_paused = true)]
+    async fn the_flow_polls_at_the_start_interval_until_a_token_arrives() {
+        let started = tokio::time::Instant::now();
+        let mut outcomes = VecDeque::from([
+            Ok(DevicePoll::Pending),
+            Ok(DevicePoll::Pending),
+            Ok(DevicePoll::Token("tok-final".to_string())),
+        ]);
+        let mut polled_at = Vec::new();
+        let start = start_with(5, 900);
+
+        let token = poll_until_token(&start, SLOW_DOWN_BACKOFF, || {
+            polled_at.push(started.elapsed());
+            std::future::ready(outcomes.pop_front().expect("one poll too many"))
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(token, "tok-final");
+        assert_eq!(
+            polled_at,
+            vec![
+                Duration::from_secs(5),
+                Duration::from_secs(10),
+                Duration::from_secs(15)
+            ],
+            "the loop waited the start interval before every poll"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn the_flow_grows_the_interval_on_every_slow_down() {
+        let started = tokio::time::Instant::now();
+        let mut outcomes = VecDeque::from([
+            Ok(DevicePoll::Pending),
+            Ok(DevicePoll::SlowDown),
+            Ok(DevicePoll::SlowDown),
+            Ok(DevicePoll::Token("tok-after-slowdown".to_string())),
+        ]);
+        let mut polled_at = Vec::new();
+        let start = start_with(5, 900);
+
+        let token = poll_until_token(&start, SLOW_DOWN_BACKOFF, || {
+            polled_at.push(started.elapsed());
+            std::future::ready(outcomes.pop_front().expect("one poll too many"))
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(token, "tok-after-slowdown");
+        // 5, then 5 again, then 10 once the first slow_down landed, then 15
+        // once the second did: five seconds added per slow_down.
+        assert_eq!(
+            polled_at,
+            vec![
+                Duration::from_secs(5),
+                Duration::from_secs(10),
+                Duration::from_secs(20),
+                Duration::from_secs(35)
+            ],
+            "each slow_down added the backoff to the interval"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn the_flow_reports_auth_expired_once_the_window_elapses() {
+        let started = tokio::time::Instant::now();
+        let mut polled_at = Vec::new();
+        let start = start_with(5, 12);
+
+        let err = poll_until_token(&start, SLOW_DOWN_BACKOFF, || {
+            polled_at.push(started.elapsed());
+            std::future::ready(Ok(DevicePoll::Pending))
+        })
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, RemoteError::AuthExpired), "{err:?}");
+        assert_eq!(
+            polled_at,
+            vec![Duration::from_secs(5), Duration::from_secs(10)],
+            "the wait that crossed the deadline expired instead of polling again"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_failing_poll_ends_the_flow() {
+        let start = start_with(5, 900);
+
+        let err = poll_until_token(&start, SLOW_DOWN_BACKOFF, || {
+            std::future::ready(Err(RemoteError::Offline))
+        })
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, RemoteError::Offline), "{err:?}");
+    }
 
     #[test]
     fn auth_base_defaults_to_github_com_when_no_override_is_given() {

--- a/crates/remote/tests/github_auth.rs
+++ b/crates/remote/tests/github_auth.rs
@@ -5,7 +5,6 @@
 //! never touches the real OS keychain.
 
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
 use axum::Json;
 use axum::Router;
@@ -14,8 +13,8 @@ use axum::http::HeaderMap;
 use axum::routing::{get, post};
 use crystalline_remote::RemoteError;
 use crystalline_remote::github::auth::{
-    DeviceFlowStart, DevicePoll, poll_device_flow_once, run_device_flow,
-    run_device_flow_with_backoff, start_device_flow, validate_token,
+    DeviceFlowStart, DevicePoll, poll_device_flow_once, run_device_flow, start_device_flow,
+    validate_token,
 };
 use tokio::net::TcpListener;
 
@@ -270,27 +269,30 @@ async fn poll_device_flow_once_maps_connection_refused_to_offline() {
 
 // --- run_device_flow ---------------------------------------------------------
 
-// These three tests keep `interval_secs: 0` so `run_device_flow`'s
-// between-poll sleeps cost no real wall time; the one test that also
-// exercises the `slow_down` backoff calls `run_device_flow_with_backoff`
-// with a near-zero backoff instead of the real, hardcoded five seconds, so
-// it stays sub-second too. A `#[tokio::test(start_paused = true)]` clock
-// was tried first, but the mock axum server and the client both run real
-// HTTP round-trips over loopback on the same runtime, and the auto-advanced
-// clock races ahead of those before they complete, turning two of the three
-// tests into spurious `RemoteError::Offline` failures.
+// One end-to-end test that the loop really drives the HTTP endpoint: it
+// polls repeatedly with the configured host, client id and device code
+// until the token arrives. The cadence itself (the start interval, the
+// `slow_down` backoff growth, the expiry deadline) is covered by the
+// paused-clock unit tests next to the loop in `github::auth`, so nothing
+// here races a wall-clock deadline: `interval_secs: 0` makes the waits
+// free and the expiry window is far larger than any round-trip a loaded
+// machine can produce. A paused clock cannot be used here, since the mock
+// axum server and the client run real loopback round-trips on the same
+// runtime and the auto-advanced clock fires the request timeout before they
+// complete.
 #[tokio::test]
-async fn run_device_flow_polls_until_a_token_arrives() {
-    let calls = Arc::new(Mutex::new(0u32));
+async fn run_device_flow_polls_the_endpoint_until_a_token_arrives() {
+    let seen = Arc::new(Mutex::new(Vec::<serde_json::Value>::new()));
+    let recorded = seen.clone();
 
     let app = Router::new().route(
         "/login/oauth/access_token",
-        post(move || {
-            let calls = calls.clone();
+        post(move |Json(body): Json<serde_json::Value>| {
+            let seen = seen.clone();
             async move {
-                let mut n = calls.lock().unwrap();
-                *n += 1;
-                if *n < 3 {
+                let mut seen = seen.lock().unwrap();
+                seen.push(body);
+                if seen.len() < 3 {
                     Json(serde_json::json!({"error": "authorization_pending"}))
                 } else {
                     Json(serde_json::json!({"access_token": "tok-final"}))
@@ -304,67 +306,18 @@ async fn run_device_flow_polls_until_a_token_arrives() {
         user_code: "WDJB-MJHT".to_string(),
         verification_url: "https://github.com/login/device".to_string(),
         interval_secs: 0,
-        expires_in_secs: 30,
+        expires_in_secs: 900,
     };
 
     let token = run_device_flow(&base, "client", &start).await.unwrap();
 
     assert_eq!(token, "tok-final");
-}
-
-#[tokio::test]
-async fn run_device_flow_backs_off_on_slow_down_then_succeeds() {
-    let calls = Arc::new(Mutex::new(0u32));
-
-    let app = Router::new().route(
-        "/login/oauth/access_token",
-        post(move || {
-            let calls = calls.clone();
-            async move {
-                let mut n = calls.lock().unwrap();
-                *n += 1;
-                match *n {
-                    1 => Json(serde_json::json!({"error": "authorization_pending"})),
-                    2 => Json(serde_json::json!({"error": "slow_down"})),
-                    _ => Json(serde_json::json!({"access_token": "tok-after-slowdown"})),
-                }
-            }
-        }),
-    );
-    let base = spawn(app).await;
-    let start = DeviceFlowStart {
-        device_code: "devicecode".to_string(),
-        user_code: "WDJB-MJHT".to_string(),
-        verification_url: "https://github.com/login/device".to_string(),
-        interval_secs: 0,
-        expires_in_secs: 30,
-    };
-
-    let token = run_device_flow_with_backoff(&base, "client", &start, Duration::from_millis(1))
-        .await
-        .unwrap();
-
-    assert_eq!(token, "tok-after-slowdown");
-}
-
-#[tokio::test]
-async fn run_device_flow_reports_auth_expired_once_the_window_elapses() {
-    let app = Router::new().route(
-        "/login/oauth/access_token",
-        post(|| async { Json(serde_json::json!({"error": "authorization_pending"})) }),
-    );
-    let base = spawn(app).await;
-    let start = DeviceFlowStart {
-        device_code: "devicecode".to_string(),
-        user_code: "WDJB-MJHT".to_string(),
-        verification_url: "https://github.com/login/device".to_string(),
-        interval_secs: 0,
-        expires_in_secs: 0,
-    };
-
-    let err = run_device_flow(&base, "client", &start).await.unwrap_err();
-
-    assert!(matches!(err, RemoteError::AuthExpired), "{err:?}");
+    let bodies = recorded.lock().unwrap();
+    assert_eq!(bodies.len(), 3, "it kept polling until the token arrived");
+    for body in bodies.iter() {
+        assert_eq!(body["client_id"], "client");
+        assert_eq!(body["device_code"], "devicecode");
+    }
 }
 
 // --- validate_token -----------------------------------------------------------


### PR DESCRIPTION
Two pre-existing tests cost real CI and gate signal during the 2026-07-27 memory work (see research/2026-07-27-memory-leak-review.md, Outcome). This PR makes both deterministic without changing any shipped behavior.

## Device-flow pollers (crystalline-remote)

The two polling tests raced the flow's real 30s expiry window: three sequential loopback round-trips, each through a freshly built reqwest client, can exceed 30s under machine load, at which point the loop returns AuthExpired and the test fails at ~35s instead of ~10ms.

- The loop is now the private `poll_until_token(start, slow_down_backoff, poll)`; `run_device_flow` passes the real `poll_device_flow_once` and `SLOW_DOWN_BACKOFF`, so the shipped loop body is unchanged and the public API shrank (the doc-hidden `run_device_flow_with_backoff` escape hatch is gone).
- Four `#[tokio::test(start_paused = true)]` unit tests assert the interval sequence itself: `[5s, 10s, 15s]` plain polling, `[5s, 10s, 20s, 35s]` across two slow_downs (now exercising the real 5s production backoff instead of a 1ms substitute), expiry after `[5s, 10s]` and poll-error propagation. No socket, no wall clock.
- One end-to-end wiring test remains against the mock server, asserting client id and device code on all three recorded request bodies, with a 900s window no loaded machine can outlast.
- `crates/remote` gains the tokio `test-util` dev-feature (paused clock); no new dependency.

Load-immunity proof: 20 iterations of both the integration binary and the unit tests while a parallel `cargo build --release --workspace` loaded the machine (load average 5.66 mid-loop): 20/20 passed, 0.54s total.

## sync_phases Windows tempdir race (crystalline-index)

The one CI failure was `Db("I/O error (tempdir): permission denied")` - not our tempdir. The store is in-memory; the string comes from the database engine, which creates a fresh scratch directory under the OS temp dir for every sorter or hash-join spill. On a busy Windows runner that create can return ACCESS_DENIED for a delete-pending name, and the tempdir library retries only on AlreadyExists. Transient, environmental, per-query and outside this crate.

- The parity harness re-runs a body (fresh tempdir, fresh store) when its panic message contains exactly `I/O error (tempdir)`: up to 3 attempts, 50ms apart. Any other panic is re-raised unchanged on the first attempt via `resume_unwind`.
- No production code touched. The retry path was proven with injected-panic throwaway tests (transient signature ran 3x then succeeded; a real assertion propagated immediately with its message intact).

## Verification

- nextest: 1358 tests run, 1358 passed, 4 skipped
- doctests ok, clippy clean, fmt clean, style-lint OK
- sync_phases 10 consecutive runs green on both backends (postgres leg via CRYSTALLINE_TEST_POSTGRES_URL)