### PR TITLE
Split the semantic candidate query so wide columns never reach a sorter

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1085,17 +1085,30 @@ fn main() -> anyhow::Result<()> {
             read_only,
             take_over,
             config,
-        }) => on_runtime(move || {
-            crystalline_service::run_serve(
-                daemon,
-                http,
-                allowed_host,
-                cli.db,
-                config,
-                read_only,
-                take_over,
-            )
-        }),
+        }) => {
+            // Point this process's temp location at the daemon's own scratch
+            // directory before the runtime starts. It has to happen here, on the
+            // only thread this process has so far: setting an environment
+            // variable is unsound once a second thread exists. It happens for
+            // `serve` alone - the daemon owns its state directory, while several
+            // CLI one-shots can run against it at once and would race each
+            // other's startup sweep. A failure is not fatal: the daemon then
+            // spills to the system temp directory exactly as it did before.
+            if let Err(e) = crystalline_service::temp_store::point_at_state_dir() {
+                eprintln!("crystalline: could not claim a scratch directory: {e}");
+            }
+            on_runtime(move || {
+                crystalline_service::run_serve(
+                    daemon,
+                    http,
+                    allowed_host,
+                    cli.db,
+                    config,
+                    read_only,
+                    take_over,
+                )
+            })
+        }
         Some(Command::Mcp {
             embedded,
             read_only,

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -831,6 +831,16 @@ pub fn daemon_log_path() -> Result<PathBuf, ConfigError> {
     Ok(state_dir()?.join("daemon.log"))
 }
 
+/// The daemon's own scratch directory, `<state_dir>/tmp`. The daemon points the
+/// process temp location here at startup so a database engine's sorter spill
+/// lands somewhere identifiable and reclaimable instead of the user's shared
+/// system temp directory, where a killed process leaves it behind forever.
+/// Owned by the daemon: nothing else writes here, so it is the only directory
+/// the startup sweep is ever allowed to delete from.
+pub fn temp_store_dir() -> Result<PathBuf, ConfigError> {
+    Ok(state_dir()?.join("tmp"))
+}
+
 /// The directory holding every origin's on-disk state, `<state_dir>/origins`.
 pub fn origins_state_dir() -> Result<PathBuf, ConfigError> {
     Ok(state_dir()?.join("origins"))

--- a/crates/index/src/postgres/mod.rs
+++ b/crates/index/src/postgres/mod.rs
@@ -877,14 +877,19 @@ impl Store for PostgresStore {
 
     async fn all_engram_contents(&self, domain: DomainId) -> Result<Vec<StoredEngram>> {
         let mut conn = self.acquire().await?;
-        let rows = sqlx::query(
-            "SELECT path, permalink, content, sha256 FROM engram WHERE domain_id=$1 ORDER BY path",
-        )
-        .bind(domain.0)
-        .fetch_all(conn.as_mut())
-        .await
-        .map_err(IndexError::from)?;
-        Ok(rows
+        // Deliberately unordered in SQL and sorted by path in Rust, mirroring
+        // the Turso backend: this projection carries every body in the domain
+        // and an `ORDER BY path` sorts all of them. The caller's contract (a
+        // path-ordered listing) is unchanged, and sorting in Rust makes the two
+        // backends agree byte for byte, where Postgres' locale collation could
+        // otherwise differ from turso's binary one.
+        let rows =
+            sqlx::query("SELECT path, permalink, content, sha256 FROM engram WHERE domain_id=$1")
+                .bind(domain.0)
+                .fetch_all(conn.as_mut())
+                .await
+                .map_err(IndexError::from)?;
+        let mut out: Vec<StoredEngram> = rows
             .iter()
             .map(|r| StoredEngram {
                 path: cell_text(r, 0).unwrap_or_default(),
@@ -892,7 +897,9 @@ impl Store for PostgresStore {
                 content: cell_text(r, 2).unwrap_or_default(),
                 sha256: cell_text(r, 3).unwrap_or_default(),
             })
-            .collect())
+            .collect();
+        out.sort_by(|a, b| a.path.cmp(&b.path));
+        Ok(out)
     }
 
     async fn clear_domain(&self, domain: DomainId) -> Result<()> {
@@ -1477,6 +1484,12 @@ impl Store for PostgresStore {
         // nothing (this instance hosts nothing embeddable). The keyset cursor
         // and the page limit ride on top of the same ordering the query always
         // had, so a paged pass sees the same jobs in the same order.
+        //
+        // This projection carries `text`, and the `ORDER BY` may sort. It stays
+        // bounded because there is no `GROUP BY` and the `LIMIT` is always
+        // present, so the plan is a top-N sort over one page of chunk texts,
+        // each capped by the chunker's token budget. Never add a `GROUP BY`
+        // here, and never drop the `LIMIT`.
         let mut sql = String::from(
             "SELECT id, engram_id, seq, text, text_hash FROM chunk \
              WHERE (embedding IS NULL OR model IS NULL OR model != $1)",

--- a/crates/index/src/postgres/search.rs
+++ b/crates/index/src/postgres/search.rs
@@ -223,10 +223,11 @@ async fn scored_lexical(
     } else {
         format!("WHERE {}", clauses.join(" AND "))
     };
+    // `ORDER BY e.id` is answered from the primary key, so this wide projection
+    // never reaches a sort node. Keep it that way: any other ordering here would
+    // sort every matched body.
     let sql = format!(
-        "SELECT e.id, d.name, e.permalink, e.title, e.engram_type, e.status, e.description, e.content, \
-         CASE WHEN jsonb_typeof(e.metadata -> 'salience') = 'number' THEN (e.metadata ->> 'salience')::double precision END \
-         FROM engram e JOIN domain d ON d.id=e.domain_id {where_sql} \
+        "SELECT {CANDIDATE_COLUMNS} FROM engram e JOIN domain d ON d.id=e.domain_id {where_sql} \
          ORDER BY e.id LIMIT {candidate_cap}"
     );
     let rows = query_all(conn, &sql, params).await?;
@@ -269,10 +270,11 @@ async fn filter_only(
     .max(0) as usize;
 
     let offset = (page - 1) * limit;
+    // This one sorts, but with a `LIMIT` and no `GROUP BY` Postgres runs a
+    // bounded top-N heapsort, so the wide projection costs one page of bodies
+    // rather than the whole match set.
     let sql = format!(
-        "SELECT e.id, d.name, e.permalink, e.title, e.engram_type, e.status, e.description, e.content, \
-         CASE WHEN jsonb_typeof(e.metadata -> 'salience') = 'number' THEN (e.metadata ->> 'salience')::double precision END \
-         FROM engram e JOIN domain d ON d.id=e.domain_id {where_sql} \
+        "SELECT {CANDIDATE_COLUMNS} FROM engram e JOIN domain d ON d.id=e.domain_id {where_sql} \
          ORDER BY e.recorded_at DESC, e.permalink ASC LIMIT {limit} OFFSET {offset}"
     );
     let rows = query_all(conn, &sql, params).await?;
@@ -475,11 +477,54 @@ async fn run_hybrid(
     finish_page(conn, items, page, limit, total).await
 }
 
+/// The projection every candidate row carries, in the column order
+/// [`Candidate::from_row`] reads. Shared by the lexical scan, the filter-only
+/// listing and the semantic hydrate so all three decode identically.
+const CANDIDATE_COLUMNS: &str = "e.id, d.name, e.permalink, e.title, e.engram_type, e.status, e.description, e.content, \
+     CASE WHEN jsonb_typeof(e.metadata -> 'salience') = 'number' \
+     THEN (e.metadata ->> 'salience')::double precision END";
+
+/// Phase 1 of the semantic scan: the narrow top-k, mirroring
+/// [`crate::turso::search`]'s split exactly. Groups the matching chunk rows by
+/// their parent engram, keeps each engram's closest chunk and projects nothing
+/// but the id and the distance.
+///
+/// Postgres does not spill the way turso's sorter does, but the projection was
+/// equally wasteful: the aggregate carried every parent engram's body once per
+/// chunk row through the grouping and the sort. The split is kept identical
+/// across backends so the ranking parity suite compares like with like.
+///
+/// Ties. `dist` alone leaves engrams at an equal distance in an unspecified
+/// order, which decides arbitrarily which of them survives the `LIMIT` cut. The
+/// `c.engram_id ASC` tiebreak makes that cut deterministic (the lower id wins).
+fn semantic_phase1_sql(where_sql: &str) -> String {
+    format!(
+        "SELECT c.engram_id, min(c.embedding <=> $1) AS dist \
+         FROM chunk c JOIN engram e ON e.id=c.engram_id JOIN domain d ON d.id=e.domain_id \
+         {where_sql} GROUP BY c.engram_id ORDER BY dist ASC, c.engram_id ASC LIMIT {SEMANTIC_TOPK}"
+    )
+}
+
+/// Phase 2 of the semantic scan: hydrate the at most [`SEMANTIC_TOPK`] winners
+/// by primary key. No `ORDER BY` and no `GROUP BY`; the phase-1 order is
+/// reapplied in Rust. The id list is interpolated because every id is an `i64`
+/// read out of this same database.
+fn semantic_hydrate_sql(ids: &str) -> String {
+    format!(
+        "SELECT {CANDIDATE_COLUMNS} FROM engram e JOIN domain d ON d.id=e.domain_id \
+         WHERE e.id IN ({ids})"
+    )
+}
+
 /// The nearest engrams to the query vector, as `(similarity, candidate)` pairs.
 /// One row per engram (the closest of its chunks), filtered by every scalar
 /// filter on the query, ordered by distance and capped at the top-k. This is an
 /// exact scan (a `GROUP BY min(distance)`), identical in result to Turso's exact
 /// scan; the HNSW index is present for a future top-k rewrite.
+///
+/// Two queries, not one: a narrow top-k ([`semantic_phase1_sql`]) and a
+/// hydrate-by-id ([`semantic_hydrate_sql`]), the same split the Turso backend
+/// runs.
 async fn semantic_candidates(
     conn: &mut PgConnection,
     query: &SearchQuery,
@@ -504,18 +549,40 @@ async fn semantic_candidates(
     ));
 
     let where_sql = format!("WHERE {}", clauses.join(" AND "));
-    let sql = format!(
-        "SELECT e.id, d.name, e.permalink, e.title, e.engram_type, e.status, e.description, e.content, \
-         CASE WHEN jsonb_typeof(e.metadata -> 'salience') = 'number' THEN (e.metadata ->> 'salience')::double precision END, \
-         min(c.embedding <=> $1) AS dist \
-         FROM chunk c JOIN engram e ON e.id=c.engram_id JOIN domain d ON d.id=e.domain_id \
-         {where_sql} GROUP BY e.id, d.name ORDER BY dist ASC LIMIT {SEMANTIC_TOPK}"
-    );
-    let rows = query_all(conn, &sql, params).await?;
-    let mut out = Vec::with_capacity(rows.len());
-    for r in &rows {
-        let dist = cell_real(r, 9).unwrap_or(1.0);
-        out.push((1.0 - dist, Candidate::from_row(r)));
+    let rows = query_all(conn, &semantic_phase1_sql(&where_sql), params).await?;
+    let winners: Vec<(i64, f64)> = rows
+        .iter()
+        .map(|r| (cell_i64(r, 0).unwrap_or(0), cell_real(r, 1).unwrap_or(1.0)))
+        .collect();
+    drop(rows);
+    if winners.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let ids = winners
+        .iter()
+        .map(|(id, _)| id.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let rows = query_all(conn, &semantic_hydrate_sql(&ids), vec![]).await?;
+    // Consume the rows by value so each engram body is moved into its candidate
+    // rather than copied beside it, the same discipline `scored_lexical` uses.
+    let mut by_id: std::collections::HashMap<i64, Candidate> =
+        std::collections::HashMap::with_capacity(rows.len());
+    for r in rows {
+        let c = Candidate::from_row(&r);
+        drop(r);
+        by_id.insert(c.id, c);
+    }
+
+    // Reapply the phase-1 order in Rust: distance ascending, then engram id.
+    // A winner missing from the hydrate is impossible under the foreign key and
+    // is skipped rather than faked into a hit.
+    let mut out = Vec::with_capacity(winners.len());
+    for (id, dist) in winners {
+        if let Some(c) = by_id.remove(&id) {
+            out.push((1.0 - dist, c));
+        }
     }
     Ok(out)
 }
@@ -1192,4 +1259,88 @@ fn eq_ci(a: char, b: char) -> bool {
 
 fn collapse_ws(text: &str) -> String {
     text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The column list a statement projects: everything between `SELECT` and the
+    /// first top-level ` FROM `. The queries under test have no subquery in
+    /// their projection, so the first ` FROM ` is the right one.
+    fn projection_of(sql: &str) -> &str {
+        let rest = sql.strip_prefix("SELECT ").expect("a SELECT statement");
+        let end = rest.find(" FROM ").expect("a FROM clause");
+        &rest[..end]
+    }
+
+    /// The Postgres half of the 2026-07-28 spill guard. Postgres does not spill
+    /// the way turso's sorter does, but the split is mirrored exactly so the two
+    /// backends group, cut and tiebreak identically and the ranking parity suite
+    /// stays honest.
+    #[test]
+    fn the_semantic_phase_one_projection_carries_no_engram_columns() {
+        let sql = semantic_phase1_sql("WHERE c.embedding IS NOT NULL AND c.model = $2");
+        let projection = projection_of(&sql);
+        assert_eq!(
+            projection, "c.engram_id, min(c.embedding <=> $1) AS dist",
+            "phase 1 projects the grouping key and the distance, nothing else"
+        );
+        for wide in ["e.content", "e.description", "e.title", "e.metadata"] {
+            assert!(
+                !projection.contains(wide),
+                "phase 1 must not carry {wide} through the aggregate, projection was: {projection}"
+            );
+        }
+        assert!(
+            sql.contains("GROUP BY c.engram_id ORDER BY dist ASC, c.engram_id ASC"),
+            "the LIMIT cut stays deterministic on a distance tie: {sql}"
+        );
+        assert!(sql.ends_with(&format!("LIMIT {SEMANTIC_TOPK}")));
+    }
+
+    /// The wide columns live in phase 2, which is a primary-key lookup: no
+    /// grouping and no ordering.
+    #[test]
+    fn the_semantic_hydrate_never_sorts() {
+        let sql = semantic_hydrate_sql("1,2,3");
+        assert!(
+            !sql.contains("ORDER BY"),
+            "no ordering in the hydrate: {sql}"
+        );
+        assert!(
+            !sql.contains("GROUP BY"),
+            "no grouping in the hydrate: {sql}"
+        );
+        assert!(
+            projection_of(&sql).contains("e.content"),
+            "the hydrate is where the bodies are read: {sql}"
+        );
+    }
+
+    /// Both backends decode a candidate row by position, so the two projections
+    /// must list the same nine columns in the same order.
+    #[test]
+    fn the_candidate_column_order_matches_the_turso_backend() {
+        let ours: Vec<&str> = CANDIDATE_COLUMNS.split(',').map(str::trim).collect();
+        assert_eq!(ours.len(), 9, "nine columns, matching Candidate::from_row");
+        assert_eq!(
+            &ours[..8],
+            &[
+                "e.id",
+                "d.name",
+                "e.permalink",
+                "e.title",
+                "e.engram_type",
+                "e.status",
+                "e.description",
+                "e.content",
+            ]
+        );
+        assert!(
+            ours[8].contains("salience"),
+            "the ninth column is the salience prior, got {}",
+            ours[8]
+        );
+    }
 }

--- a/crates/index/src/turso/mod.rs
+++ b/crates/index/src/turso/mod.rs
@@ -696,13 +696,23 @@ impl Store for TursoStore {
     }
 
     async fn all_engram_contents(&self, domain: DomainId) -> Result<Vec<StoredEngram>> {
+        // Deliberately unordered in SQL and sorted by path in Rust. This
+        // projection carries every body in the domain, and an `ORDER BY path`
+        // pushes all of them through turso's sorter, which spills each body to
+        // a temp file and holds a read buffer per flushed chunk: linear in
+        // domain size, and catastrophic with multi-MB engrams. The caller's
+        // contract (a path-ordered listing) is unchanged - the whole result set
+        // is materialized here either way, so sorting it in memory moves
+        // pointers and touches no body. Sorting in Rust also makes the two
+        // backends agree byte for byte, where Postgres' locale collation could
+        // differ from turso's binary one.
         let rows = query_all(
             &self.conn,
-            "SELECT path, permalink, content, sha256 FROM engram WHERE domain_id=?1 ORDER BY path",
+            "SELECT path, permalink, content, sha256 FROM engram WHERE domain_id=?1",
             vec![Value::Integer(domain.0)],
         )
         .await?;
-        Ok(rows
+        let mut out: Vec<StoredEngram> = rows
             .iter()
             .map(|r| StoredEngram {
                 path: cell_text(r, 0).unwrap_or_default(),
@@ -710,7 +720,9 @@ impl Store for TursoStore {
                 content: cell_text(r, 2).unwrap_or_default(),
                 sha256: cell_text(r, 3).unwrap_or_default(),
             })
-            .collect())
+            .collect();
+        out.sort_by(|a, b| a.path.cmp(&b.path));
+        Ok(out)
     }
 
     async fn clear_domain(&self, domain: DomainId) -> Result<()> {
@@ -1252,6 +1264,12 @@ impl Store for TursoStore {
         // nothing (this instance hosts nothing embeddable). The keyset cursor
         // and the page limit ride on top of the same ordering the query always
         // had, so a paged pass sees the same jobs in the same order.
+        //
+        // This projection carries `text`, and the `ORDER BY` does open a sorter.
+        // It stays bounded because there is no `GROUP BY` and the `LIMIT` is
+        // always present, so turso keeps only `limit` records: one page of chunk
+        // texts, each capped by the chunker's token budget. Never add a
+        // `GROUP BY` here, and never drop the `LIMIT`.
         let mut sql = String::from(
             "SELECT id, engram_id, seq, text, text_hash FROM chunk \
              WHERE (embedding IS NULL OR model IS NULL OR model != ?1)",

--- a/crates/index/src/turso/search.rs
+++ b/crates/index/src/turso/search.rs
@@ -218,10 +218,12 @@ async fn scored_lexical(
     } else {
         format!("WHERE {}", clauses.join(" AND "))
     };
+    // `ORDER BY e.id` is satisfied from the table's own rowid order, so this
+    // wide projection never reaches a sorter (verified by `EXPLAIN QUERY PLAN`:
+    // no `USE SORTER` line). Keep it that way: any other ordering here would
+    // spill every matched body to disk.
     let sql = format!(
-        "SELECT e.id, d.name, e.permalink, e.title, e.engram_type, e.status, e.description, e.content, \
-         CAST(json_extract(e.metadata, '$.salience') AS REAL) \
-         FROM engram e JOIN domain d ON d.id=e.domain_id {where_sql} \
+        "SELECT {CANDIDATE_COLUMNS} FROM engram e JOIN domain d ON d.id=e.domain_id {where_sql} \
          ORDER BY e.id LIMIT {candidate_cap}"
     );
     let rows = query_all(conn, &sql, params).await?;
@@ -264,10 +266,12 @@ async fn filter_only(
     .max(0) as usize;
 
     let offset = (page - 1) * limit;
+    // This one does open a sorter, but with a `LIMIT` and no `GROUP BY` turso
+    // applies its bounded-sorter optimization and holds only `limit + offset`
+    // records, so the wide projection costs one page of bodies rather than the
+    // whole match set. Adding a `GROUP BY` here would remove that bound.
     let sql = format!(
-        "SELECT e.id, d.name, e.permalink, e.title, e.engram_type, e.status, e.description, e.content, \
-         CAST(json_extract(e.metadata, '$.salience') AS REAL) \
-         FROM engram e JOIN domain d ON d.id=e.domain_id {where_sql} \
+        "SELECT {CANDIDATE_COLUMNS} FROM engram e JOIN domain d ON d.id=e.domain_id {where_sql} \
          ORDER BY e.recorded_at DESC, e.permalink ASC LIMIT {limit} OFFSET {offset}"
     );
     let rows = query_all(conn, &sql, params).await?;
@@ -493,9 +497,55 @@ async fn run_hybrid(
     finish_page(conn, items, page, limit, total).await
 }
 
+/// The projection every candidate row carries, in the column order
+/// [`Candidate::from_row`] reads. Shared by the lexical scan, the filter-only
+/// listing and the semantic hydrate so all three decode identically.
+const CANDIDATE_COLUMNS: &str = "e.id, d.name, e.permalink, e.title, e.engram_type, e.status, \
+     e.description, e.content, CAST(json_extract(e.metadata, '$.salience') AS REAL)";
+
+/// Phase 1 of the semantic scan: the narrow top-k. Groups the matching chunk
+/// rows by their parent engram, keeps each engram's closest chunk and orders by
+/// that distance, projecting nothing but the id and the distance.
+///
+/// The narrowness is the whole point. Turso feeds one record per chunk row into
+/// the `GROUP BY` sorter, so any wide column in this projection is written to
+/// the sorter's spill file once per chunk of its own engram: quadratic in engram
+/// size, measured at tens of GB on a real corpus (see
+/// `research/2026-07-28-turso-sorter-spill.md`). Two 8-byte columns per record
+/// keep the sorter in its 2MB buffer instead.
+///
+/// Ties. `dist` alone leaves engrams at an equal distance in sorter-defined
+/// order, which decides arbitrarily which of them survives the `LIMIT` cut. The
+/// `c.engram_id ASC` tiebreak makes that cut deterministic (the lower id wins)
+/// and costs nothing: it is the grouping key, already in the sorter record.
+fn semantic_phase1_sql(where_sql: &str) -> String {
+    format!(
+        "SELECT c.engram_id, min(vector_distance_cos(c.embedding, ?1)) AS dist \
+         FROM chunk c JOIN engram e ON e.id=c.engram_id JOIN domain d ON d.id=e.domain_id \
+         {where_sql} GROUP BY c.engram_id ORDER BY dist ASC, c.engram_id ASC LIMIT {SEMANTIC_TOPK}"
+    )
+}
+
+/// Phase 2 of the semantic scan: hydrate the at most [`SEMANTIC_TOPK`] winners
+/// by primary key. No `ORDER BY` and no `GROUP BY`, so the wide columns never
+/// reach a sorter; the phase-1 order is reapplied in Rust. The id list is
+/// interpolated because every id is an `i64` read out of this same database.
+fn semantic_hydrate_sql(ids: &str) -> String {
+    format!(
+        "SELECT {CANDIDATE_COLUMNS} FROM engram e JOIN domain d ON d.id=e.domain_id \
+         WHERE e.id IN ({ids})"
+    )
+}
+
 /// The nearest engrams to the query vector, as `(similarity, candidate)` pairs.
 /// One row per engram (the closest of its chunks), filtered by every scalar
 /// filter on the query, ordered by distance and capped at the top-k.
+///
+/// Two queries, not one: a narrow top-k ([`semantic_phase1_sql`]) and a
+/// hydrate-by-id ([`semantic_hydrate_sql`]). The ranking is unchanged - the same
+/// minimum distance per engram, the same [`SEMANTIC_TOPK`] cut, the same
+/// distance order - but the engram bodies are read once per hit instead of once
+/// per chunk fed to a sorter.
 async fn semantic_candidates(
     conn: &Connection,
     query: &SearchQuery,
@@ -520,18 +570,40 @@ async fn semantic_candidates(
     ));
 
     let where_sql = format!("WHERE {}", clauses.join(" AND "));
-    let sql = format!(
-        "SELECT e.id, d.name, e.permalink, e.title, e.engram_type, e.status, e.description, e.content, \
-         CAST(json_extract(e.metadata, '$.salience') AS REAL), \
-         min(vector_distance_cos(c.embedding, ?1)) AS dist \
-         FROM chunk c JOIN engram e ON e.id=c.engram_id JOIN domain d ON d.id=e.domain_id \
-         {where_sql} GROUP BY e.id ORDER BY dist ASC LIMIT {SEMANTIC_TOPK}"
-    );
-    let rows = query_all(conn, &sql, params).await?;
-    let mut out = Vec::with_capacity(rows.len());
-    for r in &rows {
-        let dist = cell_real(r, 9).unwrap_or(1.0);
-        out.push((1.0 - dist, Candidate::from_row(r)));
+    let rows = query_all(conn, &semantic_phase1_sql(&where_sql), params).await?;
+    let winners: Vec<(i64, f64)> = rows
+        .iter()
+        .map(|r| (cell_i64(r, 0).unwrap_or(0), cell_real(r, 1).unwrap_or(1.0)))
+        .collect();
+    drop(rows);
+    if winners.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let ids = winners
+        .iter()
+        .map(|(id, _)| id.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let rows = query_all(conn, &semantic_hydrate_sql(&ids), vec![]).await?;
+    // Consume the rows by value so each engram body is moved into its candidate
+    // rather than copied beside it, the same discipline `scored_lexical` uses.
+    let mut by_id: std::collections::HashMap<i64, Candidate> =
+        std::collections::HashMap::with_capacity(rows.len());
+    for r in rows {
+        let c = Candidate::from_row(&r);
+        drop(r);
+        by_id.insert(c.id, c);
+    }
+
+    // Reapply the phase-1 order in Rust: distance ascending, then engram id.
+    // A winner missing from the hydrate is impossible under the foreign key and
+    // is skipped rather than faked into a hit.
+    let mut out = Vec::with_capacity(winners.len());
+    for (id, dist) in winners {
+        if let Some(c) = by_id.remove(&id) {
+            out.push((1.0 - dist, c));
+        }
     }
     Ok(out)
 }
@@ -1203,4 +1275,118 @@ fn eq_ci(a: char, b: char) -> bool {
 
 fn collapse_ws(text: &str) -> String {
     text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The column list a statement projects: everything between `SELECT` and the
+    /// first top-level ` FROM `. The queries under test have no subquery in
+    /// their projection, so the first ` FROM ` is the right one.
+    fn projection_of(sql: &str) -> &str {
+        let rest = sql.strip_prefix("SELECT ").expect("a SELECT statement");
+        let end = rest.find(" FROM ").expect("a FROM clause");
+        &rest[..end]
+    }
+
+    /// A representative filtered WHERE clause, shaped like the one
+    /// `build_scalar_filters` produces for a domain-scoped semantic query.
+    const WHERE_SQL: &str = "WHERE d.name IN (?2) AND c.embedding IS NOT NULL \
+                             AND c.model = ?3 AND c.dims = ?4";
+
+    /// The regression guard for the 2026-07-28 spill: phase 1 runs the grouping
+    /// and the ordering, so every column it projects is written into turso's
+    /// sorter once per chunk row. An engram body in there is quadratic in engram
+    /// size (tens of GB were measured in the field). Only the grouping key and
+    /// the aggregate may appear.
+    #[test]
+    fn the_semantic_phase_one_projection_carries_no_engram_columns() {
+        let sql = semantic_phase1_sql(WHERE_SQL);
+        let projection = projection_of(&sql);
+        assert_eq!(
+            projection, "c.engram_id, min(vector_distance_cos(c.embedding, ?1)) AS dist",
+            "phase 1 projects the grouping key and the distance, nothing else"
+        );
+        for wide in ["e.content", "e.description", "e.title", "e.metadata"] {
+            assert!(
+                !projection.contains(wide),
+                "phase 1 must not feed {wide} into the sorter, projection was: {projection}"
+            );
+        }
+        assert!(
+            sql.contains("GROUP BY c.engram_id ORDER BY dist ASC, c.engram_id ASC"),
+            "the LIMIT cut stays deterministic on a distance tie: {sql}"
+        );
+        assert!(sql.ends_with(&format!("LIMIT {SEMANTIC_TOPK}")));
+    }
+
+    /// The wide columns live in phase 2, which is a primary-key lookup: no
+    /// grouping and no ordering, so nothing it projects can reach a sorter.
+    #[test]
+    fn the_semantic_hydrate_never_sorts() {
+        let sql = semantic_hydrate_sql("1,2,3");
+        assert!(
+            !sql.contains("ORDER BY"),
+            "no ordering in the hydrate: {sql}"
+        );
+        assert!(
+            !sql.contains("GROUP BY"),
+            "no grouping in the hydrate: {sql}"
+        );
+        assert!(
+            projection_of(&sql).contains("e.content"),
+            "the hydrate is where the bodies are read: {sql}"
+        );
+    }
+
+    /// The projection every caller of `Candidate::from_row` shares, pinned so a
+    /// column added to one path can never silently shift another path's decode.
+    #[test]
+    fn every_candidate_query_shares_one_column_order() {
+        assert_eq!(
+            CANDIDATE_COLUMNS,
+            "e.id, d.name, e.permalink, e.title, e.engram_type, e.status, \
+     e.description, e.content, CAST(json_extract(e.metadata, '$.salience') AS REAL)"
+        );
+    }
+
+    /// The plan-level half of the guard, in the same discipline as the
+    /// `idx_engram_current` plan test: turso opens sorters for phase 1 (that is
+    /// what a `GROUP BY` plus an `ORDER BY` costs) and opens none at all for the
+    /// hydrate, so the bodies are read by rowid and never serialized.
+    #[tokio::test]
+    async fn the_semantic_split_plans_a_sorter_free_hydrate() {
+        let store = crate::TursoStore::open_in_memory().await.unwrap();
+
+        let where_sql = "WHERE c.embedding IS NOT NULL AND c.model = ?2 AND c.dims = ?3";
+        let phase1 = store
+            .explain_query_plan(&semantic_phase1_sql(where_sql))
+            .await
+            .unwrap()
+            .join(" | ");
+        assert!(
+            phase1.contains("chunk") || phase1.contains("c "),
+            "phase 1 drives off the chunk table, plan was: {phase1}"
+        );
+        // Whatever sorters this plan opens are fed two 8-byte columns, which the
+        // projection test above pins. On an empty database turso answers the
+        // grouping from `idx_chunk_engram` and opens only the ORDER BY sorter;
+        // that is a bonus, not a guarantee, so it is not asserted here - the
+        // narrowness is the invariant, not the sorter count.
+
+        let hydrate = store
+            .explain_query_plan(&semantic_hydrate_sql("1,2,3"))
+            .await
+            .unwrap()
+            .join(" | ");
+        assert!(
+            !hydrate.to_uppercase().contains("SORTER"),
+            "the hydrate must open no sorter, plan was: {hydrate}"
+        );
+        assert!(
+            hydrate.contains("INTEGER PRIMARY KEY") || hydrate.contains("USING INDEX"),
+            "the hydrate is a keyed lookup, plan was: {hydrate}"
+        );
+    }
 }

--- a/crates/index/tests/semantic_split.rs
+++ b/crates/index/tests/semantic_split.rs
@@ -1,0 +1,340 @@
+//! The semantic candidate scan runs as two queries: a narrow top-k that groups
+//! and orders over ids and distances only, then a hydrate of the winners by id.
+//! These tests pin what that split must not change.
+//!
+//! The shape that mattered in the field (2026-07-28, see
+//! `research/2026-07-28-turso-sorter-spill.md`) is one multi-MB engram with many
+//! chunks: the old single query fed that engram's whole body into a `GROUP BY`
+//! sorter once per chunk, which is quadratic in engram size. The corpus here is
+//! that shape in miniature. CI cannot assert temp-file bytes robustly, so what
+//! is asserted is correctness: the closest chunk still decides its engram's
+//! rank, every column the hydrate carries still arrives, and ties are broken the
+//! same way on every run and on both backends.
+//!
+//! Mirrors the FakeProvider harness from `tests/retired.rs` and the parity
+//! runner from `tests/store.rs` (Turso always, Postgres when
+//! `CRYSTALLINE_TEST_POSTGRES_URL` is set).
+
+use std::path::Path;
+
+use async_trait::async_trait;
+use crystalline_index::{
+    ChunkParams, EmbeddingProvider, Result, SearchMode, SearchQuery, Store, TursoStore,
+    run_embedding_pass, sync_domain_with,
+};
+
+// --- fake provider (mirrored from tests/retired.rs) ---------------------------
+
+/// A deterministic, network-free provider. It hashes each word into one of eight
+/// buckets and L2-normalizes, so texts that share vocabulary get similar
+/// vectors: enough structure to exercise ranking.
+struct FakeProvider {
+    model: String,
+}
+
+impl FakeProvider {
+    fn new(model: &str) -> FakeProvider {
+        FakeProvider {
+            model: model.to_string(),
+        }
+    }
+}
+
+fn embed_one(text: &str) -> Vec<f32> {
+    let mut v = [0f32; 8];
+    for tok in text
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|s| !s.is_empty())
+    {
+        let mut h: u64 = 0;
+        for byte in tok.to_lowercase().bytes() {
+            h = h.wrapping_mul(31).wrapping_add(byte as u64);
+        }
+        v[(h % 8) as usize] += 1.0;
+    }
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm == 0.0 {
+        let mut z = [0f32; 8];
+        z[0] = 1.0;
+        return z.to_vec();
+    }
+    v.iter().map(|x| x / norm).collect()
+}
+
+#[async_trait]
+impl EmbeddingProvider for FakeProvider {
+    async fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
+        Ok(texts.iter().map(|t| embed_one(t)).collect())
+    }
+    fn model_id(&self) -> &str {
+        &self.model
+    }
+    fn dims(&self) -> usize {
+        8
+    }
+    fn max_input_tokens(&self) -> usize {
+        512
+    }
+}
+
+// --- helpers ------------------------------------------------------------------
+
+fn write(dir: &Path, rel: &str, content: &str) {
+    let path = dir.join(rel);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, content).unwrap();
+}
+
+fn engram(title: &str, permalink: &str, body: &str) -> String {
+    format!(
+        "---\ntype: engram\ntitle: {title}\npermalink: {permalink}\ntags:\n  - t\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n{body}\n"
+    )
+}
+
+/// Sync the corpus fingerprinting for the fake model, then embed everything.
+async fn sync_and_embed(store: &dyn Store, name: &str, root: &Path, provider: &FakeProvider) {
+    let params = ChunkParams::for_model(provider.model_id());
+    sync_domain_with(store, name, root, &params).await.unwrap();
+    run_embedding_pass(store, provider, |_, _| {})
+        .await
+        .unwrap();
+}
+
+fn semantic_query(text: &str, provider: &FakeProvider) -> SearchQuery {
+    SearchQuery {
+        text: Some(text.to_string()),
+        mode: SearchMode::Semantic,
+        query_embedding: Some(embed_one(text)),
+        active_model: Some(provider.model_id().to_string()),
+        // Keep every candidate: this is a ranking and hydration test, not a
+        // cutoff test, and the cutoff is covered in tests/embed.rs.
+        min_similarity: Some(0.0),
+        limit: 20,
+        page: 1,
+        ..SearchQuery::default()
+    }
+}
+
+// --- backend runner (mirrored from tests/store.rs) -----------------------------
+
+#[cfg(feature = "postgres")]
+fn pg_url() -> Option<String> {
+    use std::sync::Once;
+    static NOTE: Once = Once::new();
+    match std::env::var("CRYSTALLINE_TEST_POSTGRES_URL") {
+        Ok(u) if !u.is_empty() => Some(u),
+        _ => {
+            NOTE.call_once(|| {
+                eprintln!(
+                    "note: skipping the postgres parity leg (CRYSTALLINE_TEST_POSTGRES_URL is unset); turso only"
+                )
+            });
+            None
+        }
+    }
+}
+
+/// A distinct schema name per test invocation. The pid keeps runs apart, the
+/// counter keeps tests within a run apart; both stay well under Postgres's
+/// 63-byte identifier limit.
+#[cfg(feature = "postgres")]
+fn unique_schema() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("ct_{}_{}", std::process::id(), n)
+}
+
+/// Run a parity body against Turso (always) and Postgres (when configured),
+/// giving each backend a fresh, isolated store.
+macro_rules! parity {
+    ($name:ident, $body:path) => {
+        #[tokio::test]
+        async fn $name() {
+            {
+                let store = TursoStore::open_in_memory().await.unwrap();
+                $body(&store).await;
+            }
+            #[cfg(feature = "postgres")]
+            {
+                if let Some(url) = pg_url() {
+                    let schema = unique_schema();
+                    let store = crystalline_index::PostgresStore::open_in_schema(&url, &schema)
+                        .await
+                        .expect("open the postgres test schema");
+                    $body(&store).await;
+                    store
+                        .drop_schema()
+                        .await
+                        .expect("drop the postgres test schema");
+                }
+            }
+        }
+    };
+}
+
+// --- corpus -------------------------------------------------------------------
+
+/// The word the query is about. It appears exactly once in the whole corpus,
+/// buried in the middle of the giant engram, so only one of that engram's many
+/// chunks is close to the query vector.
+const NEEDLE: &str = "quasar telemetry drift anomaly";
+
+/// Filler vocabulary. Every word hashes into an embedding bucket the needle's
+/// words do not touch, so a filler-only chunk is exactly orthogonal to the query
+/// vector and cannot rank by accident.
+const FILLER: &str = "lantern cobble ferry willow maple birch alder hazel elder gorse";
+
+/// A multi-megabyte body whose middle holds the needle, as one paragraph long
+/// enough to fill its own chunks. Everything around it is filler, so the engram
+/// can only be found through that one buried region.
+fn giant_body() -> String {
+    // ~2.1MB: about 1200 chunks at the default 450-token budget, which is the
+    // many-chunks-per-engram condition the split exists for.
+    let half = format!("{FILLER}\n\n").repeat(15_000);
+    let needle_block = format!("{NEEDLE} ").repeat(200);
+    format!("{half}\n\n{needle_block}\n\n{half}")
+}
+
+// --- tests --------------------------------------------------------------------
+
+/// The closest chunk decides its engram's rank, however many chunks that engram
+/// has. Under the old single query this ranking came out of a sorter that had
+/// been fed the giant body once per chunk; under the split it comes out of a
+/// two-column top-k and a keyed hydrate. The answer must be the same.
+async fn the_closest_chunk_still_decides_the_rank(store: &dyn Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(root, "giant.md", &engram("Giant", "giant", &giant_body()));
+    // A small engram whose whole body is unrelated filler: it must lose to the
+    // giant engram's one matching chunk.
+    write(root, "small.md", &engram("Brief", "small", FILLER));
+    let fake = FakeProvider::new("fake-8");
+    sync_and_embed(store, "d", root, &fake).await;
+
+    // The corpus really is the shape this test exists for. Under the old query
+    // this many chunks over this body is a multi-gigabyte sorter spill.
+    let coverage = store.embedding_coverage().await.unwrap();
+    assert!(
+        coverage.total_chunks > 1000,
+        "the giant engram is chunked into a four-figure count, got {}",
+        coverage.total_chunks
+    );
+
+    let page = store.search(&semantic_query(NEEDLE, &fake)).await.unwrap();
+
+    assert_eq!(page.total, 2, "both engrams are candidates");
+    assert_eq!(
+        page.items[0].permalink, "giant",
+        "the engram holding the needle in one of its ~1200 chunks ranks first"
+    );
+    assert!(
+        page.items[0].score > page.items[1].score,
+        "its one close chunk beats the small engram's whole body"
+    );
+
+    // The hydrate carries every column the old projection returned. A dropped
+    // or reordered column would surface as an empty field here.
+    let hit = &page.items[0];
+    assert_eq!(hit.domain, "d");
+    assert_eq!(hit.title, "Giant");
+    assert_eq!(hit.engram_type, "engram");
+    assert_eq!(hit.status, "current");
+    assert_eq!(hit.tags, vec!["t".to_string()]);
+    assert!(
+        !hit.snippet.is_empty(),
+        "the snippet is cut from the hydrated body"
+    );
+}
+parity!(
+    semantic_search_ranks_a_multi_mb_engram_by_its_closest_chunk,
+    the_closest_chunk_still_decides_the_rank
+);
+
+/// Two engrams with byte-identical embedded text tie exactly on distance, so the
+/// order between them is decided by the tiebreak rather than by the score. The
+/// phase-1 `ORDER BY dist ASC, c.engram_id ASC` makes that deterministic; the
+/// hydrate reapplies it in Rust. Repeating the query must not shuffle them, and
+/// neither must switching backends.
+async fn an_exact_distance_tie_is_ordered_deterministically(store: &dyn Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // Same title and same body, so the chunk text (which carries the title) is
+    // identical and the embeddings are equal to the bit.
+    write(root, "tie-a.md", &engram("Tie", "tie-a", NEEDLE));
+    write(root, "tie-b.md", &engram("Tie", "tie-b", NEEDLE));
+    write(root, "tie-c.md", &engram("Tie", "tie-c", NEEDLE));
+    let fake = FakeProvider::new("fake-8");
+    sync_and_embed(store, "d", root, &fake).await;
+
+    let first: Vec<String> = store
+        .search(&semantic_query(NEEDLE, &fake))
+        .await
+        .unwrap()
+        .items
+        .into_iter()
+        .map(|h| h.permalink)
+        .collect();
+    let second: Vec<String> = store
+        .search(&semantic_query(NEEDLE, &fake))
+        .await
+        .unwrap()
+        .items
+        .into_iter()
+        .map(|h| h.permalink)
+        .collect();
+
+    assert_eq!(first.len(), 3, "all three tied engrams are returned");
+    assert_eq!(first, second, "the tie order is stable across runs");
+    let mut sorted = first.clone();
+    sorted.sort();
+    assert_eq!(
+        sorted,
+        vec![
+            "tie-a".to_string(),
+            "tie-b".to_string(),
+            "tie-c".to_string()
+        ],
+        "no tied engram is dropped by the top-k cut"
+    );
+}
+parity!(
+    a_semantic_distance_tie_orders_deterministically,
+    an_exact_distance_tie_is_ordered_deterministically
+);
+
+/// The hybrid path runs the same split. The lexical half finds the needle by
+/// term and the semantic half by vector, and the merge keys on
+/// `(domain, permalink)`, so a hydrate that returned the wrong domain or
+/// permalink would split one engram into two hits.
+async fn hybrid_search_merges_the_hydrated_candidates(store: &dyn Store) {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write(root, "giant.md", &engram("Giant", "giant", &giant_body()));
+    write(root, "small.md", &engram("Brief", "small", FILLER));
+    let fake = FakeProvider::new("fake-8");
+    sync_and_embed(store, "d", root, &fake).await;
+
+    let query = SearchQuery {
+        mode: SearchMode::Hybrid,
+        ..semantic_query(NEEDLE, &fake)
+    };
+    let page = store.search(&query).await.unwrap();
+
+    assert_eq!(
+        page.total, 2,
+        "the two engrams merge into two hits, not four"
+    );
+    assert_eq!(
+        page.items[0].permalink, "giant",
+        "the engram matched by both signals leads"
+    );
+    assert_eq!(page.items[0].domain, "d");
+    assert!(page.items[0].score > 0.0);
+}
+parity!(
+    hybrid_search_merges_split_semantic_candidates,
+    hybrid_search_merges_the_hydrated_candidates
+);

--- a/crates/service/src/daemon.rs
+++ b/crates/service/src/daemon.rs
@@ -195,6 +195,12 @@ pub async fn run_serve(
     // Take ownership first so a second daemon fails fast with the live pid.
     let ownership = acquire_ownership()?;
 
+    // The lock is held, so this daemon is the only writer of the scratch
+    // directory: reclaim whatever a killed predecessor left spilled there. The
+    // directory itself was pointed at by the CLI before the runtime started
+    // (see `temp_store::point_at_state_dir`).
+    crate::temp_store::sweep_at_startup();
+
     let store = open_store(&loaded.effective, Some(&db_path)).await?;
     // A channel the engine uses to tell the watcher (spawned below) about a
     // domain registered after this daemon started, so it starts watching that

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -22,6 +22,7 @@ pub mod params;
 mod poller;
 pub mod settings;
 pub mod stub;
+pub mod temp_store;
 mod tool_schema;
 mod toon;
 

--- a/crates/service/src/temp_store.rs
+++ b/crates/service/src/temp_store.rs
@@ -1,0 +1,239 @@
+//! Spill containment: where the daemon's database scratch files live, and how
+//! the ones a killed daemon left behind are reclaimed.
+//!
+//! The embedded database engine spills a sorter that outgrows its buffer to a
+//! temp file. It creates that file through `tempfile::tempdir()`, which resolves
+//! the process temp location (`TMPDIR` on unix, `TMP`/`TEMP` on Windows) on
+//! every call, and deletes the directory in `Drop`. A graceful error unwinds and
+//! cleans up; a `SIGKILL` - a macOS jetsam OOM-kill, for instance - does not,
+//! and the spill file survives in the user's shared temp directory with a name
+//! that says nothing about who wrote it. A crash loop leaves one per attempt.
+//! That is the 2026-07-28 field incident (see
+//! `research/2026-07-28-turso-sorter-spill.md`), where ten orphans totalling
+//! ~450GB filled the disk.
+//!
+//! So the daemon points the process temp location at
+//! [`config::temp_store_dir`] and sweeps that one directory on startup. This
+//! bounds the collateral damage of a future spill and makes the leftovers
+//! obviously ours; it is defence in depth, not the fix. The fix is that no query
+//! feeds a wide projection into a sorter (see `crate::index::turso::search`).
+//!
+//! `TURSO_TMPDIR` and `SQLITE_TMPDIR` are set alongside because the engine
+//! honors those for its temp *database* files; the sorter path reads neither, so
+//! the plain temp location is the one that matters and all three are set
+//! together.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use crystalline_core::config;
+
+/// How long a leftover must have sat untouched before the sweep reclaims it. A
+/// live daemon writes to its spill file continuously, and only one daemon owns a
+/// state directory at a time, so an hour is far beyond any legitimate age; the
+/// check exists so a sweep can never race a spill that is still in use during a
+/// takeover.
+const STALE_AFTER: Duration = Duration::from_secs(60 * 60);
+
+/// What the startup sweep reclaimed.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct SweepReport {
+    /// How many stale entries were removed.
+    pub removed: usize,
+    /// How many bytes those entries held.
+    pub bytes: u64,
+    /// How many entries were left alone because they are too young to be sure
+    /// they are orphans.
+    pub kept: usize,
+}
+
+/// Point this process's temp location at the daemon's own scratch directory,
+/// creating it if needed. Returns the directory.
+///
+/// # Safety and call site
+///
+/// This sets process-wide environment variables, which is only sound while the
+/// process is single-threaded: `setenv` is not thread-safe against a concurrent
+/// `getenv` anywhere in the process. It must therefore be called from `main`
+/// before any runtime or worker thread starts, and only for `crystalline serve`,
+/// because the daemon owns its state directory for its whole life. A CLI
+/// one-shot must never call it: several of those can run at once against the
+/// same state directory, and they would race each other's sweeps.
+///
+/// Every other temp-file user in the daemon (a model download, an atomic write)
+/// is relocated along with the database engine. That is intended: they are all
+/// the daemon's scratch, and putting them next to the index keeps them on the
+/// volume the user already sized for it.
+pub fn point_at_state_dir() -> anyhow::Result<PathBuf> {
+    let dir = config::temp_store_dir()?;
+    std::fs::create_dir_all(&dir)?;
+    // Canonicalize so a relative or symlinked state directory still yields an
+    // absolute path: a child process inheriting the variable may have a
+    // different working directory.
+    let dir = std::fs::canonicalize(&dir).unwrap_or(dir);
+
+    // SAFETY: the caller guarantees this runs on the only thread in the process,
+    // before any runtime is started (see the call site in the CLI's `serve`
+    // arm), so no concurrent `getenv` can observe a torn environment.
+    unsafe {
+        #[cfg(windows)]
+        {
+            std::env::set_var("TMP", &dir);
+            std::env::set_var("TEMP", &dir);
+        }
+        #[cfg(not(windows))]
+        {
+            std::env::set_var("TMPDIR", &dir);
+        }
+        std::env::set_var("TURSO_TMPDIR", &dir);
+        std::env::set_var("SQLITE_TMPDIR", &dir);
+    }
+    Ok(dir)
+}
+
+/// Reclaim stale scratch left behind by a killed predecessor, in the daemon's
+/// own directory only. Never touches the system temp directory: the daemon has
+/// no way to tell a foreign process's files from its own there, and deleting
+/// someone else's scratch is worse than leaking ours.
+///
+/// Safe to call after the runtime has started - it only touches the filesystem.
+pub fn sweep(dir: &Path) -> SweepReport {
+    let mut report = SweepReport::default();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return report;
+    };
+    let now = SystemTime::now();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(meta) = entry.metadata() else { continue };
+        let young = meta
+            .modified()
+            .ok()
+            .and_then(|m| now.duration_since(m).ok())
+            .is_none_or(|age| age < STALE_AFTER);
+        if young {
+            report.kept += 1;
+            continue;
+        }
+        let size = dir_size(&path, meta.is_dir());
+        let removed = if meta.is_dir() {
+            std::fs::remove_dir_all(&path).is_ok()
+        } else {
+            std::fs::remove_file(&path).is_ok()
+        };
+        if removed {
+            report.removed += 1;
+            report.bytes += size;
+        }
+    }
+    report
+}
+
+/// The bytes an entry holds, summed one level deep and beyond. Best effort: an
+/// unreadable child contributes zero rather than aborting the sweep.
+fn dir_size(path: &Path, is_dir: bool) -> u64 {
+    if !is_dir {
+        return std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    }
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .map(|e| {
+            let child = e.path();
+            let is_dir = e.metadata().map(|m| m.is_dir()).unwrap_or(false);
+            dir_size(&child, is_dir)
+        })
+        .sum()
+}
+
+/// Create the scratch directory (if the daemon was started without the CLI's
+/// `point_at_state_dir` call), sweep it and log what was reclaimed. Called once
+/// at daemon startup, after tracing is initialized.
+pub fn sweep_at_startup() {
+    let Ok(dir) = config::temp_store_dir() else {
+        return;
+    };
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::warn!(
+            "could not create the scratch directory {}: {e}",
+            dir.display()
+        );
+        return;
+    }
+    let report = sweep(&dir);
+    if report.removed > 0 {
+        tracing::info!(
+            "reclaimed {} stale scratch {} ({:.1} MB) from {}",
+            report.removed,
+            if report.removed == 1 {
+                "entry"
+            } else {
+                "entries"
+            },
+            report.bytes as f64 / 1_048_576.0,
+            dir.display()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Set an entry's mtime far enough into the past that the sweep sees it as
+    /// stale. `filetime` is not a dependency, so this goes through `utimensat`
+    /// on unix and is skipped elsewhere.
+    #[cfg(unix)]
+    fn age(path: &Path) {
+        use std::os::unix::ffi::OsStrExt;
+        let c = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+        let old = libc::timespec {
+            tv_sec: (SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+                - 7200) as libc::time_t,
+            tv_nsec: 0,
+        };
+        let times = [old, old];
+        assert_eq!(
+            unsafe { libc::utimensat(libc::AT_FDCWD, c.as_ptr(), times.as_ptr(), 0) },
+            0
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_sweep_reclaims_stale_scratch_and_spares_fresh_scratch() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path();
+
+        // A stale leftover shaped like the engine's: a directory holding one
+        // spill file.
+        let stale = dir.join(".tmpAAAAAA");
+        std::fs::create_dir(&stale).unwrap();
+        std::fs::write(stale.join("tursodb_temp_file"), vec![0u8; 4096]).unwrap();
+        age(&stale);
+
+        // A fresh one, which a live query could still be writing.
+        let fresh = dir.join(".tmpBBBBBB");
+        std::fs::create_dir(&fresh).unwrap();
+        std::fs::write(fresh.join("tursodb_temp_file"), vec![0u8; 16]).unwrap();
+
+        let report = sweep(dir);
+        assert_eq!(report.removed, 1, "only the stale entry is reclaimed");
+        assert_eq!(report.kept, 1, "the fresh entry is left alone");
+        assert_eq!(report.bytes, 4096, "the reclaimed bytes are reported");
+        assert!(!stale.exists());
+        assert!(fresh.exists());
+    }
+
+    #[test]
+    fn sweeping_a_missing_directory_is_a_no_op() {
+        let root = tempfile::tempdir().unwrap();
+        let report = sweep(&root.path().join("absent"));
+        assert_eq!(report, SweepReport::default());
+    }
+}


### PR DESCRIPTION
Fixes the 2026-07-28 disk-fill incident (investigation: research/2026-07-28-turso-sorter-spill.md, measured not modelled; plan: plans/2026-07-28-semantic-spill-fix.md): the semantic candidate query projected the full engram body into the GROUP BY sorter once per chunk of that same engram - quadratic spill in engram size, 43-52GB per hybrid search on a real 196MB corpus, daemon jetsam-killed mid-query, scratch dirs leaked on every unclean death, ten searches filled a 926GB disk.

## The fix

- Two-phase query in BOTH backends: phase 1 narrow top-k (`SELECT c.engram_id, min(distance) ... GROUP BY c.engram_id ORDER BY dist ASC, c.engram_id ASC LIMIT 100` - two 8-byte columns per sorter record instead of multi-MB bodies), phase 2 hydrate winners by primary key with no sort, phase-1 order reapplied in Rust. Ranking semantics identical; ties made deterministic (they were sorter-order-arbitrary before).
- Side-by-side control on one database: pre-fix 191ms and 196.7MB spilled, post-fix 19ms and 0 bytes, identical winner ids in identical order. At field shape (3300 engrams, 30k chunks): 404MB -> 0.
- Wide-projection sweep: `all_engram_contents` drops its SQL ORDER BY and sorts in Rust (same contract, no sorter, collation-independent across backends); the lexical scan (rides rowid order), filter-only (bounded sorter via LIMIT) and embedding backlog (same) are documented in place as safe. A shared `CANDIDATE_COLUMNS` const pins the projection across the lexical, filter-only and hydrate paths with a column-order test.
- Containment regardless of the query fix: the daemon points TMPDIR at a crystalline-owned `<state_dir>/tmp` before the runtime starts (verified against vendored turso 0.7.0: the sorter honors only the process temp dir) and sweeps stale scratch dirs older than an hour at startup with byte-accounted logging - a historically leaked spill heals on the next daemon start, and any future spill lands somewhere identifiable.
- Regression guards: SQL-narrowness and EXPLAIN plan tests in both backends, plus a parity test over a ~2.1MB thousand-chunk engram.

## Verification

- nextest: 1457 tests run, 1457 passed, 4 skipped
- Postgres legs three times locally per standing practice: 620/620, 620/620, 620/620
- Spill proof on a live corpus: owned scratch dir stays at 0KB through hybrid searches, daemon RSS flat, results correctly ranked
- doctests ok, clippy clean, fmt clean, style-lint OK