### PR TITLE
Fluid slice 1: read API surface and OpenAPI contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,6 +1310,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "turso",
+ "utoipa",
  "walkdir",
  "windows-sys 0.61.2",
 ]
@@ -6237,6 +6238,29 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,12 @@ base64 = "0.22.1"
 # dependency is needed; `std` is on so hashing errors carry `std::error::Error`.
 argon2 = { version = "0.5.3", features = ["std"] }
 
+# The OpenAPI document for the REST surface (crates/service). Default features
+# are exactly the `macros` one the `#[utoipa::path]`, `ToSchema` and
+# `IntoParams` attributes need; `preserve_order` stays off, so nothing here can
+# switch serde_json's map type on the whole workspace.
+utoipa = "5.5.0"
+
 insta = { version = "1.48.0", features = ["yaml"] }
 assert_cmd = "2.2.2"
 tempfile = "3.27.0"

--- a/crates/cli/src/users.rs
+++ b/crates/cli/src/users.rs
@@ -71,7 +71,10 @@ pub async fn run(command: UsersCommand, json: bool) -> Result<()> {
         } => {
             let password = read_password(password_stdin)?;
             store.set_password(&name, &password).await?;
-            println!("Changed the password for '{}'.", stored_name(&name));
+            println!(
+                "Changed the password for '{}' and signed out its sessions.",
+                stored_name(&name)
+            );
         }
         UsersCommand::Role { name, role } => {
             let role: Role = role.into();
@@ -81,7 +84,7 @@ pub async fn run(command: UsersCommand, json: bool) -> Result<()> {
         UsersCommand::Disable { name } => {
             store.set_disabled(&name, true).await?;
             println!(
-                "Disabled '{}'. Its sessions stop working immediately.",
+                "Disabled '{}' and revoked its sessions. Enabling it again does not bring them back.",
                 stored_name(&name)
             );
         }

--- a/crates/service/Cargo.toml
+++ b/crates/service/Cargo.toml
@@ -44,6 +44,7 @@ notify = { workspace = true }
 axum = { workspace = true }
 axum-extra = { workspace = true }
 time = { workspace = true }
+utoipa = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/service/openapi/fluid-v1.json
+++ b/crates/service/openapi/fluid-v1.json
@@ -1,0 +1,1876 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Crystalline Fluid API",
+    "description": "The JSON API `crystalline serve --http` mounts at `/api/v1`, the surface the Fluid UI talks to. Read-only in this version apart from the session and account routes.\n\nEvery path but `/auth/login`, `/auth/logout` and `/auth/me` is closed by default: a request that carries no identity is answered 401 ahead of routing, so an unauthenticated caller never learns which paths exist. Every failure is an RFC 9457 problem detail sent as `application/problem+json`.\n\nThe payloads marked as generic objects are the engine's own JSON, passed through unchanged so this API and the MCP tools stay one source of truth; each carries an example of the shape it answers with.",
+    "license": {
+      "name": "AGPL-3.0-or-later"
+    },
+    "version": "v1"
+  },
+  "paths": {
+    "/api/v1/activity": {
+      "get": {
+        "tags": [
+          "discovery"
+        ],
+        "summary": "`GET /activity` - what was recorded lately, newest first, which is what a\nclient opens on.",
+        "description": "The window defaults in the engine rather than here, so the API and the MCP\ntool answer the same question when neither is told which window to use.",
+        "operationId": "get_activity",
+        "parameters": [
+          {
+            "name": "domains",
+            "in": "query",
+            "description": "Restrict to these domains, comma separated. Defaults to every registered\ndomain.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "eng,ops"
+          },
+          {
+            "name": "timeframe",
+            "in": "query",
+            "description": "A recency window such as `7d`, `24h` or `2w`. Defaults to `7d`.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "7d"
+          },
+          {
+            "name": "types",
+            "in": "query",
+            "description": "Restrict to these `type` values, comma separated.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "decision,runbook"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The engine's own activity payload, unchanged, with the window it actually used echoed back.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "count": 1,
+                  "engrams": [
+                    {
+                      "domain": "eng",
+                      "engram_type": "engram",
+                      "permalink": "alpha",
+                      "recorded_at": "2026-08-04",
+                      "status": "stable",
+                      "tags": [
+                        "eng"
+                      ],
+                      "title": "Alpha"
+                    }
+                  ],
+                  "timeframe": "7d"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The query string will not parse.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Exchange credentials for a session.",
+        "description": "Sets the `fluid_session` cookie and returns the account plus the CSRF token every later mutating request must echo in `x-csrf-token`. Any session the request arrived holding is revoked first, so a planted token cannot survive a login.",
+        "operationId": "login",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Signed in. The session cookie is set and the CSRF token is in the body.",
+            "headers": {
+              "set-cookie": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "The `fluid_session` session cookie, HttpOnly and SameSite=Lax."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The body is not JSON.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The name or password is wrong. One message for every way this can fail, so nothing is learned about which accounts exist.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "The body is not `application/json`.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The body is JSON but not a login.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "Revoke the session and clear its cookie. Not an error without one: a browser\nlogging out twice, or with a cookie this server has already forgotten, is\nordinary. Guarded by the CSRF check like any other mutating request, so\nanother origin cannot log a user out.",
+        "operationId": "logout",
+        "responses": {
+          "200": {
+            "description": "Signed out, whether or not there was a session to revoke.",
+            "headers": {
+              "set-cookie": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Clears the `fluid_session` cookie."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogoutResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "A cookie session did not echo its CSRF token.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/me": {
+      "get": {
+        "tags": [
+          "auth"
+        ],
+        "summary": "The capability probe a client calls before anything else: who it is, whether\nit is being served anonymously, whether this instance refuses content\nmutations, and which server version it is talking to, so a mismatched UI can\nsay so instead of failing later.",
+        "description": "Answers without an identity on purpose. `user: null, anonymous: false` is\nwhat tells a browser to show a login form; `anonymous: true` tells it to\nbrowse instead.",
+        "operationId": "get_me",
+        "responses": {
+          "200": {
+            "description": "Who the caller is and what this instance allows. Answered without an identity too, which is how a client learns it has to log in.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/context": {
+      "get": {
+        "tags": [
+          "discovery"
+        ],
+        "summary": "`GET /context` - the graph around an anchor: the anchored engrams as seed\nnodes, the neighborhood ranked out from them, and the edges that connect what\ncame back. This is what a client draws a relationship view from.",
+        "description": "The three ways an anchor can be wrong stay distinguishable: absent is a 400\nfrom the extractor, one that is not a `crystalline://` URL is the engine's\nown 422, and one pointing at an engram nobody wrote is a 404.\n\n`timeframe` is not exposed: the engine documents it as advisory in this\nversion, and a parameter that does not change the answer is not worth a\nclient learning.",
+        "operationId": "get_context",
+        "parameters": [
+          {
+            "name": "anchor",
+            "in": "query",
+            "description": "A `crystalline://domain/permalink` anchor. A `/*` suffix globs a prefix.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "crystalline://eng/alpha"
+          },
+          {
+            "name": "depth",
+            "in": "query",
+            "description": "Traversal depth, 1 to 3. Defaults to 1.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "example": 1
+          },
+          {
+            "name": "domains",
+            "in": "query",
+            "description": "Restrict the returned neighborhood to these domains, comma separated.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "eng,ops"
+          },
+          {
+            "name": "max_related",
+            "in": "query",
+            "description": "Maximum related engrams beyond the anchors. Defaults to 10.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "example": 10
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The engine's own context payload, unchanged: the anchored engrams as seed nodes plus the neighborhood ranked out from them.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "anchor": "crystalline://eng/alpha",
+                  "depth": 1,
+                  "edges": [
+                    {
+                      "from": 1,
+                      "kind": "relation",
+                      "rel_type": "relates_to",
+                      "to": 2
+                    }
+                  ],
+                  "nodes": [
+                    {
+                      "domain": "eng",
+                      "id": 1,
+                      "permalink": "alpha",
+                      "seed": true,
+                      "title": "Alpha",
+                      "type": "engram"
+                    },
+                    {
+                      "domain": "eng",
+                      "id": 2,
+                      "permalink": "notes/beta",
+                      "seed": false,
+                      "title": "Beta",
+                      "type": "engram"
+                    }
+                  ],
+                  "timeframe": null
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The query string will not parse, `anchor` included: it has no default.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The anchor names no engram.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The anchor is not a `crystalline://` URL.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/domains": {
+      "get": {
+        "tags": [
+          "domains"
+        ],
+        "summary": "`GET /domains` - every registered domain with its counts, its kind and its\nrouting bullets, plus the behavior rules that govern them.",
+        "description": "`include_routing` is always on rather than a query parameter: a browser\nclient is exactly the caller that has no other way to learn what a domain is\nfor, and the bullets are a handful of lines per domain.",
+        "operationId": "list_domains",
+        "responses": {
+          "200": {
+            "description": "The engine's own domain listing, unchanged.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "behavior": [
+                    "Search before answering from memory.",
+                    "Record what was learned as an engram."
+                  ],
+                  "domains": [
+                    {
+                      "engrams": 4,
+                      "kind": "file",
+                      "last_sync": "2026-08-05T09:14:22Z",
+                      "name": "eng",
+                      "observations": 12,
+                      "path": "/Users/ada/Documents/Crystalline/eng",
+                      "relations": 3,
+                      "when_to_use": [
+                        "Route here for eng questions."
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/domains/{domain}/engrams": {
+      "get": {
+        "tags": [
+          "engrams"
+        ],
+        "summary": "One domain's engrams, filtered by frontmatter and paged.",
+        "description": "A filter-only search, so the answer carries the same page envelope a search does and a client pages it the same way. Listing by folder is not here: the tree endpoint owns the navigation view and this one owns the frontmatter view.\n\nA domain nobody registered is a 404, while filters that match nothing are an empty page: two states a client can tell apart.",
+        "operationId": "list_engrams",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "path",
+            "description": "The registered domain.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Filter by `type`.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "decision"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by `status`.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "stable"
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Require all of these tags, comma separated. A URL is a string, so the\nrepeated-parameter form a `Vec` would need is not on offer here; the\nlist is split on the way in.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "eng,nested"
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "Only engrams recorded on or after this ISO date.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "2026-01-31"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "One-based page number. Defaults to 1.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "example": 1
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Page size. Defaults to 10.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "example": 10
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The engine's page envelope, unchanged.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "count": 1,
+                  "hits": [
+                    {
+                      "domain": "eng",
+                      "engram_type": "engram",
+                      "kind": "engram",
+                      "permalink": "alpha",
+                      "score": 1.0,
+                      "snippet": "The first engram in this domain.",
+                      "status": "stable",
+                      "tags": [
+                        "eng"
+                      ],
+                      "title": "Alpha"
+                    }
+                  ],
+                  "limit": 10,
+                  "mode": "text",
+                  "page": 1,
+                  "total": 4
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The query string will not parse.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such domain.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/domains/{domain}/engrams/{permalink}": {
+      "get": {
+        "tags": [
+          "engrams"
+        ],
+        "summary": "One engram in full.",
+        "description": "Its frontmatter, its markdown as written and the references the engine resolves around it.\n\nThe response carries an `ETag` over the markdown, so a client knows which version it is holding and can say so when it later writes back.",
+        "operationId": "get_engram",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "path",
+            "description": "The registered domain.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "permalink",
+            "in": "path",
+            "description": "The engram permalink. A permalink is a path, so this segment may contain slashes: `notes/deep/gamma`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "notes/deep/gamma"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The engine's own read payload, unchanged.",
+            "headers": {
+              "etag": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "The quoted checksum of the engram as read, the same token a later write compares an `expected_checksum` against."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "checksum": "3f8a1c05e2",
+                  "content": "---\ntitle: Alpha\n---\n\nThe first engram.\n",
+                  "domain": "eng",
+                  "frontmatter": {
+                    "permalink": "alpha",
+                    "title": "Alpha"
+                  },
+                  "links": [],
+                  "observations": [],
+                  "path": "alpha.md",
+                  "permalink": "alpha",
+                  "relations": [],
+                  "status": "stable",
+                  "title": "Alpha",
+                  "type": "engram",
+                  "url": "crystalline://eng/alpha"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such domain or engram.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/domains/{domain}/manifest": {
+      "get": {
+        "tags": [
+          "domains"
+        ],
+        "summary": "`GET /domains/{domain}/manifest` - the domain's MANIFEST markdown as\nwritten, so a client can render or edit the source rather than a reduction\nof it.",
+        "operationId": "get_domain_manifest",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "path",
+            "description": "The registered domain.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The manifest source beside the domain it belongs to.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "domain": "eng",
+                  "markdown": "---\ntitle: eng\n---\n\n## When to Use\n\n- Route here for eng questions.\n"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such domain, or the domain carries no MANIFEST yet.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/domains/{domain}/tree": {
+      "get": {
+        "tags": [
+          "domains"
+        ],
+        "summary": "`GET /domains/{domain}/tree` - one domain's engrams and subfolders under a\npath, the navigation a file tree in the UI is built from.",
+        "operationId": "get_domain_tree",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "path",
+            "description": "The registered domain.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "description": "A domain-relative folder path. Defaults to the root.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "notes"
+          },
+          {
+            "name": "depth",
+            "in": "query",
+            "description": "How many folder levels deep to list. Defaults to 1.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "example": 2
+          },
+          {
+            "name": "glob",
+            "in": "query",
+            "description": "A glob filtering the engram paths listed.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "notes/**"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The engine's own browse payload, unchanged.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "domain": "eng",
+                  "engrams": [
+                    {
+                      "path": "alpha.md",
+                      "permalink": "alpha",
+                      "title": "Alpha",
+                      "type": "engram"
+                    }
+                  ],
+                  "folders": [
+                    "notes"
+                  ],
+                  "path": "/"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The query string will not parse.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such domain.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The glob is not a valid pattern.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/graph": {
+      "get": {
+        "tags": [
+          "graph"
+        ],
+        "summary": "`GET /graph` - the nodes and typed edges around an anchor: every node with\nthe address, title, status and type a client labels it with, every edge with\nits direction and `rel_type`, and `truncated` saying whether the node cap\ncut anything.",
+        "description": "Both bounds are the server's to decide: the engine clamps the depth to one or\ntwo hops and the node count to its own ceiling, so a hand-written URL can ask\nneither for nothing nor for a whole index in one payload. A clamped request\nis answered rather than refused - the honest report of what was returned is\nthe payload itself.\n\nRetired engrams are part of the answer, carrying their status. The graph is\nthe shape of what is written, and a client fades what is retired rather than\nbeing served a graph with the retired nodes already cut out of it.\n\nThe three ways an anchor can be wrong stay distinguishable, as on `/context`:\nabsent is a 400 from the extractor, one that is not a `crystalline://` URL is\nthe engine's own 422, and one pointing at an engram nobody wrote is a 404.",
+        "operationId": "get_graph",
+        "parameters": [
+          {
+            "name": "anchor",
+            "in": "query",
+            "description": "A `crystalline://domain/permalink` anchor. A `/*` suffix globs a prefix.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "crystalline://eng/alpha"
+          },
+          {
+            "name": "depth",
+            "in": "query",
+            "description": "Traversal depth, 1 or 2. Defaults to 1.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "example": 1
+          },
+          {
+            "name": "max_nodes",
+            "in": "query",
+            "description": "The most nodes to return. Defaults to 100, capped by the engine.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "example": 100
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The engine's own graph payload, unchanged: the flat node and edge lists a renderer draws from, with `truncated` saying whether the node cap cut anything. `id` is opaque and stable only within one response; the address is `crystalline://domain/permalink`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "edges": [
+                    {
+                      "from": 1,
+                      "rel_type": "relates_to",
+                      "to": 2
+                    }
+                  ],
+                  "nodes": [
+                    {
+                      "domain": "eng",
+                      "id": 1,
+                      "permalink": "alpha",
+                      "status": "stable",
+                      "title": "Alpha",
+                      "type": "engram"
+                    },
+                    {
+                      "domain": "eng",
+                      "id": 2,
+                      "permalink": "notes/beta",
+                      "status": "deprecated",
+                      "title": "Beta",
+                      "type": "engram"
+                    }
+                  ],
+                  "truncated": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The query string will not parse, `anchor` included: it has no default.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The anchor names no engram.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The anchor is not a `crystalline://` URL.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/openapi.json": {
+      "get": {
+        "tags": [
+          "meta"
+        ],
+        "summary": "This API's own OpenAPI 3.1 document.",
+        "description": "Served behind the viewer guard like every other data route: the description of a closed API is part of what being closed by default protects. Tooling does not need this route, since the document is a committed artifact in the repository at `crates/service/openapi/fluid-v1.json`.",
+        "operationId": "get_openapi_document",
+        "responses": {
+          "200": {
+            "description": "This document. Behind the viewer guard like every other data route.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/search": {
+      "get": {
+        "tags": [
+          "discovery"
+        ],
+        "summary": "`GET /search` - search across the registered domains, or across the ones\n`domains` names.",
+        "description": "The answer is the engine's page envelope (`mode`, `total`, `page`, `limit`,\n`count`, `hits`), so a client pages a search the way it pages a listing.\n`mode` is the mode that actually ran rather than the one asked for: hybrid\nand semantic fall back to text where there is nothing embedded to search, and\nthe response says which happened rather than quietly answering from a\ndifferent index than the caller expected.\n\nA `search_type` the engine does not know is its own error, surfaced as a 422\nproblem detail carrying the engine's message, so the caller learns which\nvalues do work instead of being handed a bare status.\n\n`metadata_filters` is not exposed: it takes a JSON object of comparisons,\nwhich has no honest query-string spelling, and no client needs it yet.",
+        "operationId": "search",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "The free-text query. Omit for a filter-only search.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "retrieval latency"
+          },
+          {
+            "name": "domains",
+            "in": "query",
+            "description": "Restrict to these domains, comma separated. Defaults to every registered\ndomain.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "eng,ops"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Filter by `type`.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "decision"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by `status`.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "stable"
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Require all of these tags, comma separated.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "eng,nested"
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "description": "Only engrams recorded on or after this ISO date.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "2026-01-31"
+          },
+          {
+            "name": "search_type",
+            "in": "query",
+            "description": "hybrid (default), text, semantic, title or permalink.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "hybrid"
+          },
+          {
+            "name": "min_similarity",
+            "in": "query",
+            "description": "Minimum cosine similarity for a semantic hit.",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "format": "float"
+            },
+            "example": 0.65
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "One-based page number. Defaults to 1.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "example": 1
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Page size. Defaults to 10.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "example": 10
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The engine's page envelope, unchanged. `mode` is the mode that actually ran, which may be a fallback to text.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "count": 1,
+                  "hits": [
+                    {
+                      "domain": "eng",
+                      "engram_type": "engram",
+                      "kind": "observation",
+                      "line": 14,
+                      "permalink": "alpha",
+                      "score": 0.82,
+                      "snippet": "...retrieval latency dropped by half...",
+                      "status": "stable",
+                      "tags": [
+                        "eng"
+                      ],
+                      "title": "Alpha"
+                    }
+                  ],
+                  "limit": 10,
+                  "mode": "hybrid",
+                  "page": 1,
+                  "total": 3
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The query string will not parse.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "`search_type` names a mode the engine does not know.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "summary": "Every account, by name.",
+        "description": "An account carries no password material, so the rows go out as they come back from the store. Admin only: the account list names every way into the instance and who holds it.",
+        "operationId": "list_users",
+        "responses": {
+          "200": {
+            "description": "Every account.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsersResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The caller is not an admin.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "users"
+        ],
+        "summary": "`POST /users` - add an account, answering 201 with the account as stored.",
+        "description": "The response is read back out of the store rather than echoed from the\nrequest, so what the client renders is what was written: the folded name,\nthe defaulted display name, and the disabled flag the row starts with.",
+        "operationId": "create_user",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "The account as stored.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The body is not JSON.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The caller is not an admin, or a cookie session did not echo its CSRF token.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "That name is already taken.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "The body is not `application/json`.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The body is JSON but not an account, or the password is empty.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/{name}": {
+      "delete": {
+        "tags": [
+          "users"
+        ],
+        "summary": "`DELETE /users/{name}` - remove an account and every session it holds,\nanswering 204.",
+        "description": "An admin may not remove its own account (409), and the store refuses to\nremove the last enabled admin whoever asks (409 as well, in its own words).",
+        "operationId": "delete_user",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The account, in any casing.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The account and its sessions are gone."
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The caller is not an admin, or a cookie session did not echo its CSRF token.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such account.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The account is the caller's own, or is the last enabled admin.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "users"
+        ],
+        "summary": "`PATCH /users/{name}` - change a role, a disabled flag, a password, or any\ncombination, answering with the account as it now stands.",
+        "description": "Two of the three fields are revocations as well as edits: setting a password\nand disabling an account each delete every session that account holds, in\nthe store and in the same transaction as the change. That is what makes this\nroute useful against a compromised account - a reset that left the intruder's\ncookie alive for the rest of its 30-day life would be theatre - and it means\nan admin resetting their own password signs their own other sessions out too,\nthis one included.\n\nEvery check runs before the first write, so a request that will be refused\nchanges nothing. The writes themselves are one store call each rather than\none transaction: the store's guarded statements each own their own\ninvariant, and a failure part-way leaves the earlier fields applied and says\nwhich operation was refused. That is visible to a client only in the\npathological case of a concurrent edit racing this one, since the refusals a\ncaller can provoke on purpose - the last-admin guard and an unknown account\n- are decided identically by all three statements.",
+        "operationId": "update_user",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The account, in any casing.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PatchBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The account as it now stands.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The body is not JSON.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The caller is not an admin, or a cookie session did not echo its CSRF token.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No such account.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The change would disable the caller's own account, or would leave the installation without an enabled admin.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "The body is not `application/json`.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The body changes nothing, or the new password is empty.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/vocabulary": {
+      "get": {
+        "tags": [
+          "discovery"
+        ],
+        "summary": "`GET /vocabulary` - the words the domains are written in: the tags in use\nwith their counts, the observation categories and the relation types, plus\nthe near-duplicate clusters and tag aliases the engine reports when there are\nany.",
+        "description": "The domain is a filter here rather than a path segment, so an unknown name\nanswers an empty vocabulary rather than a 404: this route asks what is in\nuse, and the answer to that can legitimately be nothing.",
+        "operationId": "get_vocabulary",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "query",
+            "description": "Restrict to one domain. Omit for a vocabulary across every domain.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "example": "eng"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The engine's own vocabulary payload, unchanged. `clusters` and `aliases` are omitted when there are none.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                },
+                "example": {
+                  "aliases": [
+                    {
+                      "alias": "engineering",
+                      "canonical": "eng"
+                    }
+                  ],
+                  "categories": [
+                    {
+                      "count": 4,
+                      "name": "decision"
+                    }
+                  ],
+                  "domain": "eng",
+                  "relation_types": [
+                    {
+                      "count": 2,
+                      "name": "relates_to"
+                    }
+                  ],
+                  "tags": [
+                    {
+                      "engrams": 3,
+                      "name": "eng",
+                      "observations": 5
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The query string will not parse.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CreateBody": {
+        "type": "object",
+        "description": "A new account. `display` defaults to `name` as typed, and `email` is optional and never used for login.",
+        "required": [
+          "name",
+          "role",
+          "password"
+        ],
+        "properties": {
+          "display": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Human-readable name for the UI. Defaults to `name` as typed.",
+            "example": "Bob"
+          },
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional contact address.",
+            "example": "bob@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "The login name, in any casing: the store folds it.",
+            "example": "bob"
+          },
+          "password": {
+            "type": "string",
+            "description": "The initial password. Never stored in the clear; the store hashes it.",
+            "example": "correct horse battery staple"
+          },
+          "role": {
+            "$ref": "#/components/schemas/Role",
+            "description": "What the new account may do."
+          }
+        }
+      },
+      "LoginBody": {
+        "type": "object",
+        "description": "What `POST /auth/login` takes.",
+        "required": [
+          "name",
+          "password"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The account name, in any casing: the store folds it.",
+            "example": "ada"
+          },
+          "password": {
+            "type": "string",
+            "description": "The password, checked with argon2id.",
+            "example": "correct horse battery staple"
+          }
+        }
+      },
+      "LoginResponse": {
+        "type": "object",
+        "description": "What `POST /auth/login` answers with.\n\nA type rather than an inline `json!`, so the OpenAPI document and the\nresponse are one definition. Same for the two below it.",
+        "required": [
+          "user",
+          "csrf"
+        ],
+        "properties": {
+          "csrf": {
+            "type": "string",
+            "description": "The session's CSRF token, which every later mutating request must echo\nin the `x-csrf-token` header (see `CSRF_HEADER`).\n\nThe header is named in plain backticks rather than through an intra-doc\nlink because utoipa copies this comment into the published document,\nwhere a Rust link target reads as noise. Same wherever else a schema\nfield's comment names something in this crate.",
+            "example": "9f2c1d7e4b6a8035"
+          },
+          "user": {
+            "$ref": "#/components/schemas/User",
+            "description": "The account that was signed in."
+          }
+        }
+      },
+      "LogoutResponse": {
+        "type": "object",
+        "description": "What `POST /auth/logout` answers with: an acknowledgement and nothing else,\nsince a logout that found no session is a success too.",
+        "required": [
+          "ok"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean",
+            "description": "Always true."
+          }
+        }
+      },
+      "MeResponse": {
+        "type": "object",
+        "description": "What `GET /auth/me` answers with: everything a client needs before it draws\nanything.",
+        "required": [
+          "anonymous",
+          "read_only",
+          "version"
+        ],
+        "properties": {
+          "anonymous": {
+            "type": "boolean",
+            "description": "Whether the request is being served as the anonymous viewer."
+          },
+          "read_only": {
+            "type": "boolean",
+            "description": "Whether this instance refuses content mutations."
+          },
+          "user": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/User",
+                "description": "The account behind this request, or null when there is none."
+              }
+            ]
+          },
+          "version": {
+            "type": "string",
+            "description": "The server version, so a mismatched UI can say so.",
+            "example": "0.12.0"
+          }
+        }
+      },
+      "PatchBody": {
+        "type": "object",
+        "description": "Whichever of the three an admin wants to change. All absent is refused with a 422 rather than served as a no-op, so a client sending the wrong field names hears about it.",
+        "properties": {
+          "disabled": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether the account is disabled. Disabling deletes every session the\naccount holds, so it is a revocation rather than a flag a later\nre-enabling hands back; it also stops any new login."
+          },
+          "password": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "A replacement password. Setting it revokes every session the account\nholds, so whoever was signed in under the old one is signed out."
+          },
+          "role": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Role",
+                "description": "The new role."
+              }
+            ]
+          }
+        }
+      },
+      "ProblemDetail": {
+        "type": "object",
+        "description": "An RFC 9457 problem detail, sent as `application/problem+json`. Every failure on this surface has this shape, so a client can branch on `status` alone.",
+        "required": [
+          "type",
+          "status",
+          "title",
+          "detail"
+        ],
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "The specific occurrence, safe to show to the caller.",
+            "example": "no engram 'ghost' in domain 'eng'"
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "description": "The HTTP status, mirrored into the body so a client that only has the\nparsed payload can still branch on it.",
+            "example": 404,
+            "minimum": 0
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, stable, human-readable summary of the problem type.",
+            "example": "not found"
+          },
+          "type": {
+            "type": "string",
+            "description": "The problem type URI. Always `about:blank`: `status` and `title` carry\nthe classification, and this surface publishes no per-problem pages to\npoint at.",
+            "example": "about:blank"
+          }
+        }
+      },
+      "Role": {
+        "type": "string",
+        "description": "What a user may do. Ordered least to most privileged; the REST layer maps\neach endpoint to the minimum role it accepts.",
+        "enum": [
+          "viewer",
+          "editor",
+          "admin"
+        ]
+      },
+      "User": {
+        "type": "object",
+        "description": "One account. Carries no password material, so it is safe to hand to a\nhandler and serialize into a response.",
+        "required": [
+          "name",
+          "display",
+          "role",
+          "disabled"
+        ],
+        "properties": {
+          "disabled": {
+            "type": "boolean",
+            "description": "A disabled account keeps its rows but can neither log in nor use an\nalready-issued session."
+          },
+          "display": {
+            "type": "string",
+            "description": "Human-readable name for the UI.",
+            "example": "Ada Lovelace"
+          },
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional contact address; never used for login.",
+            "example": "ada@example.com"
+          },
+          "name": {
+            "type": "string",
+            "description": "The login name and primary key. Also the identity the trusted-header\nmode provisions against.",
+            "example": "ada"
+          },
+          "role": {
+            "$ref": "#/components/schemas/Role",
+            "description": "What this account may do."
+          }
+        }
+      },
+      "UserResponse": {
+        "type": "object",
+        "description": "What the two writing routes answer with: the account as stored, read back\nafter the write rather than echoed from the request.",
+        "required": [
+          "user"
+        ],
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/User",
+            "description": "The account as it now stands."
+          }
+        }
+      },
+      "UsersResponse": {
+        "type": "object",
+        "description": "What `GET /users` answers with. A wrapper rather than a bare array, matching\nthe `{\"users\": [...]}` envelope `crystalline users list --json` prints.",
+        "required": [
+          "users"
+        ],
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/User"
+            },
+            "description": "Every account, by name."
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "meta",
+      "description": "The API's description of itself."
+    },
+    {
+      "name": "auth",
+      "description": "Sessions and the capability probe."
+    },
+    {
+      "name": "domains",
+      "description": "Which domains this instance serves and what each holds."
+    },
+    {
+      "name": "engrams",
+      "description": "Listing and reading engrams."
+    },
+    {
+      "name": "discovery",
+      "description": "Search, vocabulary, context and recent activity."
+    },
+    {
+      "name": "graph",
+      "description": "The neighborhood graph around an anchor."
+    },
+    {
+      "name": "users",
+      "description": "Account management. Admin only."
+    }
+  ]
+}

--- a/crates/service/openapi/fluid-v1.json
+++ b/crates/service/openapi/fluid-v1.json
@@ -96,6 +96,16 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "The trusted-header identity names a disabled account.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         }
       }
@@ -157,6 +167,16 @@
               }
             }
           },
+          "403": {
+            "description": "The trusted-header identity names a disabled account.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
           "415": {
             "description": "The body is not `application/json`.",
             "content": {
@@ -207,7 +227,7 @@
             }
           },
           "403": {
-            "description": "A cookie session did not echo its CSRF token.",
+            "description": "A cookie session did not echo its CSRF token, or the trusted-header identity names a disabled account.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -225,7 +245,7 @@
           "auth"
         ],
         "summary": "The capability probe a client calls before anything else: who it is, whether\nit is being served anonymously, whether this instance refuses content\nmutations, and which server version it is talking to, so a mismatched UI can\nsay so instead of failing later.",
-        "description": "Answers without an identity on purpose. `user: null, anonymous: false` is\nwhat tells a browser to show a login form; `anonymous: true` tells it to\nbrowse instead.",
+        "description": "Answers without an identity on purpose. `user: null, anonymous: false` is\nwhat tells a browser to show a login form; `anonymous: true` tells it to\nbrowse instead.\n\nIt also reissues the session's CSRF token, which is the only way a reloaded\nbrowser gets it back: see `MeResponse::csrf`.",
         "operationId": "get_me",
         "responses": {
           "200": {
@@ -234,6 +254,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The trusted-header identity names a disabled account. The guard resolves identity ahead of routing, so this answer reaches even the paths that are served without one.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
                 }
               }
             }
@@ -356,6 +386,16 @@
               }
             }
           },
+          "403": {
+            "description": "The trusted-header identity names a disabled account.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
           "404": {
             "description": "The anchor names no engram.",
             "content": {
@@ -420,6 +460,16 @@
           },
           "401": {
             "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The trusted-header identity names a disabled account.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -565,6 +615,16 @@
               }
             }
           },
+          "403": {
+            "description": "The trusted-header identity names a disabled account.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
           "404": {
             "description": "No such domain.",
             "content": {
@@ -654,6 +714,16 @@
               }
             }
           },
+          "403": {
+            "description": "The trusted-header identity names a disabled account.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
           "404": {
             "description": "No such domain or engram.",
             "content": {
@@ -702,6 +772,16 @@
           },
           "401": {
             "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The trusted-header identity names a disabled account.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -810,6 +890,16 @@
           },
           "401": {
             "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The trusted-header identity names a disabled account.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -943,6 +1033,16 @@
               }
             }
           },
+          "403": {
+            "description": "The trusted-header identity names a disabled account.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
           "404": {
             "description": "The anchor names no engram.",
             "content": {
@@ -987,6 +1087,16 @@
           },
           "401": {
             "description": "No identity.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The trusted-header identity names a disabled account.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1165,6 +1275,16 @@
               }
             }
           },
+          "403": {
+            "description": "The trusted-header identity names a disabled account.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
           "422": {
             "description": "`search_type` names a mode the engine does not know.",
             "content": {
@@ -1208,7 +1328,7 @@
             }
           },
           "403": {
-            "description": "The caller is not an admin.",
+            "description": "The caller is not an admin, or the trusted-header identity names a disabled account.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1268,7 +1388,7 @@
             }
           },
           "403": {
-            "description": "The caller is not an admin, or a cookie session did not echo its CSRF token.",
+            "description": "The caller is not an admin, a cookie session did not echo its CSRF token, or the trusted-header identity names a disabled account.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1344,7 +1464,7 @@
             }
           },
           "403": {
-            "description": "The caller is not an admin, or a cookie session did not echo its CSRF token.",
+            "description": "The caller is not an admin, a cookie session did not echo its CSRF token, or the trusted-header identity names a disabled account.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1435,7 +1555,7 @@
             }
           },
           "403": {
-            "description": "The caller is not an admin, or a cookie session did not echo its CSRF token.",
+            "description": "The caller is not an admin, a cookie session did not echo its CSRF token, or the trusted-header identity names a disabled account.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1565,6 +1685,16 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "The trusted-header identity names a disabled account.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         }
       }
@@ -1677,6 +1807,14 @@
           "anonymous": {
             "type": "boolean",
             "description": "Whether the request is being served as the anonymous viewer."
+          },
+          "csrf": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The CSRF token of the session this request arrived on, or null when it\narrived on no session.\n\nReissued here, not only by login, because the session cookie is\n`HttpOnly` and the token is not stored anywhere a reload survives: a\nbrowser that refreshes holds a live session whose token it can no longer\nproduce, and would be unable to log out or to write until it logged in\nagain. This probe is what a client opens on, so it is where the token\nbelongs.\n\nNull for the anonymous viewer, which has no session, and null for a\ntrusted-header identity, which has none either: what protects those\nrequests is the shape they are allowed to have, not a token. See the\n`check_csrf` invariant.\n\nHanding the token back on a `GET` is safe for the same reason handing it\nback from login is: no CORS layer exists on this surface, so another\norigin can send the request but cannot read the answer. **That is load\nbearing - a CORS layer must not be added without revisiting this.**",
+            "example": "9f2c1d7e4b6a8035"
           },
           "read_only": {
             "type": "boolean",

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -2606,6 +2606,47 @@ impl Engine {
         Ok(json!({ "domains": out }))
     }
 
+    /// One domain's MANIFEST markdown, read through the same source its routing
+    /// bullets are read through: a file domain's `MANIFEST.md` on disk, a
+    /// virtual domain's MANIFEST engram in the database.
+    ///
+    /// The source, not a reduction of it: a client that renders or edits a
+    /// manifest needs the frontmatter and every section, not the routing
+    /// bullets [`Engine::list_domains`] already extracts. An unregistered domain
+    /// errors with the registered set named, like every other verb; a domain
+    /// that carries no MANIFEST yet is a `NotFound`, since a manifest is what
+    /// routes an agent to a domain at all rather than an optional extra.
+    pub async fn manifest_markdown(&self, domain: &str) -> Result<String> {
+        match self.content_source(domain)? {
+            ContentSource::File { root } => {
+                let path = root.join("MANIFEST.md");
+                match std::fs::read_to_string(&path) {
+                    Ok(source) => Ok(source),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                        Err(EngineError::NotFound(format!(
+                            "domain '{domain}' has no MANIFEST.md at {}",
+                            path.display()
+                        )))
+                    }
+                    Err(source) => Err(EngineError::Io {
+                        path: path.display().to_string(),
+                        source,
+                    }),
+                }
+            }
+            ContentSource::Virtual => {
+                let store = self.store.lock().await;
+                let content = match store.find_engram(domain, "manifest").await? {
+                    Some(d) => store.engram_content(d.domain_id, &d.path).await?,
+                    None => None,
+                };
+                content.ok_or_else(|| {
+                    EngineError::NotFound(format!("domain '{domain}' has no MANIFEST engram yet"))
+                })
+            }
+        }
+    }
+
     /// Routing bullets for one virtual domain, read from its `MANIFEST.md`
     /// engram in the database. Empty when there is no MANIFEST engram yet.
     async fn virtual_routing_bullets_for(&self, name: &str) -> Vec<String> {

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -944,6 +944,22 @@ impl Engine {
 
     // --- domain helpers ------------------------------------------------------
 
+    /// Fail unless `name` is a registered domain, with the same
+    /// [`EngineError::UnknownDomain`] naming the domains that do exist that
+    /// every other verb produces.
+    ///
+    /// This is the check [`Engine::browse_domain`] opens with, exposed for a
+    /// caller whose own verb does not resolve a domain but whose surface still
+    /// has to: the REST engram listing addresses a domain in the path, where a
+    /// name nobody registered is a missing resource rather than a filter that
+    /// selected nothing. Search itself deliberately does not resolve its
+    /// `domains` filter - an unmatched name there is simply a narrower filter -
+    /// and that stays as it is.
+    pub fn require_domain(&self, name: &str) -> Result<()> {
+        self.domain_entry(name)?;
+        Ok(())
+    }
+
     /// Resolve a registered domain to its content source: a filesystem root for
     /// a file domain, or the database for a virtual domain. Errors when the
     /// domain is not registered (the write path wants that), the layered lookup

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -66,6 +66,13 @@ const EMBED_BATCH: usize = 16;
 /// whole-index correct rather than per-chunk.
 const NEIGHBOR_CHUNK: usize = 5_000;
 
+/// The most nodes one [`Engine::graph_neighborhood`] response carries. A graph
+/// view is read by eye, and past a couple of hundred nodes it is a hairball
+/// rather than a picture; the ceiling also keeps a hand-written `max_nodes` from
+/// asking for a whole index in one payload. A cut slice says so through its
+/// `truncated` flag rather than pretending to be whole.
+const MAX_GRAPH_NODES: usize = 150;
+
 /// The default `evolve_engrams` page size. Small on purpose: the queue is meant
 /// to be worked top-down and agreed item by item, not read in bulk.
 const EVOLVE_DEFAULT_LIMIT: usize = 10;
@@ -2540,6 +2547,141 @@ impl Engine {
         }))
     }
 
+    /// The nodes and typed edges around an anchor, for a graph view.
+    ///
+    /// The same traversal [`Engine::build_context`] runs, answered in the flat
+    /// shape a graph renderer wants: every node carries what a client labels and
+    /// styles it with (`id`, `domain`, `permalink`, `title`, `status`, `type`),
+    /// every edge keeps its direction and `rel_type`, and `truncated` says
+    /// whether the cap cut anything. `id` is the index's own engram id, opaque
+    /// to a client and stable only within one response: it is what the edges
+    /// join on, never an address. `crystalline://domain/permalink` is the
+    /// address.
+    ///
+    /// `depth` is clamped to one or two hops and `max_nodes` to at least one and
+    /// at most [`MAX_GRAPH_NODES`], so a hand-written URL can ask neither for
+    /// nothing nor for the whole index in one payload.
+    ///
+    /// Retired engrams come back like any other, with their status, because the
+    /// graph is the shape of what is written rather than of what still holds:
+    /// hiding a superseded node would break the chain that explains what replaced
+    /// it. A client fades them; this does not drop them, and the cap below does
+    /// not demote them either.
+    ///
+    /// When the cap bites, the anchors are kept first and the rest are kept by
+    /// the same spread mass and salience lift `build_context` ranks with, so what
+    /// survives is the neighborhood nearest the anchor rather than whatever the
+    /// index happened to list first.
+    pub async fn graph_neighborhood(
+        &self,
+        anchor: &str,
+        depth: u8,
+        max_nodes: usize,
+    ) -> Result<Value> {
+        let url = CrystallineUrl::parse(anchor).ok_or_else(|| {
+            EngineError::Invalid(format!("anchor '{anchor}' is not a crystalline:// URL"))
+        })?;
+        let depth = depth.clamp(1, 2);
+        let max_nodes = max_nodes.clamp(1, MAX_GRAPH_NODES);
+
+        let store = self.store.lock().await;
+        let seeds: Vec<EngramDescriptor> = if url.glob {
+            store
+                .list_engrams(&url.domain, None, None)
+                .await?
+                .into_iter()
+                .filter(|d| url.matches(&d.domain, &d.permalink))
+                .collect()
+        } else {
+            match store.find_engram(&url.domain, &url.permalink).await? {
+                Some(d) => vec![d],
+                None => {
+                    return Err(EngineError::NotFound(format!(
+                        "no engram '{}' in domain '{}'",
+                        url.permalink, url.domain
+                    )));
+                }
+            }
+        };
+        drop(store);
+        if seeds.is_empty() {
+            return Err(EngineError::NotFound(format!(
+                "anchor '{anchor}' matched no engrams"
+            )));
+        }
+
+        let seed_ids: HashSet<i64> = seeds.iter().map(|d| d.id.0).collect();
+        let ids: Vec<EngramId> = seeds.iter().map(|d| d.id).collect();
+        let slice = self.sweep_neighbors(&ids, depth).await?;
+
+        let mass = context_rank(&slice, &seed_ids);
+        let weight = {
+            let config = self.config.read().unwrap();
+            config.salience_weight().unwrap_or(DEFAULT_SALIENCE_WEIGHT)
+        };
+        let mut anchors: Vec<&GraphNode> = Vec::new();
+        let mut related: Vec<(f64, &GraphNode)> = Vec::new();
+        for node in &slice.nodes {
+            if seed_ids.contains(&node.id.0) {
+                anchors.push(node);
+            } else {
+                let score = mass.get(&node.id.0).copied().unwrap_or(0.0)
+                    * (1.0 + salience_prior(node.salience, weight));
+                related.push((score, node));
+            }
+        }
+        related.sort_by(|a, b| {
+            b.0.partial_cmp(&a.0)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| a.1.id.0.cmp(&b.1.id.0))
+        });
+
+        let total = anchors.len() + related.len();
+        let mut kept: HashSet<i64> = HashSet::new();
+        let mut nodes = Vec::new();
+        for node in anchors
+            .into_iter()
+            .chain(related.into_iter().map(|(_, node)| node))
+            .take(max_nodes)
+        {
+            kept.insert(node.id.0);
+            nodes.push(json!({
+                "id": node.id.0,
+                "domain": node.domain,
+                "permalink": node.permalink,
+                "title": node.title,
+                "status": node.status,
+                "type": node.engram_type,
+            }));
+        }
+        // An edge is only meaningful when both of its ends survived the cap; one
+        // that lost an end would render as an arrow into nothing. The relation
+        // and the prose link between one pair are one edge here, because the
+        // payload states the type rather than the origin: an engram that both
+        // declares `- links_to [[X]]` and writes the wikilink in its prose is
+        // one line on the picture, not two drawn over each other.
+        let mut drawn: HashSet<(i64, i64, &str)> = HashSet::new();
+        let edges: Vec<Value> = slice
+            .edges
+            .iter()
+            .filter(|e| kept.contains(&e.from.0) && kept.contains(&e.to.0))
+            .filter(|e| drawn.insert((e.from.0, e.to.0, e.rel_type.as_str())))
+            .map(|e| {
+                json!({
+                    "from": e.from.0,
+                    "to": e.to.0,
+                    "rel_type": e.rel_type,
+                })
+            })
+            .collect();
+
+        Ok(json!({
+            "nodes": nodes,
+            "edges": edges,
+            "truncated": total > nodes.len(),
+        }))
+    }
+
     // --- recent --------------------------------------------------------------
 
     /// Recent engrams within a timeframe.
@@ -3260,22 +3402,35 @@ impl Engine {
 
     /// The resolved graph around a whole domain, at depth 1 so every
     /// cross-domain target carries a status.
-    ///
-    /// The seed list is chunked because both backends inline it into an SQL
-    /// `IN (...)`. Every edge incident on a seed has its other end inside that
-    /// chunk's slice, so merging the slices yields exactly the whole-index edge
-    /// set for the domain. Nodes and edges are deduped on the merge: a node
-    /// reached from two chunks, and an edge whose two ends sit in different
-    /// chunks, both come back more than once, and a double-counted edge would
-    /// inflate the degrees the ranking and the orphan rule read.
     async fn sweep_graph(&self, descs: &[EngramDescriptor]) -> Result<GraphSlice> {
         let ids: Vec<EngramId> = descs.iter().map(|d| d.id).collect();
+        self.sweep_neighbors(&ids, 1).await
+    }
+
+    /// [`Store::neighbors`] over a seed list of any size, merged into one slice.
+    ///
+    /// The seed list is chunked because both backends inline it into an SQL
+    /// `IN (...)`, so a whole domain in one call would build a statement
+    /// proportional to its size. Merging is exact rather than approximate at
+    /// every depth the callers use: the traversal collects an edge whenever one
+    /// of its ends lies within `depth - 1` hops of a seed, and a node whenever it
+    /// lies within `depth` hops, and hop distance from the whole seed set is the
+    /// smallest hop distance from any one chunk. The union over the chunks is
+    /// therefore exactly what one unchunked call would have returned.
+    ///
+    /// Nodes and edges are deduped on the merge: a node reached from two chunks,
+    /// and an edge whose two ends sit in different chunks, both come back more
+    /// than once, and a double-counted edge would inflate the degrees the
+    /// consolidation ranking and the orphan rule read. The merged nodes are
+    /// sorted by id, so a chunked sweep answers in the same ascending order a
+    /// single-chunk one does and every caller's ordering holds either way.
+    async fn sweep_neighbors(&self, ids: &[EngramId], depth: u8) -> Result<GraphSlice> {
         let mut graph = GraphSlice::default();
         let mut seen_nodes: HashSet<i64> = HashSet::new();
         let mut seen_edges: HashSet<(i64, i64, String, u8)> = HashSet::new();
         for chunk in ids.chunks(NEIGHBOR_CHUNK) {
             let store = self.store.lock().await;
-            let slice = store.neighbors(chunk, 1).await?;
+            let slice = store.neighbors(chunk, depth).await?;
             drop(store);
             for node in slice.nodes {
                 if seen_nodes.insert(node.id.0) {
@@ -3292,6 +3447,7 @@ impl Engine {
                 }
             }
         }
+        graph.nodes.sort_by_key(|n| n.id.0);
         Ok(graph)
     }
 

--- a/crates/service/src/rest/auth.rs
+++ b/crates/service/src/rest/auth.rs
@@ -35,11 +35,10 @@ use axum::middleware::Next;
 use axum::response::Response;
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use crystalline_core::config::GlobalConfig;
-use serde_json::Value;
 use tokio::sync::Semaphore;
 
 use super::auth_store::{AuthStore, PasswordCheck, Role, User, dummy_verify};
-use super::{ApiError, ApiJson, RestState};
+use super::{ApiError, ApiJson, ProblemDetail, RestState};
 
 /// The session cookie. Named for the UI it serves so it never collides with a
 /// cookie another app sets on a shared host.
@@ -340,12 +339,56 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 }
 
 /// What `POST /auth/login` takes.
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, utoipa::ToSchema)]
 pub struct LoginBody {
     /// The account name, in any casing: the store folds it.
+    #[schema(example = "ada")]
     name: String,
     /// The password, checked with argon2id.
+    #[schema(example = "correct horse battery staple")]
     password: String,
+}
+
+/// What `POST /auth/login` answers with.
+///
+/// A type rather than an inline `json!`, so the OpenAPI document and the
+/// response are one definition. Same for the two below it.
+#[derive(serde::Serialize, utoipa::ToSchema)]
+pub struct LoginResponse {
+    /// The account that was signed in.
+    user: User,
+    /// The session's CSRF token, which every later mutating request must echo
+    /// in the `x-csrf-token` header (see `CSRF_HEADER`).
+    ///
+    /// The header is named in plain backticks rather than through an intra-doc
+    /// link because utoipa copies this comment into the published document,
+    /// where a Rust link target reads as noise. Same wherever else a schema
+    /// field's comment names something in this crate.
+    #[schema(example = "9f2c1d7e4b6a8035")]
+    csrf: String,
+}
+
+/// What `POST /auth/logout` answers with: an acknowledgement and nothing else,
+/// since a logout that found no session is a success too.
+#[derive(serde::Serialize, utoipa::ToSchema)]
+pub struct LogoutResponse {
+    /// Always true.
+    ok: bool,
+}
+
+/// What `GET /auth/me` answers with: everything a client needs before it draws
+/// anything.
+#[derive(serde::Serialize, utoipa::ToSchema)]
+pub struct MeResponse {
+    /// The account behind this request, or null when there is none.
+    user: Option<User>,
+    /// Whether the request is being served as the anonymous viewer.
+    anonymous: bool,
+    /// Whether this instance refuses content mutations.
+    read_only: bool,
+    /// The server version, so a mismatched UI can say so.
+    #[schema(example = "0.12.0")]
+    version: &'static str,
 }
 
 /// Exchange credentials for a session: sets [`SESSION_COOKIE`] and returns the
@@ -355,12 +398,63 @@ pub struct LoginBody {
 /// malformed one is refused in problem+json like every other failure here: this
 /// is the first request a client ever sends, and the worst moment to hand it an
 /// error shape it has no parser for.
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/login",
+    tag = "auth",
+    operation_id = "login",
+    // Spelled out rather than taken from the rustdoc above, which is written
+    // for a Rust reader and carries intra-doc links that read as noise in a
+    // published document. Same on the five other handlers whose rustdoc links.
+    summary = "Exchange credentials for a session.",
+    description = "Sets the `fluid_session` cookie and returns the account plus \
+                   the CSRF token every later mutating request must echo in \
+                   `x-csrf-token`. Any session the request arrived holding is \
+                   revoked first, so a planted token cannot survive a login.",
+    request_body = LoginBody,
+    responses(
+        (
+            status = 200,
+            description = "Signed in. The session cookie is set and the CSRF \
+                           token is in the body.",
+            body = LoginResponse,
+            headers(("set-cookie" = String, description = "The `fluid_session` \
+                     session cookie, HttpOnly and SameSite=Lax.")),
+        ),
+        (
+            status = 400,
+            description = "The body is not JSON.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 401,
+            description = "The name or password is wrong. One message for every \
+                           way this can fail, so nothing is learned about which \
+                           accounts exist.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 415,
+            description = "The body is not `application/json`.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 422,
+            description = "The body is JSON but not a login.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn login(
     State(state): State<RestState>,
     jar: CookieJar,
     headers: HeaderMap,
     ApiJson(body): ApiJson<LoginBody>,
-) -> Result<(CookieJar, axum::Json<Value>), ApiError> {
+) -> Result<(CookieJar, axum::Json<LoginResponse>), ApiError> {
     let Some(user) =
         authenticate(&state.auth, &state.login_slots, &body.name, &body.password).await?
     else {
@@ -388,7 +482,10 @@ pub async fn login(
         .build();
     Ok((
         jar.add(cookie),
-        axum::Json(serde_json::json!({ "user": user, "csrf": session.csrf })),
+        axum::Json(LoginResponse {
+            user,
+            csrf: session.csrf,
+        }),
     ))
 }
 
@@ -456,20 +553,39 @@ pub(super) async fn with_login_slot<F: Future>(
 /// logging out twice, or with a cookie this server has already forgotten, is
 /// ordinary. Guarded by the CSRF check like any other mutating request, so
 /// another origin cannot log a user out.
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/logout",
+    tag = "auth",
+    operation_id = "logout",
+    responses(
+        (
+            status = 200,
+            description = "Signed out, whether or not there was a session to \
+                           revoke.",
+            body = LogoutResponse,
+            headers(("set-cookie" = String, description = "Clears the \
+                     `fluid_session` cookie.")),
+        ),
+        (
+            status = 403,
+            description = "A cookie session did not echo its CSRF token.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn logout(
     State(state): State<RestState>,
     jar: CookieJar,
-) -> Result<(CookieJar, axum::Json<Value>), ApiError> {
+) -> Result<(CookieJar, axum::Json<LogoutResponse>), ApiError> {
     if let Some(cookie) = jar.get(SESSION_COOKIE) {
         state.auth.delete_session(cookie.value()).await?;
     }
     // The removal has to carry the same path the cookie was set with, or the
     // browser keeps the original and only shadows it.
     let removal = Cookie::build(SESSION_COOKIE).path("/").build();
-    Ok((
-        jar.remove(removal),
-        axum::Json(serde_json::json!({ "ok": true })),
-    ))
+    Ok((jar.remove(removal), axum::Json(LogoutResponse { ok: true })))
 }
 
 /// The capability probe a client calls before anything else: who it is, whether
@@ -480,13 +596,26 @@ pub async fn logout(
 /// Answers without an identity on purpose. `user: null, anonymous: false` is
 /// what tells a browser to show a login form; `anonymous: true` tells it to
 /// browse instead.
-pub async fn me(State(state): State<RestState>, identity: Identity) -> axum::Json<Value> {
-    axum::Json(serde_json::json!({
-        "user": identity.user,
-        "anonymous": identity.anonymous,
-        "read_only": state.engine.read_only(),
-        "version": crystalline_core::VERSION,
-    }))
+#[utoipa::path(
+    get,
+    path = "/api/v1/auth/me",
+    tag = "auth",
+    operation_id = "get_me",
+    responses((
+        status = 200,
+        description = "Who the caller is and what this instance allows. Answered \
+                       without an identity too, which is how a client learns it \
+                       has to log in.",
+        body = MeResponse,
+    )),
+)]
+pub async fn me(State(state): State<RestState>, identity: Identity) -> axum::Json<MeResponse> {
+    axum::Json(MeResponse {
+        user: identity.user,
+        anonymous: identity.anonymous,
+        read_only: state.engine.read_only(),
+        version: crystalline_core::VERSION,
+    })
 }
 
 /// Whether the session cookie is marked `Secure`, which is to say: is there any

--- a/crates/service/src/rest/auth.rs
+++ b/crates/service/src/rest/auth.rs
@@ -277,6 +277,23 @@ async fn resolve(state: &RestState, headers: &HeaderMap) -> Result<Identity, Api
 /// have no token to compare against, and for the trusted header the proxy that
 /// injects the identity owns that boundary. Login is exempt because it is what
 /// mints the token.
+///
+/// Passing the tokenless identities through is a deliberate invariant rather
+/// than an accident, and the mutating routes lean on it:
+///
+/// - The anonymous viewer is a viewer and nothing else, so it never reaches a
+///   route that changes anything - `require_admin` answers it 401 first.
+/// - A trusted-header caller can be an admin, and its request carries a header
+///   a browser attaches on its own for any origin. What keeps a cross-site
+///   request off those routes is the shape it is allowed to have instead:
+///   `PATCH` and `DELETE` are not simple methods, so another origin cannot send
+///   them without a CORS preflight, and the `POST` it can send is refused by
+///   [`ApiJson`], which demands `application/json` while a cross-site form can
+///   only send `application/x-www-form-urlencoded`, `text/plain` or
+///   `multipart/form-data`. **No CORS layer exists on this surface and one must
+///   not be added without revisiting this check**: allowing a cross-origin
+///   preflight would remove the only thing standing between another origin and
+///   a trusted-header admin's account.
 fn check_csrf(identity: &Identity, req: &Request) -> Result<(), ApiError> {
     if req.method().is_safe() || req.uri().path() == LOGIN_PATH {
         return Ok(());

--- a/crates/service/src/rest/auth.rs
+++ b/crates/service/src/rest/auth.rs
@@ -39,7 +39,7 @@ use serde_json::Value;
 use tokio::sync::Semaphore;
 
 use super::auth_store::{AuthStore, PasswordCheck, Role, User, dummy_verify};
-use super::{ApiError, RestState};
+use super::{ApiError, ApiJson, RestState};
 
 /// The session cookie. Named for the UI it serves so it never collides with a
 /// cookie another app sets on a shared host.
@@ -333,11 +333,16 @@ pub struct LoginBody {
 
 /// Exchange credentials for a session: sets [`SESSION_COOKIE`] and returns the
 /// account plus the CSRF token every later mutating request must echo.
+///
+/// The body comes in through [`ApiJson`] rather than `axum::Json` so a
+/// malformed one is refused in problem+json like every other failure here: this
+/// is the first request a client ever sends, and the worst moment to hand it an
+/// error shape it has no parser for.
 pub async fn login(
     State(state): State<RestState>,
     jar: CookieJar,
     headers: HeaderMap,
-    axum::Json(body): axum::Json<LoginBody>,
+    ApiJson(body): ApiJson<LoginBody>,
 ) -> Result<(CookieJar, axum::Json<Value>), ApiError> {
     let Some(user) =
         authenticate(&state.auth, &state.login_slots, &body.name, &body.password).await?

--- a/crates/service/src/rest/auth.rs
+++ b/crates/service/src/rest/auth.rs
@@ -434,8 +434,18 @@ async fn authenticate(
 }
 
 /// Run `work` holding one of the [`LOGIN_SLOTS`] password-checking permits, so
-/// concurrent logins queue instead of each reserving argon2's memory at once.
-async fn with_login_slot<F: Future>(slots: &Semaphore, work: F) -> Result<F::Output, ApiError> {
+/// concurrent argon2 work queues instead of each reserving its memory at once.
+///
+/// Every path on this surface that hashes or verifies a password goes through
+/// here, not only login: an admin creating accounts or resetting passwords
+/// (see `super::users_api`) spends the same 19 MiB per operation on the same
+/// blocking pool, so a second, unbounded, source of it would defeat the cap
+/// rather than sit beside it. [`RestState::with_login_slot`] is how a handler
+/// outside this module reaches it.
+pub(super) async fn with_login_slot<F: Future>(
+    slots: &Semaphore,
+    work: F,
+) -> Result<F::Output, ApiError> {
     let _permit = slots.acquire().await.map_err(|_| {
         ApiError::internal("the login limiter is closed, so this instance is shutting down")
     })?;

--- a/crates/service/src/rest/auth.rs
+++ b/crates/service/src/rest/auth.rs
@@ -382,6 +382,27 @@ pub struct LogoutResponse {
 pub struct MeResponse {
     /// The account behind this request, or null when there is none.
     user: Option<User>,
+    /// The CSRF token of the session this request arrived on, or null when it
+    /// arrived on no session.
+    ///
+    /// Reissued here, not only by login, because the session cookie is
+    /// `HttpOnly` and the token is not stored anywhere a reload survives: a
+    /// browser that refreshes holds a live session whose token it can no longer
+    /// produce, and would be unable to log out or to write until it logged in
+    /// again. This probe is what a client opens on, so it is where the token
+    /// belongs.
+    ///
+    /// Null for the anonymous viewer, which has no session, and null for a
+    /// trusted-header identity, which has none either: what protects those
+    /// requests is the shape they are allowed to have, not a token. See the
+    /// `check_csrf` invariant.
+    ///
+    /// Handing the token back on a `GET` is safe for the same reason handing it
+    /// back from login is: no CORS layer exists on this surface, so another
+    /// origin can send the request but cannot read the answer. **That is load
+    /// bearing - a CORS layer must not be added without revisiting this.**
+    #[schema(example = "9f2c1d7e4b6a8035")]
+    csrf: Option<String>,
     /// Whether the request is being served as the anonymous viewer.
     anonymous: bool,
     /// Whether this instance refuses content mutations.
@@ -432,6 +453,12 @@ pub struct MeResponse {
             description = "The name or password is wrong. One message for every \
                            way this can fail, so nothing is learned about which \
                            accounts exist.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 403,
+            description = "The trusted-header identity names a disabled account.",
             body = ProblemDetail,
             content_type = "application/problem+json",
         ),
@@ -569,7 +596,9 @@ pub(super) async fn with_login_slot<F: Future>(
         ),
         (
             status = 403,
-            description = "A cookie session did not echo its CSRF token.",
+            description = "A cookie session did not echo its CSRF token, or \
+                           the trusted-header identity names a disabled \
+                           account.",
             body = ProblemDetail,
             content_type = "application/problem+json",
         ),
@@ -596,22 +625,37 @@ pub async fn logout(
 /// Answers without an identity on purpose. `user: null, anonymous: false` is
 /// what tells a browser to show a login form; `anonymous: true` tells it to
 /// browse instead.
+///
+/// It also reissues the session's CSRF token, which is the only way a reloaded
+/// browser gets it back: see `MeResponse::csrf`.
 #[utoipa::path(
     get,
     path = "/api/v1/auth/me",
     tag = "auth",
     operation_id = "get_me",
-    responses((
-        status = 200,
-        description = "Who the caller is and what this instance allows. Answered \
-                       without an identity too, which is how a client learns it \
-                       has to log in.",
-        body = MeResponse,
-    )),
+    responses(
+        (
+            status = 200,
+            description = "Who the caller is and what this instance allows. \
+                           Answered without an identity too, which is how a \
+                           client learns it has to log in.",
+            body = MeResponse,
+        ),
+        (
+            status = 403,
+            description = "The trusted-header identity names a disabled account. \
+                           The guard resolves identity ahead of routing, so this \
+                           answer reaches even the paths that are served without \
+                           one.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
 )]
 pub async fn me(State(state): State<RestState>, identity: Identity) -> axum::Json<MeResponse> {
     axum::Json(MeResponse {
         user: identity.user,
+        csrf: identity.csrf,
         anonymous: identity.anonymous,
         read_only: state.engine.read_only(),
         version: crystalline_core::VERSION,

--- a/crates/service/src/rest/auth_store.rs
+++ b/crates/service/src/rest/auth_store.rs
@@ -398,16 +398,42 @@ impl AuthStore {
         }
     }
 
-    /// Replace an account's password. Errors if the account does not exist, so
-    /// a mistyped name on the CLI is reported rather than silently ignored.
+    /// Replace an account's password and revoke every session it holds. Errors
+    /// if the account does not exist, so a mistyped name on the CLI is reported
+    /// rather than silently ignored.
+    ///
+    /// The revocation is the point rather than a courtesy. A password is reset
+    /// because the old one is no longer trusted, and a session issued under it
+    /// never presents a password again: without this, whoever holds a cookie
+    /// minted before the reset keeps the account for the rest of the session's
+    /// life, which is exactly the person a reset is meant to evict. Both
+    /// statements are one `BEGIN IMMEDIATE` transaction, so no session from
+    /// before the change can survive it, and a refused change (an account that
+    /// is not there) revokes nothing.
     pub async fn set_password(&self, name: &str, password: &str) -> Result<()> {
+        let name = normalize_name(name)?;
+        // Hash before taking the lock: argon2 is CPU, not database.
         let hash = hash_password(password).await?;
-        self.update_user(
-            "UPDATE users SET pass_hash = ?2 WHERE name = ?1",
-            name,
-            Value::Text(hash),
-        )
-        .await
+        let _guard = self.guard.lock().await;
+        self.begin_immediate()
+            .await
+            .with_context(|| format!("updating user '{name}'"))?;
+        let result = async {
+            let changed = self
+                .conn
+                .execute(
+                    "UPDATE users SET pass_hash = ?2 WHERE name = ?1",
+                    vec![Value::Text(name.clone()), Value::Text(hash)],
+                )
+                .await
+                .with_context(|| format!("updating user '{name}'"))?;
+            if changed == 0 {
+                bail!("no such user: '{name}'");
+            }
+            self.delete_sessions_of(&name).await
+        }
+        .await;
+        self.finish(result).await
     }
 
     /// Change an account's role. Demoting the last enabled admin is refused
@@ -425,22 +451,64 @@ impl AuthStore {
         .await
     }
 
-    /// Disable or re-enable an account. Disabling leaves existing sessions in
-    /// place but [`AuthStore::session_user`] stops honoring them, so the effect
-    /// is immediate without having to hunt the session rows down.
+    /// Disable or re-enable an account. Disabling deletes every session it
+    /// holds, in the same transaction as the flag.
+    ///
+    /// [`AuthStore::session_user`] also refuses a disabled account's sessions
+    /// at read time, and that check stays: it is what makes the effect
+    /// immediate for a session another process is already holding open. It is
+    /// not enough on its own, though, because it only hides the rows while the
+    /// flag is set - re-enabling the account would hand every cookie from
+    /// before the disabling back. Deleting them means disabling is a
+    /// revocation, which is what an operator disabling a compromised account
+    /// is asking for, and re-enabling starts from no sessions at all.
     ///
     /// Disabling the last enabled admin is refused (see [`NOT_LAST_ADMIN`]);
-    /// re-enabling never is, so the `?2 = 0` arm short-circuits the guard.
+    /// re-enabling never is, so the `?2 = 0` arm short-circuits the guard. A
+    /// refused disabling rolls back, sessions included.
     pub async fn set_disabled(&self, name: &str, disabled: bool) -> Result<()> {
-        self.update_guarded(
-            &format!(
-                "UPDATE users SET disabled = ?2 WHERE name = ?1 AND (?2 = 0 OR {NOT_LAST_ADMIN})"
-            ),
-            name,
-            Value::Integer(i64::from(disabled)),
-            "disable",
-        )
-        .await
+        let name = normalize_name(name)?;
+        let _guard = self.guard.lock().await;
+        self.begin_immediate()
+            .await
+            .with_context(|| format!("updating user '{name}'"))?;
+        let result = async {
+            let changed = self
+                .conn
+                .execute(
+                    &format!(
+                        "UPDATE users SET disabled = ?2 \
+                         WHERE name = ?1 AND (?2 = 0 OR {NOT_LAST_ADMIN})"
+                    ),
+                    vec![
+                        Value::Text(name.clone()),
+                        Value::Integer(i64::from(disabled)),
+                    ],
+                )
+                .await
+                .with_context(|| format!("updating user '{name}'"))?;
+            if changed == 0 {
+                // Zero rows means the account is not there, or that disabling
+                // it would have left no enabled admin. The probe is inside the
+                // transaction, so it sees exactly what the update saw.
+                let exists = self
+                    .query_first(
+                        "SELECT 1 FROM users WHERE name = ?1",
+                        vec![Value::Text(name.clone())],
+                    )
+                    .await?;
+                if exists.is_some() {
+                    return Err(last_admin_error("disable", &name));
+                }
+                bail!("no such user: '{name}'");
+            }
+            if disabled {
+                self.delete_sessions_of(&name).await?;
+            }
+            Ok(())
+        }
+        .await;
+        self.finish(result).await
     }
 
     /// Delete an account and every session it holds. Errors if there is no
@@ -473,10 +541,7 @@ impl AuthStore {
             .await
             .with_context(|| format!("removing user '{name}'"))?;
         let result = async {
-            self.conn
-                .execute("DELETE FROM sessions WHERE user_name = ?1", key.clone())
-                .await
-                .with_context(|| format!("removing sessions for user '{name}'"))?;
+            self.delete_sessions_of(&name).await?;
             let changed = self
                 .conn
                 .execute(
@@ -674,26 +739,28 @@ impl AuthStore {
         Ok(())
     }
 
-    /// Run a single-column update against one account, failing when the
-    /// account does not exist.
-    async fn update_user(&self, sql: &str, name: &str, value: Value) -> Result<()> {
-        let name = normalize_name(name)?;
-        let _guard = self.guard.lock().await;
-        let changed = self
-            .conn
-            .execute(sql, vec![Value::Text(name.clone()), value])
+    /// Delete every session `name` holds. `name` must already be normalized.
+    ///
+    /// Called by the three operations that end an account's right to the
+    /// sessions it was issued - a removal, a password change and a disabling -
+    /// each of which calls it while holding the guard and inside its own
+    /// transaction, so the revocation lands with the change or not at all.
+    async fn delete_sessions_of(&self, name: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "DELETE FROM sessions WHERE user_name = ?1",
+                vec![Value::Text(name.to_string())],
+            )
             .await
-            .with_context(|| format!("updating user '{name}'"))?;
-        if changed == 0 {
-            bail!("no such user: '{name}'");
-        }
+            .with_context(|| format!("removing sessions for user '{name}'"))?;
         Ok(())
     }
 
-    /// [`AuthStore::update_user`] for a statement carrying the
-    /// [`NOT_LAST_ADMIN`] guard, where zero rows changed has a second possible
-    /// meaning: the edit was refused because it would have left no enabled
-    /// admin. `verb` names the refused operation in that message.
+    /// Run a single-column update against one account, failing when the account
+    /// does not exist, for a statement carrying the [`NOT_LAST_ADMIN`] guard:
+    /// zero rows changed then has a second possible meaning, that the edit was
+    /// refused because it would have left no enabled admin. `verb` names the
+    /// refused operation in that message.
     ///
     /// The follow-up existence probe only picks between the two messages -
     /// nothing was written either way - so it does not need to share the
@@ -1010,6 +1077,80 @@ mod tests {
         assert!(store.session_user(&s.token).await.unwrap().is_none());
     }
 
+    /// Disabling is a revocation, not a flag over the session rows: re-enabling
+    /// the account must not hand back the cookies it held before. Otherwise
+    /// disabling a compromised account and enabling it again once the password
+    /// was changed would restore the intruder's session.
+    #[tokio::test]
+    async fn re_enabling_does_not_resurrect_the_sessions_disabling_took() {
+        let (_dir, store) = store().await;
+        store
+            .add_user("ada", "Ada", None, Role::Editor, "pw")
+            .await
+            .unwrap();
+        let s = store.create_session("ada", 3600).await.unwrap();
+        store.set_disabled("ada", true).await.unwrap();
+        store.set_disabled("ada", false).await.unwrap();
+        assert!(
+            store.session_user(&s.token).await.unwrap().is_none(),
+            "the session was deleted, not merely hidden while the flag was set"
+        );
+        // The account itself is back, and a fresh session works.
+        let fresh = store.create_session("ada", 3600).await.unwrap();
+        assert!(store.session_user(&fresh.token).await.unwrap().is_some());
+    }
+
+    /// A password reset evicts whoever was signed in under the old one: a
+    /// session never presents a password again, so without this the holder of a
+    /// cookie minted before the reset keeps the account.
+    #[tokio::test]
+    async fn changing_a_password_revokes_the_sessions_it_issued() {
+        let (_dir, store) = store().await;
+        store
+            .add_user("ada", "Ada", None, Role::Editor, "pw")
+            .await
+            .unwrap();
+        let before = store.create_session("ada", 3600).await.unwrap();
+        store.set_password("ada", "new pw").await.unwrap();
+        assert!(
+            store.session_user(&before.token).await.unwrap().is_none(),
+            "the cookie from before the reset is dead"
+        );
+        assert!(
+            store
+                .verify_password("ada", "new pw")
+                .await
+                .unwrap()
+                .is_some(),
+            "and the new password logs in"
+        );
+        let after = store.create_session("ada", 3600).await.unwrap();
+        assert!(store.session_user(&after.token).await.unwrap().is_some());
+    }
+
+    /// A refused edit revokes nothing: the transaction rolls back with the
+    /// sessions in it, the same property `a_refused_removal_keeps_the_admins_sessions`
+    /// pins for a removal.
+    #[tokio::test]
+    async fn a_refused_edit_leaves_the_sessions_alone() {
+        let (_dir, store) = store().await;
+        store
+            .add_user("ada", "Ada", None, Role::Admin, "pw")
+            .await
+            .unwrap();
+        let live = store.create_session("ada", 3600).await.unwrap();
+        assert!(
+            store.set_disabled("ada", true).await.is_err(),
+            "the last enabled admin cannot be disabled"
+        );
+        assert!(
+            store.session_user(&live.token).await.unwrap().is_some(),
+            "the rolled-back disabling must leave the live session in place"
+        );
+        assert!(store.set_password("ghost", "new pw").await.is_err());
+        assert!(store.session_user(&live.token).await.unwrap().is_some());
+    }
+
     #[tokio::test]
     async fn the_plaintext_token_is_not_in_the_database() {
         let dir = tempfile::tempdir().unwrap();
@@ -1160,7 +1301,8 @@ mod tests {
         let second = daemon.create_session("ada", 3600).await.unwrap();
         assert!(cli.session_user(&second.token).await.unwrap().is_some());
 
-        // The CLI disables; the daemon stops honoring the live session.
+        // The CLI disables, which revokes; the daemon no longer resolves the
+        // session the CLI's write deleted.
         cli.set_disabled("ada", true).await.unwrap();
         assert!(daemon.session_user(&session.token).await.unwrap().is_none());
 

--- a/crates/service/src/rest/auth_store.rs
+++ b/crates/service/src/rest/auth_store.rs
@@ -58,7 +58,7 @@ use turso::{Builder, Connection, Database, Row, Value};
 
 /// What a user may do. Ordered least to most privileged; the REST layer maps
 /// each endpoint to the minimum role it accepts.
-#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
     /// Read only: search, read, browse.
@@ -132,14 +132,17 @@ fn normalize_name(name: &str) -> Result<String> {
 
 /// One account. Carries no password material, so it is safe to hand to a
 /// handler and serialize into a response.
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize, utoipa::ToSchema)]
 pub struct User {
     /// The login name and primary key. Also the identity the trusted-header
     /// mode provisions against.
+    #[schema(example = "ada")]
     pub name: String,
     /// Human-readable name for the UI.
+    #[schema(example = "Ada Lovelace")]
     pub display: String,
     /// Optional contact address; never used for login.
+    #[schema(example = "ada@example.com")]
     pub email: Option<String>,
     /// What this account may do.
     pub role: Role,

--- a/crates/service/src/rest/discovery.rs
+++ b/crates/service/src/rest/discovery.rs
@@ -134,6 +134,12 @@ pub struct SearchQuery {
             content_type = "application/problem+json",
         ),
         (
+            status = 403,
+            description = "The trusted-header identity names a disabled account.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
             status = 422,
             description = "`search_type` names a mode the engine does not know.",
             body = ProblemDetail,
@@ -212,6 +218,12 @@ pub struct VocabularyQuery {
         (
             status = 401,
             description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 403,
+            description = "The trusted-header identity names a disabled account.",
             body = ProblemDetail,
             content_type = "application/problem+json",
         ),
@@ -319,6 +331,12 @@ pub struct ContextQuery {
             content_type = "application/problem+json",
         ),
         (
+            status = 403,
+            description = "The trusted-header identity names a disabled account.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
             status = 404,
             description = "The anchor names no engram.",
             body = ProblemDetail,
@@ -408,6 +426,12 @@ pub struct ActivityQuery {
         (
             status = 401,
             description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 403,
+            description = "The trusted-header identity names a disabled account.",
             body = ProblemDetail,
             content_type = "application/problem+json",
         ),

--- a/crates/service/src/rest/discovery.rs
+++ b/crates/service/src/rest/discovery.rs
@@ -1,0 +1,211 @@
+//! The four ways a client finds its way around what an instance knows: search
+//! across the domains, the vocabulary they are written in, the graph around one
+//! engram, and what was recorded lately.
+//!
+//! Each one is the engine verb the matching MCP tool calls, behind a query
+//! string that maps onto its parameter struct one for one, and each hands the
+//! engine's own JSON back unchanged so the two surfaces answer with one payload
+//! rather than two shapes that drift.
+//!
+//! A domain named in a query string here is a *filter*, never a resource: an
+//! unmatched name narrows the answer to nothing and is answered 200, which is
+//! what separates these routes from the ones that carry a domain in a path
+//! segment and 404 when nobody registered it. Filtering to nothing and pointing
+//! at nothing are different facts, and a client can tell them apart by which
+//! shape of URL it asked with.
+
+use axum::Json;
+use axum::extract::State;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::{ApiError, ApiQuery, RestState, csv};
+use crate::params::{ContextParams, RecentParams, SearchParams, VocabularyParams};
+
+/// The query string `GET /search` takes, mirroring [`SearchParams`]. The free
+/// text is `q` rather than `query`, the spelling a browser client's address bar
+/// and every other search API already use; the rest keep the engine's names.
+#[derive(Debug, Deserialize)]
+pub struct SearchQuery {
+    /// The free-text query. Omit for a filter-only search.
+    #[serde(default)]
+    q: Option<String>,
+    /// Restrict to these domains, comma separated. Defaults to every registered
+    /// domain.
+    #[serde(default)]
+    domains: Option<String>,
+    /// Filter by `type`.
+    #[serde(rename = "type", default)]
+    engram_type: Option<String>,
+    /// Filter by `status`.
+    #[serde(default)]
+    status: Option<String>,
+    /// Require all of these tags, comma separated.
+    #[serde(default)]
+    tags: Option<String>,
+    /// Only engrams recorded on or after this ISO date.
+    #[serde(default)]
+    after: Option<String>,
+    /// hybrid (default), text, semantic, title or permalink.
+    #[serde(default)]
+    search_type: Option<String>,
+    /// Minimum cosine similarity for a semantic hit.
+    #[serde(default)]
+    min_similarity: Option<f32>,
+    /// One-based page number. Defaults to 1.
+    #[serde(default)]
+    page: Option<usize>,
+    /// Page size. Defaults to 10.
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+/// `GET /search` - search across the registered domains, or across the ones
+/// `domains` names.
+///
+/// The answer is the engine's page envelope (`mode`, `total`, `page`, `limit`,
+/// `count`, `hits`), so a client pages a search the way it pages a listing.
+/// `mode` is the mode that actually ran rather than the one asked for: hybrid
+/// and semantic fall back to text where there is nothing embedded to search, and
+/// the response says which happened rather than quietly answering from a
+/// different index than the caller expected.
+///
+/// A `search_type` the engine does not know is its own error, surfaced as a 422
+/// problem detail carrying the engine's message, so the caller learns which
+/// values do work instead of being handed a bare status.
+///
+/// `metadata_filters` is not exposed: it takes a JSON object of comparisons,
+/// which has no honest query-string spelling, and no client needs it yet.
+pub async fn search(
+    State(state): State<RestState>,
+    ApiQuery(query): ApiQuery<SearchQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let value = state
+        .engine
+        .search_engrams(&SearchParams {
+            query: query.q,
+            domains: csv(query.domains.as_deref()),
+            engram_type: query.engram_type,
+            tags: csv(query.tags.as_deref()),
+            status: query.status,
+            metadata_filters: None,
+            after: query.after,
+            search_type: query.search_type,
+            min_similarity: query.min_similarity,
+            limit: query.limit,
+            page: query.page,
+        })
+        .await?;
+    Ok(Json(value))
+}
+
+/// The query string `GET /vocabulary` takes, mirroring [`VocabularyParams`].
+#[derive(Debug, Deserialize)]
+pub struct VocabularyQuery {
+    /// Restrict to one domain. Omit for a vocabulary across every domain.
+    #[serde(default)]
+    domain: Option<String>,
+}
+
+/// `GET /vocabulary` - the words the domains are written in: the tags in use
+/// with their counts, the observation categories and the relation types, plus
+/// the near-duplicate clusters and tag aliases the engine reports when there are
+/// any.
+///
+/// The domain is a filter here rather than a path segment, so an unknown name
+/// answers an empty vocabulary rather than a 404: this route asks what is in
+/// use, and the answer to that can legitimately be nothing.
+pub async fn vocabulary(
+    State(state): State<RestState>,
+    ApiQuery(query): ApiQuery<VocabularyQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let value = state
+        .engine
+        .vocabulary(&VocabularyParams {
+            domain: query.domain,
+        })
+        .await?;
+    Ok(Json(value))
+}
+
+/// The query string `GET /context` takes, mirroring [`ContextParams`]. `anchor`
+/// has no default: a traversal with nothing to start from is not a request this
+/// route can answer, so a missing one is rejected by the extractor as a 400
+/// rather than guessed at.
+#[derive(Debug, Deserialize)]
+pub struct ContextQuery {
+    /// A `crystalline://domain/permalink` anchor. A `/*` suffix globs a prefix.
+    anchor: String,
+    /// Traversal depth, 1 to 3. Defaults to 1.
+    #[serde(default)]
+    depth: Option<u8>,
+    /// Restrict the returned neighborhood to these domains, comma separated.
+    #[serde(default)]
+    domains: Option<String>,
+    /// Maximum related engrams beyond the anchors. Defaults to 10.
+    #[serde(default)]
+    max_related: Option<usize>,
+}
+
+/// `GET /context` - the graph around an anchor: the anchored engrams as seed
+/// nodes, the neighborhood ranked out from them, and the edges that connect what
+/// came back. This is what a client draws a relationship view from.
+///
+/// The three ways an anchor can be wrong stay distinguishable: absent is a 400
+/// from the extractor, one that is not a `crystalline://` URL is the engine's
+/// own 422, and one pointing at an engram nobody wrote is a 404.
+///
+/// `timeframe` is not exposed: the engine documents it as advisory in this
+/// version, and a parameter that does not change the answer is not worth a
+/// client learning.
+pub async fn context(
+    State(state): State<RestState>,
+    ApiQuery(query): ApiQuery<ContextQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let value = state
+        .engine
+        .build_context(&ContextParams {
+            anchor: query.anchor,
+            depth: query.depth,
+            domains: csv(query.domains.as_deref()),
+            timeframe: None,
+            max_related: query.max_related,
+        })
+        .await?;
+    Ok(Json(value))
+}
+
+/// The query string `GET /activity` takes, mirroring [`RecentParams`].
+#[derive(Debug, Deserialize)]
+pub struct ActivityQuery {
+    /// Restrict to these domains, comma separated. Defaults to every registered
+    /// domain.
+    #[serde(default)]
+    domains: Option<String>,
+    /// A recency window such as `7d`, `24h` or `2w`. Defaults to `7d`.
+    #[serde(default)]
+    timeframe: Option<String>,
+    /// Restrict to these `type` values, comma separated.
+    #[serde(default)]
+    types: Option<String>,
+}
+
+/// `GET /activity` - what was recorded lately, newest first, which is what a
+/// client opens on.
+///
+/// The window defaults in the engine rather than here, so the API and the MCP
+/// tool answer the same question when neither is told which window to use.
+pub async fn activity(
+    State(state): State<RestState>,
+    ApiQuery(query): ApiQuery<ActivityQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let value = state
+        .engine
+        .recent_activity(&RecentParams {
+            domains: csv(query.domains.as_deref()),
+            timeframe: query.timeframe,
+            types: csv(query.types.as_deref()),
+        })
+        .await?;
+    Ok(Json(value))
+}

--- a/crates/service/src/rest/discovery.rs
+++ b/crates/service/src/rest/discovery.rs
@@ -18,45 +18,57 @@ use axum::Json;
 use axum::extract::State;
 use serde::Deserialize;
 use serde_json::Value;
+use utoipa::IntoParams;
 
-use super::{ApiError, ApiQuery, RestState, csv};
+use super::{ApiError, ApiQuery, ProblemDetail, RestState, csv};
 use crate::params::{ContextParams, RecentParams, SearchParams, VocabularyParams};
 
 /// The query string `GET /search` takes, mirroring [`SearchParams`]. The free
 /// text is `q` rather than `query`, the spelling a browser client's address bar
 /// and every other search API already use; the rest keep the engine's names.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct SearchQuery {
     /// The free-text query. Omit for a filter-only search.
     #[serde(default)]
+    #[param(example = "retrieval latency")]
     q: Option<String>,
     /// Restrict to these domains, comma separated. Defaults to every registered
     /// domain.
     #[serde(default)]
+    #[param(example = "eng,ops")]
     domains: Option<String>,
     /// Filter by `type`.
     #[serde(rename = "type", default)]
+    #[param(example = "decision")]
     engram_type: Option<String>,
     /// Filter by `status`.
     #[serde(default)]
+    #[param(example = "stable")]
     status: Option<String>,
     /// Require all of these tags, comma separated.
     #[serde(default)]
+    #[param(example = "eng,nested")]
     tags: Option<String>,
     /// Only engrams recorded on or after this ISO date.
     #[serde(default)]
+    #[param(example = "2026-01-31")]
     after: Option<String>,
     /// hybrid (default), text, semantic, title or permalink.
     #[serde(default)]
+    #[param(example = "hybrid")]
     search_type: Option<String>,
     /// Minimum cosine similarity for a semantic hit.
     #[serde(default)]
+    #[param(example = 0.65)]
     min_similarity: Option<f32>,
     /// One-based page number. Defaults to 1.
     #[serde(default)]
+    #[param(example = 1)]
     page: Option<usize>,
     /// Page size. Defaults to 10.
     #[serde(default)]
+    #[param(example = 10)]
     limit: Option<usize>,
 }
 
@@ -76,6 +88,59 @@ pub struct SearchQuery {
 ///
 /// `metadata_filters` is not exposed: it takes a JSON object of comparisons,
 /// which has no honest query-string spelling, and no client needs it yet.
+#[utoipa::path(
+    get,
+    path = "/api/v1/search",
+    tag = "discovery",
+    operation_id = "search",
+    params(SearchQuery),
+    responses(
+        (
+            status = 200,
+            description = "The engine's page envelope, unchanged. `mode` is the \
+                           mode that actually ran, which may be a fallback to \
+                           text.",
+            body = Object,
+            example = json!({
+                "mode": "hybrid",
+                "total": 3,
+                "page": 1,
+                "limit": 10,
+                "count": 1,
+                "hits": [{
+                    "domain": "eng",
+                    "permalink": "alpha",
+                    "title": "Alpha",
+                    "snippet": "...retrieval latency dropped by half...",
+                    "score": 0.82,
+                    "engram_type": "engram",
+                    "status": "stable",
+                    "tags": ["eng"],
+                    "kind": "observation",
+                    "line": 14
+                }]
+            }),
+        ),
+        (
+            status = 400,
+            description = "The query string will not parse.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 422,
+            description = "`search_type` names a mode the engine does not know.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn search(
     State(state): State<RestState>,
     ApiQuery(query): ApiQuery<SearchQuery>,
@@ -100,10 +165,12 @@ pub async fn search(
 }
 
 /// The query string `GET /vocabulary` takes, mirroring [`VocabularyParams`].
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct VocabularyQuery {
     /// Restrict to one domain. Omit for a vocabulary across every domain.
     #[serde(default)]
+    #[param(example = "eng")]
     domain: Option<String>,
 }
 
@@ -115,6 +182,41 @@ pub struct VocabularyQuery {
 /// The domain is a filter here rather than a path segment, so an unknown name
 /// answers an empty vocabulary rather than a 404: this route asks what is in
 /// use, and the answer to that can legitimately be nothing.
+#[utoipa::path(
+    get,
+    path = "/api/v1/vocabulary",
+    tag = "discovery",
+    operation_id = "get_vocabulary",
+    params(VocabularyQuery),
+    responses(
+        (
+            status = 200,
+            description = "The engine's own vocabulary payload, unchanged. \
+                           `clusters` and `aliases` are omitted when there are \
+                           none.",
+            body = Object,
+            example = json!({
+                "domain": "eng",
+                "tags": [{ "name": "eng", "engrams": 3, "observations": 5 }],
+                "categories": [{ "name": "decision", "count": 4 }],
+                "relation_types": [{ "name": "relates_to", "count": 2 }],
+                "aliases": [{ "alias": "engineering", "canonical": "eng" }]
+            }),
+        ),
+        (
+            status = 400,
+            description = "The query string will not parse.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn vocabulary(
     State(state): State<RestState>,
     ApiQuery(query): ApiQuery<VocabularyQuery>,
@@ -132,18 +234,23 @@ pub async fn vocabulary(
 /// has no default: a traversal with nothing to start from is not a request this
 /// route can answer, so a missing one is rejected by the extractor as a 400
 /// rather than guessed at.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct ContextQuery {
     /// A `crystalline://domain/permalink` anchor. A `/*` suffix globs a prefix.
+    #[param(example = "crystalline://eng/alpha")]
     anchor: String,
     /// Traversal depth, 1 to 3. Defaults to 1.
     #[serde(default)]
+    #[param(example = 1)]
     depth: Option<u8>,
     /// Restrict the returned neighborhood to these domains, comma separated.
     #[serde(default)]
+    #[param(example = "eng,ops")]
     domains: Option<String>,
     /// Maximum related engrams beyond the anchors. Defaults to 10.
     #[serde(default)]
+    #[param(example = 10)]
     max_related: Option<usize>,
 }
 
@@ -158,6 +265,73 @@ pub struct ContextQuery {
 /// `timeframe` is not exposed: the engine documents it as advisory in this
 /// version, and a parameter that does not change the answer is not worth a
 /// client learning.
+#[utoipa::path(
+    get,
+    path = "/api/v1/context",
+    tag = "discovery",
+    operation_id = "get_context",
+    params(ContextQuery),
+    responses(
+        (
+            status = 200,
+            description = "The engine's own context payload, unchanged: the \
+                           anchored engrams as seed nodes plus the neighborhood \
+                           ranked out from them.",
+            body = Object,
+            example = json!({
+                "anchor": "crystalline://eng/alpha",
+                "depth": 1,
+                "timeframe": null,
+                "nodes": [
+                    {
+                        "id": 1,
+                        "domain": "eng",
+                        "permalink": "alpha",
+                        "title": "Alpha",
+                        "type": "engram",
+                        "seed": true
+                    },
+                    {
+                        "id": 2,
+                        "domain": "eng",
+                        "permalink": "notes/beta",
+                        "title": "Beta",
+                        "type": "engram",
+                        "seed": false
+                    }
+                ],
+                "edges": [
+                    { "from": 1, "to": 2, "rel_type": "relates_to", "kind": "relation" }
+                ]
+            }),
+        ),
+        (
+            status = 400,
+            description = "The query string will not parse, `anchor` included: it \
+                           has no default.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 404,
+            description = "The anchor names no engram.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 422,
+            description = "The anchor is not a `crystalline://` URL.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn context(
     State(state): State<RestState>,
     ApiQuery(query): ApiQuery<ContextQuery>,
@@ -176,17 +350,21 @@ pub async fn context(
 }
 
 /// The query string `GET /activity` takes, mirroring [`RecentParams`].
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct ActivityQuery {
     /// Restrict to these domains, comma separated. Defaults to every registered
     /// domain.
     #[serde(default)]
+    #[param(example = "eng,ops")]
     domains: Option<String>,
     /// A recency window such as `7d`, `24h` or `2w`. Defaults to `7d`.
     #[serde(default)]
+    #[param(example = "7d")]
     timeframe: Option<String>,
     /// Restrict to these `type` values, comma separated.
     #[serde(default)]
+    #[param(example = "decision,runbook")]
     types: Option<String>,
 }
 
@@ -195,6 +373,46 @@ pub struct ActivityQuery {
 ///
 /// The window defaults in the engine rather than here, so the API and the MCP
 /// tool answer the same question when neither is told which window to use.
+#[utoipa::path(
+    get,
+    path = "/api/v1/activity",
+    tag = "discovery",
+    operation_id = "get_activity",
+    params(ActivityQuery),
+    responses(
+        (
+            status = 200,
+            description = "The engine's own activity payload, unchanged, with \
+                           the window it actually used echoed back.",
+            body = Object,
+            example = json!({
+                "timeframe": "7d",
+                "count": 1,
+                "engrams": [{
+                    "domain": "eng",
+                    "permalink": "alpha",
+                    "title": "Alpha",
+                    "engram_type": "engram",
+                    "status": "stable",
+                    "recorded_at": "2026-08-04",
+                    "tags": ["eng"]
+                }]
+            }),
+        ),
+        (
+            status = 400,
+            description = "The query string will not parse.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn activity(
     State(state): State<RestState>,
     ApiQuery(query): ApiQuery<ActivityQuery>,

--- a/crates/service/src/rest/domains.rs
+++ b/crates/service/src/rest/domains.rs
@@ -1,0 +1,77 @@
+//! What a client sees before it sees any engram: which domains this instance
+//! serves, what each one holds, and what each one is for.
+//!
+//! The listing and the tree pass the engine's own JSON through unchanged, so
+//! the MCP tools and this API answer with one payload rather than two shapes
+//! that drift. The manifest endpoint is the one wrapper here, because a
+//! markdown document is not JSON: it is handed over as a string beside the
+//! domain it belongs to.
+
+use axum::Json;
+use axum::extract::State;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::{ApiError, ApiPath, ApiQuery, RestState};
+use crate::params::{BrowseParams, ListDomainsParams};
+
+/// `GET /domains` - every registered domain with its counts, its kind and its
+/// routing bullets, plus the behavior rules that govern them.
+///
+/// `include_routing` is always on rather than a query parameter: a browser
+/// client is exactly the caller that has no other way to learn what a domain is
+/// for, and the bullets are a handful of lines per domain.
+pub async fn list(State(state): State<RestState>) -> Result<Json<Value>, ApiError> {
+    let value = state
+        .engine
+        .list_domains(&ListDomainsParams {
+            include_routing: true,
+        })
+        .await?;
+    Ok(Json(value))
+}
+
+/// The query string `GET /domains/{domain}/tree` takes, mirroring
+/// [`BrowseParams`] minus the domain the path already names.
+#[derive(Debug, Deserialize)]
+pub struct TreeQuery {
+    /// A domain-relative folder path. Defaults to the root.
+    #[serde(default)]
+    path: Option<String>,
+    /// How many folder levels deep to list. Defaults to 1.
+    #[serde(default)]
+    depth: Option<usize>,
+    /// A glob filtering the engram paths listed.
+    #[serde(default)]
+    glob: Option<String>,
+}
+
+/// `GET /domains/{domain}/tree` - one domain's engrams and subfolders under a
+/// path, the navigation a file tree in the UI is built from.
+pub async fn tree(
+    State(state): State<RestState>,
+    ApiPath(domain): ApiPath<String>,
+    ApiQuery(query): ApiQuery<TreeQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let value = state
+        .engine
+        .browse_domain(&BrowseParams {
+            domain,
+            path: query.path,
+            depth: query.depth,
+            glob: query.glob,
+        })
+        .await?;
+    Ok(Json(value))
+}
+
+/// `GET /domains/{domain}/manifest` - the domain's MANIFEST markdown as
+/// written, so a client can render or edit the source rather than a reduction
+/// of it.
+pub async fn manifest(
+    State(state): State<RestState>,
+    ApiPath(domain): ApiPath<String>,
+) -> Result<Json<Value>, ApiError> {
+    let markdown = state.engine.manifest_markdown(&domain).await?;
+    Ok(Json(json!({ "domain": domain, "markdown": markdown })))
+}

--- a/crates/service/src/rest/domains.rs
+++ b/crates/service/src/rest/domains.rs
@@ -11,8 +11,9 @@ use axum::Json;
 use axum::extract::State;
 use serde::Deserialize;
 use serde_json::{Value, json};
+use utoipa::IntoParams;
 
-use super::{ApiError, ApiPath, ApiQuery, RestState};
+use super::{ApiError, ApiPath, ApiQuery, ProblemDetail, RestState};
 use crate::params::{BrowseParams, ListDomainsParams};
 
 /// `GET /domains` - every registered domain with its counts, its kind and its
@@ -21,6 +22,41 @@ use crate::params::{BrowseParams, ListDomainsParams};
 /// `include_routing` is always on rather than a query parameter: a browser
 /// client is exactly the caller that has no other way to learn what a domain is
 /// for, and the bullets are a handful of lines per domain.
+#[utoipa::path(
+    get,
+    path = "/api/v1/domains",
+    tag = "domains",
+    operation_id = "list_domains",
+    responses(
+        (
+            status = 200,
+            description = "The engine's own domain listing, unchanged.",
+            body = Object,
+            example = json!({
+                "behavior": [
+                    "Search before answering from memory.",
+                    "Record what was learned as an engram."
+                ],
+                "domains": [{
+                    "name": "eng",
+                    "kind": "file",
+                    "path": "/Users/ada/Documents/Crystalline/eng",
+                    "engrams": 4,
+                    "observations": 12,
+                    "relations": 3,
+                    "last_sync": "2026-08-05T09:14:22Z",
+                    "when_to_use": ["Route here for eng questions."]
+                }]
+            }),
+        ),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn list(State(state): State<RestState>) -> Result<Json<Value>, ApiError> {
     let value = state
         .engine
@@ -33,21 +69,74 @@ pub async fn list(State(state): State<RestState>) -> Result<Json<Value>, ApiErro
 
 /// The query string `GET /domains/{domain}/tree` takes, mirroring
 /// [`BrowseParams`] minus the domain the path already names.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct TreeQuery {
     /// A domain-relative folder path. Defaults to the root.
     #[serde(default)]
+    #[param(example = "notes")]
     path: Option<String>,
     /// How many folder levels deep to list. Defaults to 1.
     #[serde(default)]
+    #[param(example = 2)]
     depth: Option<usize>,
     /// A glob filtering the engram paths listed.
     #[serde(default)]
+    #[param(example = "notes/**")]
     glob: Option<String>,
 }
 
 /// `GET /domains/{domain}/tree` - one domain's engrams and subfolders under a
 /// path, the navigation a file tree in the UI is built from.
+#[utoipa::path(
+    get,
+    path = "/api/v1/domains/{domain}/tree",
+    tag = "domains",
+    operation_id = "get_domain_tree",
+    params(("domain" = String, Path, description = "The registered domain."), TreeQuery),
+    responses(
+        (
+            status = 200,
+            description = "The engine's own browse payload, unchanged.",
+            body = Object,
+            example = json!({
+                "domain": "eng",
+                "path": "/",
+                "folders": ["notes"],
+                "engrams": [{
+                    "permalink": "alpha",
+                    "title": "Alpha",
+                    "type": "engram",
+                    "path": "alpha.md"
+                }]
+            }),
+        ),
+        (
+            status = 400,
+            description = "The query string will not parse.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 404,
+            description = "No such domain.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 422,
+            description = "The glob is not a valid pattern.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn tree(
     State(state): State<RestState>,
     ApiPath(domain): ApiPath<String>,
@@ -68,6 +157,36 @@ pub async fn tree(
 /// `GET /domains/{domain}/manifest` - the domain's MANIFEST markdown as
 /// written, so a client can render or edit the source rather than a reduction
 /// of it.
+#[utoipa::path(
+    get,
+    path = "/api/v1/domains/{domain}/manifest",
+    tag = "domains",
+    operation_id = "get_domain_manifest",
+    params(("domain" = String, Path, description = "The registered domain.")),
+    responses(
+        (
+            status = 200,
+            description = "The manifest source beside the domain it belongs to.",
+            body = Object,
+            example = json!({
+                "domain": "eng",
+                "markdown": "---\ntitle: eng\n---\n\n## When to Use\n\n- Route here for eng questions.\n"
+            }),
+        ),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 404,
+            description = "No such domain, or the domain carries no MANIFEST yet.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn manifest(
     State(state): State<RestState>,
     ApiPath(domain): ApiPath<String>,

--- a/crates/service/src/rest/domains.rs
+++ b/crates/service/src/rest/domains.rs
@@ -55,6 +55,12 @@ use crate::params::{BrowseParams, ListDomainsParams};
             body = ProblemDetail,
             content_type = "application/problem+json",
         ),
+        (
+            status = 403,
+            description = "The trusted-header identity names a disabled account.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
     ),
 )]
 pub async fn list(State(state): State<RestState>) -> Result<Json<Value>, ApiError> {
@@ -124,6 +130,12 @@ pub struct TreeQuery {
             content_type = "application/problem+json",
         ),
         (
+            status = 403,
+            description = "The trusted-header identity names a disabled account.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
             status = 404,
             description = "No such domain.",
             body = ProblemDetail,
@@ -176,6 +188,12 @@ pub async fn tree(
         (
             status = 401,
             description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 403,
+            description = "The trusted-header identity names a disabled account.",
             body = ProblemDetail,
             content_type = "application/problem+json",
         ),

--- a/crates/service/src/rest/engrams.rs
+++ b/crates/service/src/rest/engrams.rs
@@ -14,7 +14,7 @@ use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
 use serde_json::Value;
 
-use super::{ApiError, ApiPath, ApiQuery, RestState};
+use super::{ApiError, ApiPath, ApiQuery, RestState, csv};
 use crate::params::{ReadParams, SearchParams};
 
 /// The query string `GET /domains/{domain}/engrams` takes: the filter side of
@@ -76,7 +76,7 @@ pub async fn list(
             query: None,
             domains: vec![domain],
             engram_type: query.engram_type,
-            tags: query.tags.as_deref().map(split_tags).unwrap_or_default(),
+            tags: csv(query.tags.as_deref()),
             status: query.status,
             after: query.after,
             page: query.page,
@@ -136,36 +136,9 @@ fn etag(value: &Value) -> Result<HeaderValue, ApiError> {
         .map_err(|_| ApiError::internal("the engram's checksum is not a usable ETag"))
 }
 
-/// Split a comma-separated tag list, dropping the whitespace and the empties a
-/// hand-written URL brings with it, so `?tags=a,%20b,` asks for `a` and `b`
-/// rather than for a tag that is one space long.
-fn split_tags(raw: &str) -> Vec<String> {
-    raw.split(',')
-        .map(str::trim)
-        .filter(|t| !t.is_empty())
-        .map(str::to_string)
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn a_tag_list_splits_on_commas_and_drops_the_empties() {
-        assert_eq!(split_tags("a,b"), vec!["a".to_string(), "b".to_string()]);
-        assert_eq!(
-            split_tags(" a , b "),
-            vec!["a".to_string(), "b".to_string()],
-            "a hand-written list is not punished for its spaces"
-        );
-        assert_eq!(split_tags("a,,"), vec!["a".to_string()]);
-        assert!(
-            split_tags("").is_empty(),
-            "no tags rather than one empty one"
-        );
-        assert!(split_tags(" , ").is_empty());
-    }
 
     /// The tag is a quoted strong validator, which is what an `If-Match`
     /// comparison later depends on: unquoted or `W/`-prefixed would not match.

--- a/crates/service/src/rest/engrams.rs
+++ b/crates/service/src/rest/engrams.rs
@@ -13,34 +13,42 @@ use axum::http::header::ETAG;
 use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
 use serde_json::Value;
+use utoipa::IntoParams;
 
-use super::{ApiError, ApiPath, ApiQuery, RestState, csv};
+use super::{ApiError, ApiPath, ApiQuery, ProblemDetail, RestState, csv};
 use crate::params::{ReadParams, SearchParams};
 
 /// The query string `GET /domains/{domain}/engrams` takes: the filter side of
 /// [`SearchParams`], minus the domain the path already names and minus the
 /// free-text query, which belongs to the search endpoint rather than a listing.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct ListQuery {
     /// Filter by `type`.
     #[serde(rename = "type", default)]
+    #[param(example = "decision")]
     engram_type: Option<String>,
     /// Filter by `status`.
     #[serde(default)]
+    #[param(example = "stable")]
     status: Option<String>,
     /// Require all of these tags, comma separated. A URL is a string, so the
     /// repeated-parameter form a `Vec` would need is not on offer here; the
     /// list is split on the way in.
     #[serde(default)]
+    #[param(example = "eng,nested")]
     tags: Option<String>,
     /// Only engrams recorded on or after this ISO date.
     #[serde(default)]
+    #[param(example = "2026-01-31")]
     after: Option<String>,
     /// One-based page number. Defaults to 1.
     #[serde(default)]
+    #[param(example = 1)]
     page: Option<usize>,
     /// Page size. Defaults to 10.
     #[serde(default)]
+    #[param(example = 10)]
     limit: Option<usize>,
 }
 
@@ -62,6 +70,64 @@ pub struct ListQuery {
 /// route's own verb opens with; `search_engrams` is left alone, because an
 /// unmatched name in its `domains` filter really is just a narrower filter, and
 /// that verb is shared with the MCP tool.
+#[utoipa::path(
+    get,
+    path = "/api/v1/domains/{domain}/engrams",
+    tag = "engrams",
+    operation_id = "list_engrams",
+    summary = "One domain's engrams, filtered by frontmatter and paged.",
+    description = "A filter-only search, so the answer carries the same page \
+                   envelope a search does and a client pages it the same way. \
+                   Listing by folder is not here: the tree endpoint owns the \
+                   navigation view and this one owns the frontmatter view.\n\nA \
+                   domain nobody registered is a 404, while filters that match \
+                   nothing are an empty page: two states a client can tell \
+                   apart.",
+    params(("domain" = String, Path, description = "The registered domain."), ListQuery),
+    responses(
+        (
+            status = 200,
+            description = "The engine's page envelope, unchanged.",
+            body = Object,
+            example = json!({
+                "mode": "text",
+                "total": 4,
+                "page": 1,
+                "limit": 10,
+                "count": 1,
+                "hits": [{
+                    "domain": "eng",
+                    "permalink": "alpha",
+                    "title": "Alpha",
+                    "snippet": "The first engram in this domain.",
+                    "score": 1.0,
+                    "engram_type": "engram",
+                    "status": "stable",
+                    "tags": ["eng"],
+                    "kind": "engram"
+                }]
+            }),
+        ),
+        (
+            status = 400,
+            description = "The query string will not parse.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 404,
+            description = "No such domain.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn list(
     State(state): State<RestState>,
     ApiPath(domain): ApiPath<String>,
@@ -97,6 +163,64 @@ pub async fn list(
 ///
 /// The response carries an `ETag` over the markdown, so a client knows which
 /// version it is holding. See [`etag`].
+#[utoipa::path(
+    get,
+    path = "/api/v1/domains/{domain}/engrams/{permalink}",
+    tag = "engrams",
+    operation_id = "get_engram",
+    summary = "One engram in full.",
+    description = "Its frontmatter, its markdown as written and the references \
+                   the engine resolves around it.\n\nThe response carries an \
+                   `ETag` over the markdown, so a client knows which version it \
+                   is holding and can say so when it later writes back.",
+    params(
+        ("domain" = String, Path, description = "The registered domain."),
+        (
+            "permalink" = String,
+            Path,
+            description = "The engram permalink. A permalink is a path, so this \
+                           segment may contain slashes: `notes/deep/gamma`.",
+            example = "notes/deep/gamma",
+        ),
+    ),
+    responses(
+        (
+            status = 200,
+            description = "The engine's own read payload, unchanged.",
+            body = Object,
+            headers(("etag" = String, description = "The quoted checksum of the \
+                     engram as read, the same token a later write compares an \
+                     `expected_checksum` against.")),
+            example = json!({
+                "domain": "eng",
+                "permalink": "alpha",
+                "title": "Alpha",
+                "type": "engram",
+                "status": "stable",
+                "path": "alpha.md",
+                "url": "crystalline://eng/alpha",
+                "content": "---\ntitle: Alpha\n---\n\nThe first engram.\n",
+                "checksum": "3f8a1c05e2",
+                "frontmatter": { "title": "Alpha", "permalink": "alpha" },
+                "observations": [],
+                "relations": [],
+                "links": []
+            }),
+        ),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 404,
+            description = "No such domain or engram.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn detail(
     State(state): State<RestState>,
     ApiPath((domain, permalink)): ApiPath<(String, String)>,

--- a/crates/service/src/rest/engrams.rs
+++ b/crates/service/src/rest/engrams.rs
@@ -121,6 +121,12 @@ pub struct ListQuery {
             content_type = "application/problem+json",
         ),
         (
+            status = 403,
+            description = "The trusted-header identity names a disabled account.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
             status = 404,
             description = "No such domain.",
             body = ProblemDetail,
@@ -210,6 +216,12 @@ pub async fn list(
         (
             status = 401,
             description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 403,
+            description = "The trusted-header identity names a disabled account.",
             body = ProblemDetail,
             content_type = "application/problem+json",
         ),

--- a/crates/service/src/rest/engrams.rs
+++ b/crates/service/src/rest/engrams.rs
@@ -1,0 +1,177 @@
+//! The two ways a client reaches an engram: a filtered listing of a domain,
+//! and one engram in full.
+//!
+//! Both hand the engine's own JSON over unchanged, so this API and the MCP
+//! tools answer with one payload rather than two shapes that drift. The detail
+//! route adds exactly one thing on top: an `ETag`, so a client that later wants
+//! to write back can say which version it read.
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::HeaderValue;
+use axum::http::header::ETAG;
+use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::{ApiError, ApiPath, ApiQuery, RestState};
+use crate::params::{ReadParams, SearchParams};
+
+/// The query string `GET /domains/{domain}/engrams` takes: the filter side of
+/// [`SearchParams`], minus the domain the path already names and minus the
+/// free-text query, which belongs to the search endpoint rather than a listing.
+#[derive(Debug, Deserialize)]
+pub struct ListQuery {
+    /// Filter by `type`.
+    #[serde(rename = "type", default)]
+    engram_type: Option<String>,
+    /// Filter by `status`.
+    #[serde(default)]
+    status: Option<String>,
+    /// Require all of these tags, comma separated. A URL is a string, so the
+    /// repeated-parameter form a `Vec` would need is not on offer here; the
+    /// list is split on the way in.
+    #[serde(default)]
+    tags: Option<String>,
+    /// Only engrams recorded on or after this ISO date.
+    #[serde(default)]
+    after: Option<String>,
+    /// One-based page number. Defaults to 1.
+    #[serde(default)]
+    page: Option<usize>,
+    /// Page size. Defaults to 10.
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+/// `GET /domains/{domain}/engrams` - one domain's engrams, filtered by
+/// frontmatter and paged, which is what a browsing client lists from.
+///
+/// This is `search_engrams` with no query text: a filter-only search, so the
+/// answer carries the engine's own page envelope (`total`, `page`, `limit`,
+/// `count`, `hits`) and a client pages it the way it pages a search. Listing by
+/// folder is not here: the tree endpoint owns the navigation view, this one
+/// owns the frontmatter view, and neither reimplements the other.
+///
+/// An unregistered domain lists empty rather than answering 404, which is what
+/// `search_engrams` does with a domain filter nothing matches. The tree and
+/// manifest routes do 404, because the engine's verbs behind them resolve the
+/// domain first; keeping each route on its verb's own contract is what keeps
+/// this surface a projection of the engine rather than a second opinion.
+pub async fn list(
+    State(state): State<RestState>,
+    ApiPath(domain): ApiPath<String>,
+    ApiQuery(query): ApiQuery<ListQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let value = state
+        .engine
+        .search_engrams(&SearchParams {
+            // No text: the filters alone select, and the engine takes that as
+            // the filter-only mode rather than as an empty search.
+            query: None,
+            domains: vec![domain],
+            engram_type: query.engram_type,
+            tags: query.tags.as_deref().map(split_tags).unwrap_or_default(),
+            status: query.status,
+            after: query.after,
+            page: query.page,
+            limit: query.limit,
+            ..SearchParams::default()
+        })
+        .await?;
+    Ok(Json(value))
+}
+
+/// `GET /domains/{domain}/engrams/{*permalink}` - one engram in full: its
+/// frontmatter, its markdown as written and the references the engine resolves
+/// around it.
+///
+/// The permalink is a wildcard segment because a permalink is a path: an engram
+/// two folders down carries `notes/deep/gamma`, and a single segment would only
+/// ever reach the ones at a domain's root.
+///
+/// The response carries an `ETag` over the markdown, so a client knows which
+/// version it is holding. See [`etag`].
+pub async fn detail(
+    State(state): State<RestState>,
+    ApiPath((domain, permalink)): ApiPath<(String, String)>,
+) -> Result<Response, ApiError> {
+    let value = state
+        .engine
+        .read_engram(&ReadParams {
+            identifier: permalink,
+            domain: Some(domain),
+        })
+        .await?;
+    let etag = etag(&value)?;
+    let mut resp = Json(value).into_response();
+    resp.headers_mut().insert(ETAG, etag);
+    Ok(resp)
+}
+
+/// The strong validator for the engram this read returned: the checksum the
+/// engine computed over the markdown it is handing back, quoted the way RFC
+/// 9110 requires of a strong one.
+///
+/// The engine's `checksum` is reused rather than the content hashed a second
+/// time here, and not to save the hash: it is the same value `edit_engram`
+/// compares an `expected_checksum` against, so the tag a client reads out of a
+/// response is exactly the token a later `If-Match` can be turned into, with
+/// one definition of what version an engram is at rather than two that agree
+/// until one of them moves.
+fn etag(value: &Value) -> Result<HeaderValue, ApiError> {
+    let checksum = value["checksum"].as_str().ok_or_else(|| {
+        ApiError::internal("the engram read carried no checksum to version it by")
+    })?;
+    HeaderValue::from_str(&format!("\"{checksum}\""))
+        .map_err(|_| ApiError::internal("the engram's checksum is not a usable ETag"))
+}
+
+/// Split a comma-separated tag list, dropping the whitespace and the empties a
+/// hand-written URL brings with it, so `?tags=a,%20b,` asks for `a` and `b`
+/// rather than for a tag that is one space long.
+fn split_tags(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_tag_list_splits_on_commas_and_drops_the_empties() {
+        assert_eq!(split_tags("a,b"), vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(
+            split_tags(" a , b "),
+            vec!["a".to_string(), "b".to_string()],
+            "a hand-written list is not punished for its spaces"
+        );
+        assert_eq!(split_tags("a,,"), vec!["a".to_string()]);
+        assert!(
+            split_tags("").is_empty(),
+            "no tags rather than one empty one"
+        );
+        assert!(split_tags(" , ").is_empty());
+    }
+
+    /// The tag is a quoted strong validator, which is what an `If-Match`
+    /// comparison later depends on: unquoted or `W/`-prefixed would not match.
+    #[test]
+    fn the_etag_is_the_quoted_checksum() {
+        let value = serde_json::json!({ "checksum": "abc123", "content": "hi" });
+        assert_eq!(etag(&value).unwrap(), "\"abc123\"");
+    }
+
+    /// A response with no checksum is an engine contract this layer cannot
+    /// paper over, so it says so loudly instead of dropping the header and
+    /// leaving a client to think the engram has no version.
+    #[test]
+    fn a_read_without_a_checksum_is_an_internal_error() {
+        let err = etag(&serde_json::json!({ "content": "hi" })).unwrap_err();
+        assert_eq!(err.status, axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+    }
+}

--- a/crates/service/src/rest/engrams.rs
+++ b/crates/service/src/rest/engrams.rs
@@ -53,16 +53,21 @@ pub struct ListQuery {
 /// folder is not here: the tree endpoint owns the navigation view, this one
 /// owns the frontmatter view, and neither reimplements the other.
 ///
-/// An unregistered domain lists empty rather than answering 404, which is what
-/// `search_engrams` does with a domain filter nothing matches. The tree and
-/// manifest routes do 404, because the engine's verbs behind them resolve the
-/// domain first; keeping each route on its verb's own contract is what keeps
-/// this surface a projection of the engine rather than a second opinion.
+/// A domain nobody registered is a 404, like the tree and manifest routes
+/// beside it: a path segment names a resource, and a resource that does not
+/// exist is missing, while query filters may legitimately filter to nothing. So
+/// an unknown domain answers 404 and a registered domain that holds nothing
+/// answers an empty page, two states a client can tell apart. The check is
+/// [`crate::engine::Engine::require_domain`], the same resolution the tree
+/// route's own verb opens with; `search_engrams` is left alone, because an
+/// unmatched name in its `domains` filter really is just a narrower filter, and
+/// that verb is shared with the MCP tool.
 pub async fn list(
     State(state): State<RestState>,
     ApiPath(domain): ApiPath<String>,
     ApiQuery(query): ApiQuery<ListQuery>,
 ) -> Result<Json<Value>, ApiError> {
+    state.engine.require_domain(&domain)?;
     let value = state
         .engine
         .search_engrams(&SearchParams {
@@ -119,6 +124,10 @@ pub async fn detail(
 /// response is exactly the token a later `If-Match` can be turned into, with
 /// one definition of what version an engram is at rather than two that agree
 /// until one of them moves.
+///
+/// The error branch is unreachable under the current engine, which always emits
+/// `checksum` from a read; it guards against a future contract break, loudly,
+/// rather than letting an engram be served without a version.
 fn etag(value: &Value) -> Result<HeaderValue, ApiError> {
     let checksum = value["checksum"].as_str().ok_or_else(|| {
         ApiError::internal("the engram read carried no checksum to version it by")

--- a/crates/service/src/rest/error.rs
+++ b/crates/service/src/rest/error.rs
@@ -61,6 +61,26 @@ impl ApiError {
         }
     }
 
+    /// A 409 for a request the server understood, is allowed to serve, and
+    /// refuses because carrying it out would break a rule about the state
+    /// rather than about the request: a name already taken, or an edit that
+    /// would leave the installation without an admin. Nothing about the request
+    /// can be corrected to make it succeed - something else has to change
+    /// first, which is what separates it from [`ApiError::unprocessable`].
+    pub fn conflict(detail: impl Into<String>) -> ApiError {
+        ApiError {
+            status: StatusCode::CONFLICT,
+            title: "conflict",
+            detail: detail.into(),
+        }
+    }
+
+    /// A 422 for a request the server understood but cannot act on, matching
+    /// the status the engine's own caller errors take.
+    pub fn unprocessable(detail: impl Into<String>) -> ApiError {
+        unprocessable_error(detail.into())
+    }
+
     /// A 500 for a failure that is not the caller's fault.
     pub fn internal(detail: impl Into<String>) -> ApiError {
         internal_error(detail.into())
@@ -205,7 +225,7 @@ impl From<EngineError> for ApiError {
             | EngineError::Conflict(_)
             | EngineError::Invalid(_)
             | EngineError::ReadOnly
-            | EngineError::EnvTokenConnect => unprocessable(detail),
+            | EngineError::EnvTokenConnect => unprocessable_error(detail),
             EngineError::Remote(remote) => remote_to_api_error(remote, detail),
             EngineError::Io { .. } | EngineError::Internal(_) => internal_error(detail),
         }
@@ -246,12 +266,12 @@ fn remote_to_api_error(e: crystalline_remote::RemoteError, detail: String) -> Ap
         | RemoteError::ConflictNotFound { .. } => ApiError::not_found(detail),
         RemoteError::NotEnabled
         | RemoteError::NotConnected
-        | RemoteError::ConflictsPending { .. } => unprocessable(detail),
+        | RemoteError::ConflictsPending { .. } => unprocessable_error(detail),
     }
 }
 
 /// A 422 for a request the server understood but cannot act on.
-fn unprocessable(detail: String) -> ApiError {
+fn unprocessable_error(detail: String) -> ApiError {
     ApiError {
         status: StatusCode::UNPROCESSABLE_ENTITY,
         title: "invalid request",

--- a/crates/service/src/rest/error.rs
+++ b/crates/service/src/rest/error.rs
@@ -187,14 +187,45 @@ impl<T: DeserializeOwned, S: Send + Sync> FromRequest<S> for ApiJson<T> {
     }
 }
 
+/// The wire form of an [`ApiError`]: the RFC 9457 body every failure on this
+/// surface carries, and the one schema the OpenAPI document names for every
+/// error response.
+///
+/// Written as a type rather than as an inline `json!` so the document and the
+/// response are the same definition: a field renamed here changes both at once,
+/// which is the whole reason a generated client can trust the error shape.
+#[derive(Debug, serde::Serialize, utoipa::ToSchema)]
+#[schema(description = "An RFC 9457 problem detail, sent as \
+                        `application/problem+json`. Every failure on this \
+                        surface has this shape, so a client can branch on \
+                        `status` alone.")]
+pub struct ProblemDetail {
+    /// The problem type URI. Always `about:blank`: `status` and `title` carry
+    /// the classification, and this surface publishes no per-problem pages to
+    /// point at.
+    #[serde(rename = "type")]
+    #[schema(example = "about:blank")]
+    pub problem_type: &'static str,
+    /// The HTTP status, mirrored into the body so a client that only has the
+    /// parsed payload can still branch on it.
+    #[schema(example = 404)]
+    pub status: u16,
+    /// A short, stable, human-readable summary of the problem type.
+    #[schema(example = "not found")]
+    pub title: &'static str,
+    /// The specific occurrence, safe to show to the caller.
+    #[schema(example = "no engram 'ghost' in domain 'eng'")]
+    pub detail: String,
+}
+
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
-        let body = serde_json::json!({
-            "type": "about:blank",
-            "status": self.status.as_u16(),
-            "title": self.title,
-            "detail": self.detail,
-        });
+        let body = ProblemDetail {
+            problem_type: "about:blank",
+            status: self.status.as_u16(),
+            title: self.title,
+            detail: self.detail,
+        };
         let mut resp = (self.status, axum::Json(body)).into_response();
         // `axum::Json` writes `application/json`; RFC 9457 requires the
         // problem media type, so the header is replaced rather than appended.

--- a/crates/service/src/rest/error.rs
+++ b/crates/service/src/rest/error.rs
@@ -1,8 +1,18 @@
 //! The single error type every REST handler returns, rendered as an RFC 9457
 //! problem detail so a browser client can branch on `status` alone.
+//!
+//! axum's own extractors reject in plain text, which would put a second error
+//! shape on the wire for exactly the requests a client is most likely to get
+//! wrong. [`ApiQuery`], [`ApiPath`] and [`ApiJson`] wrap them so every
+//! rejection arrives as a problem detail too; the router pairs them with a
+//! method-not-allowed fallback (see [`ApiError::method_not_allowed`]) so the
+//! last plain-text answer axum can produce is covered as well.
 
+use axum::extract::{FromRequest, FromRequestParts, Request};
 use axum::http::StatusCode;
+use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
+use serde::de::DeserializeOwned;
 
 use crate::engine::EngineError;
 
@@ -54,6 +64,106 @@ impl ApiError {
     /// A 500 for a failure that is not the caller's fault.
     pub fn internal(detail: impl Into<String>) -> ApiError {
         internal_error(detail.into())
+    }
+
+    /// A 405 for a path that exists but does not serve this method. Mounted as
+    /// the router's `method_not_allowed_fallback`, which is the one answer axum
+    /// would otherwise produce with an empty body; the `Allow` header axum adds
+    /// on the way out survives, so the response still names what does work.
+    pub fn method_not_allowed() -> ApiError {
+        ApiError {
+            status: StatusCode::METHOD_NOT_ALLOWED,
+            title: "method not allowed",
+            detail: "this path does not serve that method".to_string(),
+        }
+    }
+
+    /// Re-render an axum extractor rejection as a problem detail.
+    ///
+    /// The status axum chose is kept rather than folded into one of this
+    /// module's own: its rejections already distinguish unparseable from
+    /// well-formed-but-wrong (400 against 422) and a missing JSON content type
+    /// (415), and that classification is more specific than anything this layer
+    /// could recover after the fact. Only the rendering changes. The two
+    /// accessors each wrapper reads it with are inherent methods on unrelated
+    /// rejection types rather than one shared trait, so the call sites repeat
+    /// rather than routing through a seam that would only exist to hide three
+    /// identical lines.
+    fn from_rejection(status: StatusCode, detail: String) -> ApiError {
+        let title = match status {
+            StatusCode::METHOD_NOT_ALLOWED => "method not allowed",
+            StatusCode::UNSUPPORTED_MEDIA_TYPE => "unsupported media type",
+            StatusCode::PAYLOAD_TOO_LARGE => "payload too large",
+            s if s.is_server_error() => "internal error",
+            _ => "invalid request",
+        };
+        ApiError {
+            status,
+            title,
+            detail,
+        }
+    }
+}
+
+/// [`axum::extract::Query`] with this module's rejection contract: a query
+/// string that will not deserialize answers in problem+json instead of text.
+pub struct ApiQuery<T>(
+    /// The deserialized query parameters.
+    pub T,
+);
+
+impl<T: DeserializeOwned, S: Send + Sync> FromRequestParts<S> for ApiQuery<T> {
+    type Rejection = ApiError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<ApiQuery<T>, ApiError> {
+        match axum::extract::Query::<T>::from_request_parts(parts, state).await {
+            Ok(axum::extract::Query(value)) => Ok(ApiQuery(value)),
+            Err(rejection) => Err(ApiError::from_rejection(
+                rejection.status(),
+                rejection.body_text(),
+            )),
+        }
+    }
+}
+
+/// [`axum::extract::Path`] with this module's rejection contract.
+pub struct ApiPath<T>(
+    /// The deserialized path parameters.
+    pub T,
+);
+
+impl<T: DeserializeOwned + Send, S: Send + Sync> FromRequestParts<S> for ApiPath<T> {
+    type Rejection = ApiError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<ApiPath<T>, ApiError> {
+        match axum::extract::Path::<T>::from_request_parts(parts, state).await {
+            Ok(axum::extract::Path(value)) => Ok(ApiPath(value)),
+            Err(rejection) => Err(ApiError::from_rejection(
+                rejection.status(),
+                rejection.body_text(),
+            )),
+        }
+    }
+}
+
+/// [`axum::Json`] with this module's rejection contract, for request bodies. A
+/// response still uses `axum::Json`, which never rejects.
+pub struct ApiJson<T>(
+    /// The deserialized body.
+    pub T,
+);
+
+impl<T: DeserializeOwned, S: Send + Sync> FromRequest<S> for ApiJson<T> {
+    type Rejection = ApiError;
+
+    async fn from_request(req: Request, state: &S) -> Result<ApiJson<T>, ApiError> {
+        match axum::Json::<T>::from_request(req, state).await {
+            Ok(axum::Json(value)) => Ok(ApiJson(value)),
+            Err(rejection) => Err(ApiError::from_rejection(
+                rejection.status(),
+                rejection.body_text(),
+            )),
+        }
     }
 }
 
@@ -181,6 +291,31 @@ mod tests {
             ApiError::from(EngineError::Internal("store blew up".into())).status,
             StatusCode::INTERNAL_SERVER_ERROR
         );
+    }
+
+    /// An axum rejection keeps the status axum chose and gains a title from
+    /// this module's stable set, so a client can branch on either.
+    #[test]
+    fn a_rejection_keeps_its_status_and_gains_a_title() {
+        let title = |status| ApiError::from_rejection(status, "why".to_string()).title;
+        assert_eq!(title(StatusCode::BAD_REQUEST), "invalid request");
+        assert_eq!(title(StatusCode::UNPROCESSABLE_ENTITY), "invalid request");
+        assert_eq!(
+            title(StatusCode::UNSUPPORTED_MEDIA_TYPE),
+            "unsupported media type"
+        );
+        assert_eq!(title(StatusCode::PAYLOAD_TOO_LARGE), "payload too large");
+        assert_eq!(
+            title(StatusCode::METHOD_NOT_ALLOWED),
+            "method not allowed",
+            "the same title the router's own 405 carries"
+        );
+        assert_eq!(title(StatusCode::INTERNAL_SERVER_ERROR), "internal error");
+
+        let rendered = ApiError::from_rejection(StatusCode::BAD_REQUEST, "why".to_string());
+        assert_eq!(rendered.status, StatusCode::BAD_REQUEST);
+        assert_eq!(rendered.detail, "why", "axum's own message is kept");
+        assert_eq!(ApiError::method_not_allowed().title, "method not allowed");
     }
 
     #[test]

--- a/crates/service/src/rest/graph.rs
+++ b/crates/service/src/rest/graph.rs
@@ -10,21 +10,26 @@ use axum::Json;
 use axum::extract::State;
 use serde::Deserialize;
 use serde_json::Value;
+use utoipa::IntoParams;
 
-use super::{ApiError, ApiQuery, RestState};
+use super::{ApiError, ApiQuery, ProblemDetail, RestState};
 
 /// The query string `GET /graph` takes. `anchor` has no default: a traversal
 /// with nothing to start from is not a request this route can answer, so a
 /// missing one is rejected by the extractor as a 400 rather than guessed at.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
 pub struct GraphQuery {
     /// A `crystalline://domain/permalink` anchor. A `/*` suffix globs a prefix.
+    #[param(example = "crystalline://eng/alpha")]
     anchor: String,
     /// Traversal depth, 1 or 2. Defaults to 1.
     #[serde(default)]
+    #[param(example = 1)]
     depth: Option<u8>,
     /// The most nodes to return. Defaults to 100, capped by the engine.
     #[serde(default)]
+    #[param(example = 100)]
     max_nodes: Option<usize>,
 }
 
@@ -55,6 +60,71 @@ const DEFAULT_MAX_NODES: usize = 100;
 /// The three ways an anchor can be wrong stay distinguishable, as on `/context`:
 /// absent is a 400 from the extractor, one that is not a `crystalline://` URL is
 /// the engine's own 422, and one pointing at an engram nobody wrote is a 404.
+#[utoipa::path(
+    get,
+    path = "/api/v1/graph",
+    tag = "graph",
+    operation_id = "get_graph",
+    params(GraphQuery),
+    responses(
+        (
+            status = 200,
+            description = "The engine's own graph payload, unchanged: the flat \
+                           node and edge lists a renderer draws from, with \
+                           `truncated` saying whether the node cap cut anything. \
+                           `id` is opaque and stable only within one response; \
+                           the address is `crystalline://domain/permalink`.",
+            body = Object,
+            example = json!({
+                "nodes": [
+                    {
+                        "id": 1,
+                        "domain": "eng",
+                        "permalink": "alpha",
+                        "title": "Alpha",
+                        "status": "stable",
+                        "type": "engram"
+                    },
+                    {
+                        "id": 2,
+                        "domain": "eng",
+                        "permalink": "notes/beta",
+                        "title": "Beta",
+                        "status": "deprecated",
+                        "type": "engram"
+                    }
+                ],
+                "edges": [{ "from": 1, "to": 2, "rel_type": "relates_to" }],
+                "truncated": false
+            }),
+        ),
+        (
+            status = 400,
+            description = "The query string will not parse, `anchor` included: it \
+                           has no default.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 404,
+            description = "The anchor names no engram.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 422,
+            description = "The anchor is not a `crystalline://` URL.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn graph(
     State(state): State<RestState>,
     ApiQuery(query): ApiQuery<GraphQuery>,

--- a/crates/service/src/rest/graph.rs
+++ b/crates/service/src/rest/graph.rs
@@ -112,6 +112,12 @@ const DEFAULT_MAX_NODES: usize = 100;
             content_type = "application/problem+json",
         ),
         (
+            status = 403,
+            description = "The trusted-header identity names a disabled account.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
             status = 404,
             description = "The anchor names no engram.",
             body = ProblemDetail,

--- a/crates/service/src/rest/graph.rs
+++ b/crates/service/src/rest/graph.rs
@@ -1,0 +1,71 @@
+//! The neighborhood graph: the nodes and typed edges around one anchor, in the
+//! flat shape a graph renderer draws from.
+//!
+//! This is the same traversal `/context` runs, answered differently rather than
+//! answered again: `/context` ranks a neighborhood for reading, this one reports
+//! it for drawing. Both hand the engine's own JSON back unchanged, so the two
+//! agree about what is connected to what.
+
+use axum::Json;
+use axum::extract::State;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::{ApiError, ApiQuery, RestState};
+
+/// The query string `GET /graph` takes. `anchor` has no default: a traversal
+/// with nothing to start from is not a request this route can answer, so a
+/// missing one is rejected by the extractor as a 400 rather than guessed at.
+#[derive(Debug, Deserialize)]
+pub struct GraphQuery {
+    /// A `crystalline://domain/permalink` anchor. A `/*` suffix globs a prefix.
+    anchor: String,
+    /// Traversal depth, 1 or 2. Defaults to 1.
+    #[serde(default)]
+    depth: Option<u8>,
+    /// The most nodes to return. Defaults to 100, capped by the engine.
+    #[serde(default)]
+    max_nodes: Option<usize>,
+}
+
+/// The hops walked when the caller does not say. One: an engram page opens on
+/// its immediate neighborhood, and a second hop is a deliberate act.
+const DEFAULT_DEPTH: u8 = 1;
+
+/// The nodes returned when the caller does not say. Below the engine's ceiling
+/// on purpose: it is what one view renders comfortably, and a client that wants
+/// the ceiling asks for it.
+const DEFAULT_MAX_NODES: usize = 100;
+
+/// `GET /graph` - the nodes and typed edges around an anchor: every node with
+/// the address, title, status and type a client labels it with, every edge with
+/// its direction and `rel_type`, and `truncated` saying whether the node cap
+/// cut anything.
+///
+/// Both bounds are the server's to decide: the engine clamps the depth to one or
+/// two hops and the node count to its own ceiling, so a hand-written URL can ask
+/// neither for nothing nor for a whole index in one payload. A clamped request
+/// is answered rather than refused - the honest report of what was returned is
+/// the payload itself.
+///
+/// Retired engrams are part of the answer, carrying their status. The graph is
+/// the shape of what is written, and a client fades what is retired rather than
+/// being served a graph with the retired nodes already cut out of it.
+///
+/// The three ways an anchor can be wrong stay distinguishable, as on `/context`:
+/// absent is a 400 from the extractor, one that is not a `crystalline://` URL is
+/// the engine's own 422, and one pointing at an engram nobody wrote is a 404.
+pub async fn graph(
+    State(state): State<RestState>,
+    ApiQuery(query): ApiQuery<GraphQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let value = state
+        .engine
+        .graph_neighborhood(
+            &query.anchor,
+            query.depth.unwrap_or(DEFAULT_DEPTH),
+            query.max_nodes.unwrap_or(DEFAULT_MAX_NODES),
+        )
+        .await?;
+    Ok(Json(value))
+}

--- a/crates/service/src/rest/mod.rs
+++ b/crates/service/src/rest/mod.rs
@@ -58,6 +58,20 @@ impl RestState {
             login_slots: auth::login_slots(),
         })
     }
+
+    /// Run `work` holding one of the [`LOGIN_SLOTS`] password-work permits.
+    ///
+    /// The semaphore is deliberately not exposed itself: password work is the
+    /// only thing it may gate, and a handler that hashes has to go through here
+    /// rather than reach for the field. See [`auth::with_login_slot`] for what
+    /// the cap is for and why the admin routes share the login one instead of
+    /// getting a second.
+    pub(super) async fn with_login_slot<F: std::future::Future>(
+        &self,
+        work: F,
+    ) -> Result<F::Output, ApiError> {
+        auth::with_login_slot(&self.login_slots, work).await
+    }
 }
 
 /// Build the REST router. Mounted with `nest("/api/v1", ...)`, so the paths
@@ -142,7 +156,69 @@ fn csv(raw: Option<&str>) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
+
+    /// A [`RestState`] over an empty in-memory engine and a fresh auth
+    /// database: enough to exercise the state's own machinery without a domain
+    /// on disk behind it.
+    async fn test_state() -> (tempfile::TempDir, RestState) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = crystalline_index::TursoStore::open_in_memory()
+            .await
+            .unwrap();
+        let engine = Arc::new(Engine::new(
+            Arc::new(tokio::sync::Mutex::new(store)),
+            crystalline_core::config::GlobalConfig::default(),
+            None,
+            None,
+        ));
+        let auth = Arc::new(
+            AuthStore::open(&dir.path().join("web-auth.db"))
+                .await
+                .unwrap(),
+        );
+        (dir, RestState::new(engine, auth).unwrap())
+    }
+
+    /// The cap the admin routes borrow: whatever calls
+    /// [`RestState::with_login_slot`] - a login, an account being created, a
+    /// password being reset - only [`LOGIN_SLOTS`] of them hold argon2's
+    /// working memory at a time. Asserted on the mechanism, by counting how
+    /// many bodies are inside at once, rather than on how long anything took.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn the_login_limiter_caps_every_caller_that_hashes() {
+        let (_dir, state) = test_state().await;
+        let live = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+
+        let mut tasks = Vec::new();
+        for _ in 0..32 {
+            let (state, live, peak) = (state.clone(), live.clone(), peak.clone());
+            tasks.push(tokio::spawn(async move {
+                state
+                    .with_login_slot(async {
+                        let now = live.fetch_add(1, Ordering::SeqCst) + 1;
+                        peak.fetch_max(now, Ordering::SeqCst);
+                        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                        live.fetch_sub(1, Ordering::SeqCst);
+                    })
+                    .await
+                    .unwrap();
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+        assert_eq!(live.load(Ordering::SeqCst), 0, "every permit came back");
+        let peak = peak.load(Ordering::SeqCst);
+        assert!(
+            peak <= LOGIN_SLOTS,
+            "at most {LOGIN_SLOTS} may hash at once, saw {peak}"
+        );
+        assert!(peak > 1, "and the limiter must not serialize them either");
+    }
 
     #[test]
     fn a_comma_list_splits_and_drops_the_empties() {

--- a/crates/service/src/rest/mod.rs
+++ b/crates/service/src/rest/mod.rs
@@ -9,6 +9,7 @@ mod discovery;
 mod domains;
 mod engrams;
 mod error;
+mod graph;
 
 use std::sync::Arc;
 
@@ -87,6 +88,7 @@ pub fn router(state: RestState) -> Router {
         .route("/vocabulary", get(discovery::vocabulary))
         .route("/context", get(discovery::context))
         .route("/activity", get(discovery::activity))
+        .route("/graph", get(graph::graph))
         .fallback(unknown_path)
         // Applies to every method router registered above it, so it stays
         // below the routes and above the guard.

--- a/crates/service/src/rest/mod.rs
+++ b/crates/service/src/rest/mod.rs
@@ -10,11 +10,12 @@ mod domains;
 mod engrams;
 mod error;
 mod graph;
+mod users_api;
 
 use std::sync::Arc;
 
 use axum::Router;
-use axum::routing::{get, post};
+use axum::routing::{get, patch, post};
 use tokio::sync::Semaphore;
 
 pub use auth::{
@@ -89,6 +90,14 @@ pub fn router(state: RestState) -> Router {
         .route("/context", get(discovery::context))
         .route("/activity", get(discovery::activity))
         .route("/graph", get(graph::graph))
+        // Admin only, enforced inside the handlers: the guard below stops at
+        // viewer. See [`users_api`] for the three rules these first mutating
+        // routes are held to.
+        .route("/users", get(users_api::list).post(users_api::create))
+        .route(
+            "/users/{name}",
+            patch(users_api::update).delete(users_api::remove),
+        )
         .fallback(unknown_path)
         // Applies to every method router registered above it, so it stays
         // below the routes and above the guard.

--- a/crates/service/src/rest/mod.rs
+++ b/crates/service/src/rest/mod.rs
@@ -22,9 +22,93 @@ pub use auth::{
     AuthCfg, CSRF_HEADER, Caller, Identity, LOGIN_SLOTS, SESSION_COOKIE, SESSION_TTL_SECS,
 };
 pub use auth_store::*;
-pub use error::{ApiError, ApiJson, ApiPath, ApiQuery};
+pub use error::{ApiError, ApiJson, ApiPath, ApiQuery, ProblemDetail};
 
 use crate::engine::Engine;
+
+/// The OpenAPI 3.1 document for this surface, assembled from the
+/// `#[utoipa::path]` annotation on every handler.
+///
+/// `info.version` is the *API* version, pinned to `v1` to match the `/api/v1`
+/// mount, rather than the crate version utoipa would otherwise take from
+/// `Cargo.toml`. That is what makes the committed snapshot survive a release:
+/// bumping the workspace version must not rewrite an artifact the UI's client
+/// generator is compiled against, and the crate version is already reported by
+/// `GET /auth/me` for the client that wants it.
+#[derive(utoipa::OpenApi)]
+#[openapi(
+    info(
+        title = "Crystalline Fluid API",
+        version = "v1",
+        description = "The JSON API `crystalline serve --http` mounts at \
+                       `/api/v1`, the surface the Fluid UI talks to. Read-only \
+                       in this version apart from the session and account \
+                       routes.\n\nEvery path but `/auth/login`, `/auth/logout` \
+                       and `/auth/me` is closed by default: a request that \
+                       carries no identity is answered 401 ahead of routing, so \
+                       an unauthenticated caller never learns which paths \
+                       exist. Every failure is an RFC 9457 problem detail sent \
+                       as `application/problem+json`.\n\nThe payloads marked as \
+                       generic objects are the engine's own JSON, passed \
+                       through unchanged so this API and the MCP tools stay one \
+                       source of truth; each carries an example of the shape it \
+                       answers with.",
+        license(name = "AGPL-3.0-or-later"),
+    ),
+    tags(
+        (name = "meta", description = "The API's description of itself."),
+        (name = "auth", description = "Sessions and the capability probe."),
+        (name = "domains", description = "Which domains this instance serves and what each holds."),
+        (name = "engrams", description = "Listing and reading engrams."),
+        (name = "discovery", description = "Search, vocabulary, context and recent activity."),
+        (name = "graph", description = "The neighborhood graph around an anchor."),
+        (name = "users", description = "Account management. Admin only."),
+    ),
+    paths(
+        openapi_json,
+        auth::login,
+        auth::logout,
+        auth::me,
+        domains::list,
+        domains::tree,
+        domains::manifest,
+        engrams::list,
+        engrams::detail,
+        discovery::search,
+        discovery::vocabulary,
+        discovery::context,
+        discovery::activity,
+        graph::graph,
+        users_api::list,
+        users_api::create,
+        users_api::update,
+        users_api::remove,
+    ),
+    components(schemas(
+        ProblemDetail,
+        User,
+        Role,
+        auth::LoginBody,
+        auth::LoginResponse,
+        auth::LogoutResponse,
+        auth::MeResponse,
+        users_api::CreateBody,
+        users_api::PatchBody,
+        users_api::UserResponse,
+        users_api::UsersResponse,
+    )),
+)]
+struct ApiDoc;
+
+/// This surface's OpenAPI document.
+///
+/// One definition with two consumers: the [`openapi_json`] route serves it, and
+/// `tests/openapi_snapshot.rs` compares it against the committed
+/// `openapi/fluid-v1.json` the UI generates its client types from. Neither can
+/// drift from the annotations without the other noticing.
+pub fn openapi_document() -> utoipa::openapi::OpenApi {
+    <ApiDoc as utoipa::OpenApi>::openapi()
+}
 
 /// What every REST handler is given: the one shared engine the daemon owns,
 /// the one auth store this process holds open, and the auth settings resolved
@@ -86,6 +170,7 @@ impl RestState {
 /// route added below would serve unguarded.
 pub fn router(state: RestState) -> Router {
     Router::new()
+        .route("/openapi.json", get(openapi_json))
         .route("/auth/login", post(auth::login))
         .route("/auth/logout", post(auth::logout))
         .route("/auth/me", get(auth::me))
@@ -121,6 +206,46 @@ pub fn router(state: RestState) -> Router {
             auth::guard,
         ))
         .with_state(state)
+}
+
+/// `GET /openapi.json` - this API's own OpenAPI 3.1 document.
+///
+/// Served *behind* the viewer guard, with no [`auth`] `PUBLIC_PATHS` exception:
+/// the description of a closed API is part of what being closed by default
+/// protects, and an unauthenticated caller learning every path and parameter
+/// would undo what the guard's answering 401 ahead of routing is for. Nothing
+/// is lost by that. The document is a committed artifact at
+/// `crates/service/openapi/fluid-v1.json`, and the UI's client generator reads
+/// the file rather than this route, so tooling never needs a running server -
+/// let alone an unauthenticated one.
+#[utoipa::path(
+    get,
+    path = "/api/v1/openapi.json",
+    tag = "meta",
+    operation_id = "get_openapi_document",
+    summary = "This API's own OpenAPI 3.1 document.",
+    description = "Served behind the viewer guard like every other data route: \
+                   the description of a closed API is part of what being closed \
+                   by default protects. Tooling does not need this route, since \
+                   the document is a committed artifact in the repository at \
+                   `crates/service/openapi/fluid-v1.json`.",
+    responses(
+        (
+            status = 200,
+            description = "This document. Behind the viewer guard like every \
+                           other data route.",
+            body = Object,
+        ),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
+async fn openapi_json() -> axum::Json<utoipa::openapi::OpenApi> {
+    axum::Json(openapi_document())
 }
 
 /// Answer an unknown `/api/v1` path in problem+json rather than letting it

--- a/crates/service/src/rest/mod.rs
+++ b/crates/service/src/rest/mod.rs
@@ -5,6 +5,7 @@
 
 mod auth;
 mod auth_store;
+mod discovery;
 mod domains;
 mod engrams;
 mod error;
@@ -82,6 +83,10 @@ pub fn router(state: RestState) -> Router {
             "/domains/{domain}/engrams/{*permalink}",
             get(engrams::detail),
         )
+        .route("/search", get(discovery::search))
+        .route("/vocabulary", get(discovery::vocabulary))
+        .route("/context", get(discovery::context))
+        .route("/activity", get(discovery::activity))
         .fallback(unknown_path)
         // Applies to every method router registered above it, so it stays
         // below the routes and above the guard.
@@ -103,4 +108,45 @@ async fn unknown_path() -> ApiError {
 /// problem+json rather than axum's empty 405.
 async fn wrong_method() -> ApiError {
     ApiError::method_not_allowed()
+}
+
+/// Split a comma-separated query parameter into the `Vec<String>` the engine's
+/// params take, dropping the whitespace and the empties a hand-written URL
+/// brings with it: `?tags=a,%20b,` asks for `a` and `b` rather than for a tag
+/// that is one space long, and an absent parameter asks for nothing at all.
+///
+/// Every list-valued parameter on this surface arrives this way rather than as a
+/// repeated key: one spelling for a caller to learn, and the same one the engine
+/// then sees whichever endpoint it came through.
+fn csv(raw: Option<&str>) -> Vec<String> {
+    raw.map(|raw| {
+        raw.split(',')
+            .map(str::trim)
+            .filter(|part| !part.is_empty())
+            .map(str::to_string)
+            .collect()
+    })
+    .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_comma_list_splits_and_drops_the_empties() {
+        assert_eq!(csv(Some("a,b")), vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(
+            csv(Some(" a , b ")),
+            vec!["a".to_string(), "b".to_string()],
+            "a hand-written list is not punished for its spaces"
+        );
+        assert_eq!(csv(Some("a,,")), vec!["a".to_string()]);
+        assert!(
+            csv(Some("")).is_empty(),
+            "no values rather than one empty one"
+        );
+        assert!(csv(Some(" , ")).is_empty());
+        assert!(csv(None).is_empty(), "an absent parameter asks for nothing");
+    }
 }

--- a/crates/service/src/rest/mod.rs
+++ b/crates/service/src/rest/mod.rs
@@ -242,6 +242,12 @@ pub fn router(state: RestState) -> Router {
             body = ProblemDetail,
             content_type = "application/problem+json",
         ),
+        (
+            status = 403,
+            description = "The trusted-header identity names a disabled account.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
     ),
 )]
 async fn openapi_json() -> axum::Json<utoipa::openapi::OpenApi> {

--- a/crates/service/src/rest/mod.rs
+++ b/crates/service/src/rest/mod.rs
@@ -6,6 +6,7 @@
 mod auth;
 mod auth_store;
 mod domains;
+mod engrams;
 mod error;
 
 use std::sync::Arc;
@@ -74,6 +75,13 @@ pub fn router(state: RestState) -> Router {
         .route("/domains", get(domains::list))
         .route("/domains/{domain}/tree", get(domains::tree))
         .route("/domains/{domain}/manifest", get(domains::manifest))
+        .route("/domains/{domain}/engrams", get(engrams::list))
+        // A wildcard, not a segment: a permalink is a path, so an engram in a
+        // subfolder carries the slashes with it.
+        .route(
+            "/domains/{domain}/engrams/{*permalink}",
+            get(engrams::detail),
+        )
         .fallback(unknown_path)
         // Applies to every method router registered above it, so it stays
         // below the routes and above the guard.

--- a/crates/service/src/rest/mod.rs
+++ b/crates/service/src/rest/mod.rs
@@ -5,6 +5,7 @@
 
 mod auth;
 mod auth_store;
+mod domains;
 mod error;
 
 use std::sync::Arc;
@@ -17,7 +18,7 @@ pub use auth::{
     AuthCfg, CSRF_HEADER, Caller, Identity, LOGIN_SLOTS, SESSION_COOKIE, SESSION_TTL_SECS,
 };
 pub use auth_store::*;
-pub use error::ApiError;
+pub use error::{ApiError, ApiJson, ApiPath, ApiQuery};
 
 use crate::engine::Engine;
 
@@ -62,13 +63,21 @@ impl RestState {
 /// [`auth::guard`] is layered over the whole thing, fallback included, so
 /// identity resolution, the CSRF check and the closed-by-default rule apply to
 /// every path under the mount - including the ones later tasks add, which are
-/// guarded the moment they are registered.
+/// guarded the moment they are registered. Every route therefore belongs
+/// *above* the `.layer` call: axum only wraps what was declared before it, so a
+/// route added below would serve unguarded.
 pub fn router(state: RestState) -> Router {
     Router::new()
         .route("/auth/login", post(auth::login))
         .route("/auth/logout", post(auth::logout))
         .route("/auth/me", get(auth::me))
+        .route("/domains", get(domains::list))
+        .route("/domains/{domain}/tree", get(domains::tree))
+        .route("/domains/{domain}/manifest", get(domains::manifest))
         .fallback(unknown_path)
+        // Applies to every method router registered above it, so it stays
+        // below the routes and above the guard.
+        .method_not_allowed_fallback(wrong_method)
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth::guard,
@@ -80,4 +89,10 @@ pub fn router(state: RestState) -> Router {
 /// fall through to the MCP transport, which would reply in its own shape.
 async fn unknown_path() -> ApiError {
     ApiError::not_found("unknown API path")
+}
+
+/// Answer a known path asked for with a method it does not serve, in
+/// problem+json rather than axum's empty 405.
+async fn wrong_method() -> ApiError {
+    ApiError::method_not_allowed()
 }

--- a/crates/service/src/rest/users_api.rs
+++ b/crates/service/src/rest/users_api.rs
@@ -1,0 +1,435 @@
+//! The accounts that may sign in to this instance, managed over HTTP.
+//!
+//! The same four operations `crystalline users` performs, behind the same
+//! store, so the CLI and the UI are one source of truth rather than two: the
+//! listing is the `{"users": [...]}` envelope `users list --json` already
+//! prints, and every refusal here is the store's own, surfaced with a status a
+//! browser client can branch on.
+//!
+//! These are the first mutating routes on this surface, so three rules are
+//! written down rather than left to be re-derived:
+//!
+//! 1. **Admin only, in the handler.** [`super::auth::guard`] enforces viewer
+//!    and nothing more, so every handler below opens with
+//!    [`Identity::require_admin`]. A route added here without it would be
+//!    reachable by any account that can log in.
+//! 2. **Cross-site protection.** A cookie session must echo its CSRF token on
+//!    every unsafe method; the middleware does that. The other two identities
+//!    carry no token, so each needs its own reason to be safe:
+//!    - The anonymous viewer never gets past `require_admin`. It has no
+//!      account, so it is answered 401 rather than served.
+//!    - A trusted-header admin is protected by the request shape. `PATCH` and
+//!      `DELETE` are not simple methods, so a cross-origin caller cannot send
+//!      them at all without a CORS preflight; `POST` it can send, but only with
+//!      `application/x-www-form-urlencoded`, `text/plain` or
+//!      `multipart/form-data`, and [`create`] takes its body through
+//!      [`ApiJson`], which demands `application/json` and refuses all three.
+//!      **No CORS layer exists on this surface and one must not be added
+//!      without revisiting the CSRF check in [`super::auth`] first**: a
+//!      permitted preflight would remove the only thing standing between
+//!      another origin and a trusted-header admin's account.
+//! 3. **No lockout escape hatch.** The store refuses to remove, disable or
+//!    demote the last enabled admin, and that refusal is passed through as a
+//!    409 rather than overridden by any flag. An installation must never be
+//!    lockable out of its own user management over HTTP; `crystalline users`,
+//!    which runs on the machine that holds the database, is the recovery path.
+//!    For the same reason an admin may not delete or disable *itself*, which is
+//!    a distinct refusal: another admin may well exist, and the account being
+//!    protected is the caller's own way back in.
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use serde::Deserialize;
+use serde_json::{Value, json};
+
+use super::auth::{Caller, Identity};
+use super::auth_store::{Role, User};
+use super::{ApiError, ApiJson, ApiPath, RestState};
+
+/// `GET /users` - every account, by name.
+///
+/// [`User`] carries no password material, so the rows go out as they come back
+/// from the store. Admin only: the account list names every way into the
+/// instance and who holds it.
+pub async fn list(
+    State(state): State<RestState>,
+    identity: Identity,
+) -> Result<Json<Value>, ApiError> {
+    identity.require_admin()?;
+    let users = state
+        .auth
+        .list_users()
+        .await
+        .map_err(|e| store_error(e, ""))?;
+    Ok(Json(json!({ "users": users })))
+}
+
+/// What `POST /users` takes. `display` defaults to the name as typed, matching
+/// `crystalline users add`, and `email` is optional and never used for login.
+#[derive(Debug, Deserialize)]
+pub struct CreateBody {
+    /// The login name, in any casing: the store folds it.
+    name: String,
+    /// Human-readable name for the UI. Defaults to `name` as typed.
+    #[serde(default)]
+    display: Option<String>,
+    /// Optional contact address.
+    #[serde(default)]
+    email: Option<String>,
+    /// What the new account may do.
+    role: Role,
+    /// The initial password. Never stored in the clear; the store hashes it.
+    password: String,
+}
+
+/// `POST /users` - add an account, answering 201 with the account as stored.
+///
+/// The response is read back out of the store rather than echoed from the
+/// request, so what the client renders is what was written: the folded name,
+/// the defaulted display name, and the disabled flag the row starts with.
+pub async fn create(
+    State(state): State<RestState>,
+    identity: Identity,
+    ApiJson(body): ApiJson<CreateBody>,
+) -> Result<(StatusCode, Json<Value>), ApiError> {
+    identity.require_admin()?;
+    check_password(&body.password)?;
+    // The login name as typed makes the better default display name: the store
+    // folds the login name but keeps this one as given.
+    let display = body.display.unwrap_or_else(|| body.name.trim().to_string());
+    state
+        .auth
+        .add_user(
+            &body.name,
+            &display,
+            body.email.as_deref(),
+            body.role,
+            &body.password,
+        )
+        .await
+        .map_err(|e| store_error(e, &body.name))?;
+    let user = read_back(&state, &body.name).await?;
+    Ok((StatusCode::CREATED, Json(json!({ "user": user }))))
+}
+
+/// What `PATCH /users/{name}` takes: whichever of the three an admin wants to
+/// change. All absent is refused rather than served as a no-op, so a client
+/// sending the wrong field names hears about it.
+#[derive(Debug, Deserialize)]
+pub struct PatchBody {
+    /// The new role.
+    #[serde(default)]
+    role: Option<Role>,
+    /// Whether the account is disabled. A disabled account can neither log in
+    /// nor use a session it already holds.
+    #[serde(default)]
+    disabled: Option<bool>,
+    /// A replacement password.
+    #[serde(default)]
+    password: Option<String>,
+}
+
+/// `PATCH /users/{name}` - change a role, a disabled flag, a password, or any
+/// combination, answering with the account as it now stands.
+///
+/// Every check runs before the first write, so a request that will be refused
+/// changes nothing. The writes themselves are one store call each rather than
+/// one transaction: the store's guarded statements each own their own
+/// invariant, and a failure part-way leaves the earlier fields applied and says
+/// which operation was refused. That is visible to a client only in the
+/// pathological case of a concurrent edit racing this one, since the refusals a
+/// caller can provoke on purpose - the last-admin guard and an unknown account
+/// - are decided identically by all three statements.
+pub async fn update(
+    State(state): State<RestState>,
+    identity: Identity,
+    ApiPath(name): ApiPath<String>,
+    ApiJson(body): ApiJson<PatchBody>,
+) -> Result<Json<Value>, ApiError> {
+    let caller = identity.require_admin()?;
+    if body.role.is_none() && body.disabled.is_none() && body.password.is_none() {
+        return Err(ApiError::unprocessable(
+            "this request changes nothing: send role, disabled or password",
+        ));
+    }
+    if let Some(password) = &body.password {
+        check_password(password)?;
+    }
+    if body.disabled == Some(true) {
+        refuse_self(&caller, &name, "disable")?;
+    }
+    if let Some(role) = body.role {
+        state
+            .auth
+            .set_role(&name, role)
+            .await
+            .map_err(|e| store_error(e, &name))?;
+    }
+    if let Some(disabled) = body.disabled {
+        state
+            .auth
+            .set_disabled(&name, disabled)
+            .await
+            .map_err(|e| store_error(e, &name))?;
+    }
+    if let Some(password) = &body.password {
+        state
+            .auth
+            .set_password(&name, password)
+            .await
+            .map_err(|e| store_error(e, &name))?;
+    }
+    let user = read_back(&state, &name).await?;
+    Ok(Json(json!({ "user": user })))
+}
+
+/// `DELETE /users/{name}` - remove an account and every session it holds,
+/// answering 204.
+///
+/// An admin may not remove its own account (409), and the store refuses to
+/// remove the last enabled admin whoever asks (409 as well, in its own words).
+pub async fn remove(
+    State(state): State<RestState>,
+    identity: Identity,
+    ApiPath(name): ApiPath<String>,
+) -> Result<StatusCode, ApiError> {
+    let caller = identity.require_admin()?;
+    refuse_self(&caller, &name, "delete")?;
+    state
+        .auth
+        .remove_user(&name)
+        .await
+        .map_err(|e| store_error(e, &name))?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// Refuse an admin acting destructively on its own account. `verb` names what
+/// was asked for, and the message is deliberately unlike the store's last-admin
+/// one: this refusal can fire while other admins exist, and what it protects is
+/// the caller's own session rather than the installation.
+fn refuse_self(caller: &Caller, target: &str, verb: &str) -> Result<(), ApiError> {
+    if folded(target) != caller.name() {
+        return Ok(());
+    }
+    Err(ApiError::conflict(format!(
+        "refusing to {verb} your own account ('{}'): ask another admin to do it, \
+         or use `crystalline users` on the server",
+        caller.name()
+    )))
+}
+
+/// Refuse an empty password before it is hashed into an account nobody can log
+/// in as. The store would accept it; `crystalline users` refuses it, and this
+/// surface matches.
+fn check_password(password: &str) -> Result<(), ApiError> {
+    if password.is_empty() {
+        return Err(ApiError::unprocessable(
+            "the password is empty; pick one with at least one character",
+        ));
+    }
+    Ok(())
+}
+
+/// The account as it now stands, read back out of the store after a write.
+///
+/// The listing rather than a single-row read because the store exposes no
+/// by-name getter, and the cost is one small query over a table with a handful
+/// of rows in it.
+async fn read_back(state: &RestState, name: &str) -> Result<User, ApiError> {
+    let name = folded(name);
+    state
+        .auth
+        .list_users()
+        .await
+        .map_err(|e| store_error(e, &name))?
+        .into_iter()
+        .find(|user| user.name == name)
+        .ok_or_else(|| {
+            // Only reachable if something removed the account between the write
+            // and this read. The write did happen, so this is not a failure of
+            // the request - but answering with a body that was made up here
+            // would be worse than saying the read did not work.
+            ApiError::internal(format!(
+                "the account '{name}' was written but could not be read back"
+            ))
+        })
+}
+
+/// The form the store keys on: trimmed and lowercased, mirroring the store's
+/// own `normalize_name`.
+///
+/// Mirrored rather than shared because the store's folding is private to it and
+/// is the authority; nothing here writes with this value, it only compares
+/// (`refuse_self`) and looks up (`read_back`). `folding_matches_the_store`
+/// pins the two together, so a change on either side fails a test rather than
+/// silently opening a way around the self-account check.
+fn folded(name: &str) -> String {
+    name.trim().to_lowercase()
+}
+
+/// Classify an [`AuthStore`](super::AuthStore) failure for the wire.
+///
+/// The store reports in `anyhow`, so this reads its message. That is a string
+/// seam, and it is tested rather than assumed: `store_errors_are_classified`
+/// below drives a real store into each of these failures and asserts the status
+/// that comes out, so rewording a message on the store side fails here instead
+/// of quietly turning a 409 into a 500.
+///
+/// Anything unrecognized stays a 500: an error this layer cannot name is not
+/// the caller's fault by default. `subject` is the account the failed call was
+/// about, for the one message that has to be rewritten rather than passed
+/// through; pass `""` where there is no single one.
+fn store_error(e: anyhow::Error, subject: &str) -> ApiError {
+    let detail = format!("{e:#}");
+    if detail.contains("UNIQUE constraint") {
+        // The store's message here is the database's, and it names a column.
+        // The caller gets product copy instead, naming the account and what to
+        // do about it, the way `crystalline users add` does.
+        return ApiError::conflict(format!(
+            "a user named '{}' already exists; edit that account instead",
+            folded(subject)
+        ));
+    }
+    if detail.contains("the last admin") {
+        return ApiError::conflict(detail);
+    }
+    if detail.contains("no such user") {
+        return ApiError::not_found(detail);
+    }
+    if detail.contains("a user name cannot be empty") {
+        return ApiError::unprocessable(detail);
+    }
+    ApiError::internal(detail)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rest::AuthStore;
+
+    async fn store() -> (tempfile::TempDir, AuthStore) {
+        let dir = tempfile::tempdir().unwrap();
+        let store = AuthStore::open(&dir.path().join("web-auth.db"))
+            .await
+            .unwrap();
+        (dir, store)
+    }
+
+    /// The classifier against the store's real errors rather than against
+    /// strings written down twice: every one of these is provoked by asking the
+    /// store to do the thing it refuses.
+    #[tokio::test]
+    async fn store_errors_are_classified() {
+        let (_dir, store) = store().await;
+        store
+            .add_user("ada", "Ada", None, Role::Admin, "s3cret")
+            .await
+            .unwrap();
+
+        let duplicate = store
+            .add_user("ADA", "Ada again", None, Role::Viewer, "other")
+            .await
+            .expect_err("the primary key refuses a second 'ada'");
+        let api = store_error(duplicate, "ADA");
+        assert_eq!(api.status, StatusCode::CONFLICT);
+        assert!(
+            !api.detail.contains("UNIQUE"),
+            "in product copy: {}",
+            api.detail
+        );
+        assert!(
+            api.detail.contains("'ada'"),
+            "naming the account as it is stored: {}",
+            api.detail
+        );
+
+        let last_admin = store
+            .set_role("ada", Role::Viewer)
+            .await
+            .expect_err("the last admin cannot be demoted");
+        let api = store_error(last_admin, "ada");
+        assert_eq!(api.status, StatusCode::CONFLICT);
+        assert!(
+            api.detail.contains("last admin"),
+            "the store's own words: {}",
+            api.detail
+        );
+
+        let removed = store
+            .remove_user("ada")
+            .await
+            .expect_err("nor removed")
+            .to_string();
+        assert!(removed.contains("last admin"), "{removed}");
+
+        let missing = store
+            .set_password("ghost", "s3cret")
+            .await
+            .expect_err("no such account");
+        let api = store_error(missing, "ghost");
+        assert_eq!(api.status, StatusCode::NOT_FOUND);
+        assert!(api.detail.contains("ghost"), "{}", api.detail);
+
+        let empty = store
+            .set_disabled("   ", true)
+            .await
+            .expect_err("an empty name is not a name");
+        assert_eq!(
+            store_error(empty, "   ").status,
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+
+        assert_eq!(
+            store_error(anyhow::anyhow!("the disk fell over"), "ada").status,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "an error this layer cannot name is not the caller's fault"
+        );
+    }
+
+    /// [`folded`] and the store must agree, because the self-account check
+    /// compares this layer's folding against the name the store handed back.
+    #[tokio::test]
+    async fn folding_matches_the_store() {
+        let (_dir, store) = store().await;
+        for raw in ["  AdA ", "ADA", "ada", "Ada\t"] {
+            store
+                .add_user(raw, "Ada", None, Role::Viewer, "s3cret")
+                .await
+                .ok();
+            let users = store.list_users().await.unwrap();
+            assert_eq!(users.len(), 1, "every spelling is the one account");
+            assert_eq!(users[0].name, folded(raw), "'{raw}' folds the same way");
+        }
+    }
+
+    /// The self-account refusal fires on the folded name, so a differently
+    /// spelled path is not a way around it, and leaves another account alone.
+    #[test]
+    fn an_admin_cannot_target_its_own_account() {
+        let caller = Caller::Account(User {
+            name: "root".to_string(),
+            display: "Root".to_string(),
+            email: None,
+            role: Role::Admin,
+            disabled: false,
+        });
+        for spelling in ["root", "ROOT", "  Root  "] {
+            let refused = refuse_self(&caller, spelling, "delete")
+                .expect_err("'{spelling}' is the caller's own account");
+            assert_eq!(refused.status, StatusCode::CONFLICT);
+            assert!(refused.detail.contains("your own account"));
+        }
+        assert!(refuse_self(&caller, "ada", "delete").is_ok());
+    }
+
+    /// An empty password is refused before it reaches the store.
+    #[test]
+    fn an_empty_password_is_refused() {
+        assert_eq!(
+            check_password("").unwrap_err().status,
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+        assert!(check_password(" ").is_ok(), "a space is a character");
+    }
+}

--- a/crates/service/src/rest/users_api.rs
+++ b/crates/service/src/rest/users_api.rs
@@ -67,7 +67,11 @@ pub async fn list(
 
 /// What `POST /users` takes. `display` defaults to the name as typed, matching
 /// `crystalline users add`, and `email` is optional and never used for login.
-#[derive(Debug, Deserialize)]
+///
+/// [`Debug`] is written by hand rather than derived, here and on [`PatchBody`]:
+/// the derived one would print the plaintext password, and this type is one
+/// `tracing::debug!` or one `unwrap` on a rejection away from a log file.
+#[derive(Deserialize)]
 pub struct CreateBody {
     /// The login name, in any casing: the store folds it.
     name: String,
@@ -98,16 +102,19 @@ pub async fn create(
     // The login name as typed makes the better default display name: the store
     // folds the login name but keeps this one as given.
     let display = body.display.unwrap_or_else(|| body.name.trim().to_string());
+    // Under the login limiter: `add_user` hashes with argon2id, which costs
+    // about 19 MiB on a blocking thread, and an admin client looping over a
+    // list of new accounts would otherwise reserve that memory without bound
+    // while logins on the same instance are being held to four.
     state
-        .auth
-        .add_user(
+        .with_login_slot(state.auth.add_user(
             &body.name,
             &display,
             body.email.as_deref(),
             body.role,
             &body.password,
-        )
-        .await
+        ))
+        .await?
         .map_err(|e| store_error(e, &body.name))?;
     let user = read_back(&state, &body.name).await?;
     Ok((StatusCode::CREATED, Json(json!({ "user": user }))))
@@ -116,22 +123,56 @@ pub async fn create(
 /// What `PATCH /users/{name}` takes: whichever of the three an admin wants to
 /// change. All absent is refused rather than served as a no-op, so a client
 /// sending the wrong field names hears about it.
-#[derive(Debug, Deserialize)]
+///
+/// [`Debug`] is hand-written and redacts the password, as on [`CreateBody`].
+#[derive(Deserialize)]
 pub struct PatchBody {
     /// The new role.
     #[serde(default)]
     role: Option<Role>,
-    /// Whether the account is disabled. A disabled account can neither log in
-    /// nor use a session it already holds.
+    /// Whether the account is disabled. Disabling deletes every session the
+    /// account holds, so it is a revocation rather than a flag a later
+    /// re-enabling hands back; it also stops any new login.
     #[serde(default)]
     disabled: Option<bool>,
-    /// A replacement password.
+    /// A replacement password. Setting it revokes every session the account
+    /// holds, so whoever was signed in under the old one is signed out.
     #[serde(default)]
     password: Option<String>,
 }
 
+impl std::fmt::Debug for CreateBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CreateBody")
+            .field("name", &self.name)
+            .field("display", &self.display)
+            .field("email", &self.email)
+            .field("role", &self.role)
+            .field("password", &"<redacted>")
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for PatchBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PatchBody")
+            .field("role", &self.role)
+            .field("disabled", &self.disabled)
+            .field("password", &self.password.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
+}
+
 /// `PATCH /users/{name}` - change a role, a disabled flag, a password, or any
 /// combination, answering with the account as it now stands.
+///
+/// Two of the three fields are revocations as well as edits: setting a password
+/// and disabling an account each delete every session that account holds, in
+/// the store and in the same transaction as the change. That is what makes this
+/// route useful against a compromised account - a reset that left the intruder's
+/// cookie alive for the rest of its 30-day life would be theatre - and it means
+/// an admin resetting their own password signs their own other sessions out too,
+/// this one included.
 ///
 /// Every check runs before the first write, so a request that will be refused
 /// changes nothing. The writes themselves are one store call each rather than
@@ -174,10 +215,10 @@ pub async fn update(
             .map_err(|e| store_error(e, &name))?;
     }
     if let Some(password) = &body.password {
+        // Under the login limiter, for the reason `create` gives.
         state
-            .auth
-            .set_password(&name, password)
-            .await
+            .with_login_slot(state.auth.set_password(&name, password))
+            .await?
             .map_err(|e| store_error(e, &name))?;
     }
     let user = read_back(&state, &name).await?;
@@ -291,11 +332,14 @@ fn store_error(e: anyhow::Error, subject: &str) -> ApiError {
             folded(subject)
         ));
     }
-    if detail.contains("the last admin") {
-        return ApiError::conflict(detail);
-    }
+    // Before the last-admin branch, not after: `no such user: 'the last admin'`
+    // is a legal name for an account nobody created, and reading the refusals
+    // in the other order would answer that miss with a 409.
     if detail.contains("no such user") {
         return ApiError::not_found(detail);
+    }
+    if detail.contains("the last admin") {
+        return ApiError::conflict(detail);
     }
     if detail.contains("a user name cannot be empty") {
         return ApiError::unprocessable(detail);
@@ -356,12 +400,10 @@ mod tests {
             api.detail
         );
 
-        let removed = store
-            .remove_user("ada")
-            .await
-            .expect_err("nor removed")
-            .to_string();
-        assert!(removed.contains("last admin"), "{removed}");
+        let removed = store.remove_user("ada").await.expect_err("nor removed");
+        let api = store_error(removed, "ada");
+        assert_eq!(api.status, StatusCode::CONFLICT);
+        assert!(api.detail.contains("last admin"), "{}", api.detail);
 
         let missing = store
             .set_password("ghost", "s3cret")
@@ -370,6 +412,18 @@ mod tests {
         let api = store_error(missing, "ghost");
         assert_eq!(api.status, StatusCode::NOT_FOUND);
         assert!(api.detail.contains("ghost"), "{}", api.detail);
+
+        // A miss stays a miss even when the account name is the phrase the
+        // last-admin refusal is recognized by, which is why that branch is
+        // read second.
+        let named = store
+            .set_password("the last admin", "s3cret")
+            .await
+            .expect_err("no such account");
+        assert_eq!(
+            store_error(named, "the last admin").status,
+            StatusCode::NOT_FOUND
+        );
 
         let empty = store
             .set_disabled("   ", true)
@@ -421,6 +475,33 @@ mod tests {
             assert!(refused.detail.contains("your own account"));
         }
         assert!(refuse_self(&caller, "ada", "delete").is_ok());
+    }
+
+    /// The plaintext password must never be one `tracing::debug!` away, on
+    /// either body.
+    #[test]
+    fn a_debugged_body_redacts_the_password() {
+        let create: CreateBody = serde_json::from_value(json!({
+            "name": "bob",
+            "role": "viewer",
+            "password": "hunter2",
+        }))
+        .unwrap();
+        let text = format!("{create:?}");
+        assert!(!text.contains("hunter2"), "{text}");
+        assert!(text.contains("<redacted>"), "{text}");
+        assert!(text.contains("bob"), "the rest of the body is still there");
+
+        let patch: PatchBody = serde_json::from_value(json!({"password": "hunter2"})).unwrap();
+        let text = format!("{patch:?}");
+        assert!(!text.contains("hunter2"), "{text}");
+        assert!(text.contains("<redacted>"), "{text}");
+
+        let empty: PatchBody = serde_json::from_value(json!({})).unwrap();
+        assert!(
+            format!("{empty:?}").contains("None"),
+            "an absent password still reads as absent"
+        );
     }
 
     /// An empty password is refused before it reaches the store.

--- a/crates/service/src/rest/users_api.rs
+++ b/crates/service/src/rest/users_api.rs
@@ -86,7 +86,8 @@ pub struct UserResponse {
         ),
         (
             status = 403,
-            description = "The caller is not an admin.",
+            description = "The caller is not an admin, or the trusted-header \
+                           identity names a disabled account.",
             body = ProblemDetail,
             content_type = "application/problem+json",
         ),
@@ -160,8 +161,9 @@ pub struct CreateBody {
         ),
         (
             status = 403,
-            description = "The caller is not an admin, or a cookie session did \
-                           not echo its CSRF token.",
+            description = "The caller is not an admin, a cookie session did \
+                           not echo its CSRF token, or the trusted-header \
+                           identity names a disabled account.",
             body = ProblemDetail,
             content_type = "application/problem+json",
         ),
@@ -303,8 +305,9 @@ impl std::fmt::Debug for PatchBody {
         ),
         (
             status = 403,
-            description = "The caller is not an admin, or a cookie session did \
-                           not echo its CSRF token.",
+            description = "The caller is not an admin, a cookie session did \
+                           not echo its CSRF token, or the trusted-header \
+                           identity names a disabled account.",
             body = ProblemDetail,
             content_type = "application/problem+json",
         ),
@@ -399,8 +402,9 @@ pub async fn update(
         ),
         (
             status = 403,
-            description = "The caller is not an admin, or a cookie session did \
-                           not echo its CSRF token.",
+            description = "The caller is not an admin, a cookie session did \
+                           not echo its CSRF token, or the trusted-header \
+                           identity names a disabled account.",
             body = ProblemDetail,
             content_type = "application/problem+json",
         ),

--- a/crates/service/src/rest/users_api.rs
+++ b/crates/service/src/rest/users_api.rs
@@ -41,28 +41,68 @@ use axum::Json;
 use axum::extract::State;
 use axum::http::StatusCode;
 use serde::Deserialize;
-use serde_json::{Value, json};
 
 use super::auth::{Caller, Identity};
 use super::auth_store::{Role, User};
-use super::{ApiError, ApiJson, ApiPath, RestState};
+use super::{ApiError, ApiJson, ApiPath, ProblemDetail, RestState};
+
+/// What `GET /users` answers with. A wrapper rather than a bare array, matching
+/// the `{"users": [...]}` envelope `crystalline users list --json` prints.
+#[derive(serde::Serialize, utoipa::ToSchema)]
+pub struct UsersResponse {
+    /// Every account, by name.
+    users: Vec<User>,
+}
+
+/// What the two writing routes answer with: the account as stored, read back
+/// after the write rather than echoed from the request.
+#[derive(serde::Serialize, utoipa::ToSchema)]
+pub struct UserResponse {
+    /// The account as it now stands.
+    user: User,
+}
 
 /// `GET /users` - every account, by name.
 ///
 /// [`User`] carries no password material, so the rows go out as they come back
 /// from the store. Admin only: the account list names every way into the
 /// instance and who holds it.
+#[utoipa::path(
+    get,
+    path = "/api/v1/users",
+    tag = "users",
+    operation_id = "list_users",
+    summary = "Every account, by name.",
+    description = "An account carries no password material, so the rows go out \
+                   as they come back from the store. Admin only: the account \
+                   list names every way into the instance and who holds it.",
+    responses(
+        (status = 200, description = "Every account.", body = UsersResponse),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 403,
+            description = "The caller is not an admin.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn list(
     State(state): State<RestState>,
     identity: Identity,
-) -> Result<Json<Value>, ApiError> {
+) -> Result<Json<UsersResponse>, ApiError> {
     identity.require_admin()?;
     let users = state
         .auth
         .list_users()
         .await
         .map_err(|e| store_error(e, ""))?;
-    Ok(Json(json!({ "users": users })))
+    Ok(Json(UsersResponse { users }))
 }
 
 /// What `POST /users` takes. `display` defaults to the name as typed, matching
@@ -71,19 +111,25 @@ pub async fn list(
 /// [`Debug`] is written by hand rather than derived, here and on [`PatchBody`]:
 /// the derived one would print the plaintext password, and this type is one
 /// `tracing::debug!` or one `unwrap` on a rejection away from a log file.
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
+#[schema(description = "A new account. `display` defaults to `name` as typed, \
+                        and `email` is optional and never used for login.")]
 pub struct CreateBody {
     /// The login name, in any casing: the store folds it.
+    #[schema(example = "bob")]
     name: String,
     /// Human-readable name for the UI. Defaults to `name` as typed.
     #[serde(default)]
+    #[schema(example = "Bob")]
     display: Option<String>,
     /// Optional contact address.
     #[serde(default)]
+    #[schema(example = "bob@example.com")]
     email: Option<String>,
     /// What the new account may do.
     role: Role,
     /// The initial password. Never stored in the clear; the store hashes it.
+    #[schema(example = "correct horse battery staple")]
     password: String,
 }
 
@@ -92,11 +138,59 @@ pub struct CreateBody {
 /// The response is read back out of the store rather than echoed from the
 /// request, so what the client renders is what was written: the folded name,
 /// the defaulted display name, and the disabled flag the row starts with.
+#[utoipa::path(
+    post,
+    path = "/api/v1/users",
+    tag = "users",
+    operation_id = "create_user",
+    request_body = CreateBody,
+    responses(
+        (status = 201, description = "The account as stored.", body = UserResponse),
+        (
+            status = 400,
+            description = "The body is not JSON.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 403,
+            description = "The caller is not an admin, or a cookie session did \
+                           not echo its CSRF token.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 409,
+            description = "That name is already taken.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 415,
+            description = "The body is not `application/json`.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 422,
+            description = "The body is JSON but not an account, or the password \
+                           is empty.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn create(
     State(state): State<RestState>,
     identity: Identity,
     ApiJson(body): ApiJson<CreateBody>,
-) -> Result<(StatusCode, Json<Value>), ApiError> {
+) -> Result<(StatusCode, Json<UserResponse>), ApiError> {
     identity.require_admin()?;
     check_password(&body.password)?;
     // The login name as typed makes the better default display name: the store
@@ -117,7 +211,7 @@ pub async fn create(
         .await?
         .map_err(|e| store_error(e, &body.name))?;
     let user = read_back(&state, &body.name).await?;
-    Ok((StatusCode::CREATED, Json(json!({ "user": user }))))
+    Ok((StatusCode::CREATED, Json(UserResponse { user })))
 }
 
 /// What `PATCH /users/{name}` takes: whichever of the three an admin wants to
@@ -125,7 +219,11 @@ pub async fn create(
 /// sending the wrong field names hears about it.
 ///
 /// [`Debug`] is hand-written and redacts the password, as on [`CreateBody`].
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::ToSchema)]
+#[schema(description = "Whichever of the three an admin wants to change. All \
+                        absent is refused with a 422 rather than served as a \
+                        no-op, so a client sending the wrong field names hears \
+                        about it.")]
 pub struct PatchBody {
     /// The new role.
     #[serde(default)]
@@ -182,12 +280,67 @@ impl std::fmt::Debug for PatchBody {
 /// pathological case of a concurrent edit racing this one, since the refusals a
 /// caller can provoke on purpose - the last-admin guard and an unknown account
 /// - are decided identically by all three statements.
+#[utoipa::path(
+    patch,
+    path = "/api/v1/users/{name}",
+    tag = "users",
+    operation_id = "update_user",
+    params(("name" = String, Path, description = "The account, in any casing.")),
+    request_body = PatchBody,
+    responses(
+        (status = 200, description = "The account as it now stands.", body = UserResponse),
+        (
+            status = 400,
+            description = "The body is not JSON.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 403,
+            description = "The caller is not an admin, or a cookie session did \
+                           not echo its CSRF token.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 404,
+            description = "No such account.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 409,
+            description = "The change would disable the caller's own account, or \
+                           would leave the installation without an enabled admin.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 415,
+            description = "The body is not `application/json`.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 422,
+            description = "The body changes nothing, or the new password is empty.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn update(
     State(state): State<RestState>,
     identity: Identity,
     ApiPath(name): ApiPath<String>,
     ApiJson(body): ApiJson<PatchBody>,
-) -> Result<Json<Value>, ApiError> {
+) -> Result<Json<UserResponse>, ApiError> {
     let caller = identity.require_admin()?;
     if body.role.is_none() && body.disabled.is_none() && body.password.is_none() {
         return Err(ApiError::unprocessable(
@@ -222,7 +375,7 @@ pub async fn update(
             .map_err(|e| store_error(e, &name))?;
     }
     let user = read_back(&state, &name).await?;
-    Ok(Json(json!({ "user": user })))
+    Ok(Json(UserResponse { user }))
 }
 
 /// `DELETE /users/{name}` - remove an account and every session it holds,
@@ -230,6 +383,42 @@ pub async fn update(
 ///
 /// An admin may not remove its own account (409), and the store refuses to
 /// remove the last enabled admin whoever asks (409 as well, in its own words).
+#[utoipa::path(
+    delete,
+    path = "/api/v1/users/{name}",
+    tag = "users",
+    operation_id = "delete_user",
+    params(("name" = String, Path, description = "The account, in any casing.")),
+    responses(
+        (status = 204, description = "The account and its sessions are gone."),
+        (
+            status = 401,
+            description = "No identity.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 403,
+            description = "The caller is not an admin, or a cookie session did \
+                           not echo its CSRF token.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 404,
+            description = "No such account.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+        (
+            status = 409,
+            description = "The account is the caller's own, or is the last \
+                           enabled admin.",
+            body = ProblemDetail,
+            content_type = "application/problem+json",
+        ),
+    ),
+)]
 pub async fn remove(
     State(state): State<RestState>,
     identity: Identity,
@@ -349,6 +538,8 @@ fn store_error(e: anyhow::Error, subject: &str) -> ApiError {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
     use crate::rest::AuthStore;
 

--- a/crates/service/tests/graph.rs
+++ b/crates/service/tests/graph.rs
@@ -1,0 +1,313 @@
+//! Engine-level tests for `graph_neighborhood`, the nodes-and-typed-edges view
+//! the Fluid graph screen draws from.
+//!
+//! The fixture is a chain in one virtual domain, written through the engine so
+//! the relations are resolved the way a real write resolves them:
+//!
+//! ```text
+//! Alpha -supersedes-> Beta -relates_to-> Gamma -relates_to-> Delta -relates_to-> Epsilon
+//! ```
+//!
+//! Anchored on Beta, the chain makes every rule observable: one hop reaches
+//! Alpha and Gamma, a second reaches Delta, and nothing reaches Epsilon, so a
+//! depth that was clamped is visible in the node count rather than in a field
+//! the response would have to invent.
+
+use std::sync::Arc;
+
+use crystalline_core::config::{DomainEntry, GlobalConfig};
+use crystalline_index::TursoStore;
+use crystalline_service::engine::{Engine, EngineError};
+use crystalline_service::params::WriteParams;
+use tokio::sync::Mutex;
+
+/// An engine over a single virtual domain named `notes`.
+async fn engine() -> Engine {
+    let store = TursoStore::open_in_memory().await.unwrap();
+    let mut cfg = GlobalConfig::default();
+    cfg.domains
+        .insert("notes".to_string(), DomainEntry::virtual_domain());
+    Engine::new(Arc::new(Mutex::new(store)), cfg, None, None)
+}
+
+/// Write one engram into `notes` with a body and a status.
+async fn write(engine: &Engine, title: &str, status: &str, body: &str) {
+    engine
+        .write_engram(&WriteParams {
+            domain: "notes".to_string(),
+            title: title.to_string(),
+            content: body.to_string(),
+            folder: None,
+            engram_type: Some("engram".to_string()),
+            tags: vec!["chain".to_string()],
+            status: Some(status.to_string()),
+            metadata: None,
+            overwrite: false,
+        })
+        .await
+        .unwrap();
+}
+
+/// The chain above. Alpha is retired, so a neighborhood that includes it proves
+/// the API reports retired knowledge rather than hiding it.
+async fn chain() -> Engine {
+    let engine = engine().await;
+    write(
+        &engine,
+        "Alpha",
+        "superseded",
+        "The first link.\n\n- supersedes [[Beta]]\n",
+    )
+    .await;
+    write(
+        &engine,
+        "Beta",
+        "stable",
+        "The second link.\n\n- relates_to [[Gamma]]\n",
+    )
+    .await;
+    write(
+        &engine,
+        "Gamma",
+        "stable",
+        "The third link.\n\n- relates_to [[Delta]]\n",
+    )
+    .await;
+    write(
+        &engine,
+        "Delta",
+        "stable",
+        "The fourth link.\n\n- relates_to [[Epsilon]]\n",
+    )
+    .await;
+    write(&engine, "Epsilon", "stable", "The last link.\n").await;
+    engine
+}
+
+/// The `permalink` of every node in a graph response, in the order returned.
+fn permalinks(graph: &serde_json::Value) -> Vec<String> {
+    graph["nodes"]
+        .as_array()
+        .expect("a graph response carries a nodes array")
+        .iter()
+        .map(|n| n["permalink"].as_str().unwrap().to_string())
+        .collect()
+}
+
+/// One hop out of an anchor: the anchor itself, the engram that supersedes it
+/// and the one it relates to, with both edges typed and directed.
+#[tokio::test]
+async fn depth_one_returns_the_anchor_its_neighbors_and_the_typed_edges() {
+    let engine = chain().await;
+
+    let graph = engine
+        .graph_neighborhood("crystalline://notes/beta", 1, 100)
+        .await
+        .unwrap();
+
+    let mut names = permalinks(&graph);
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()],
+        "the anchor and its two neighbors: {graph}"
+    );
+    assert_eq!(
+        graph["nodes"][0]["permalink"], "beta",
+        "the anchor leads the list: {graph}"
+    );
+    assert_eq!(graph["truncated"], false, "nothing was cut: {graph}");
+
+    // Every node carries what the graph view labels and styles it with.
+    let anchor = &graph["nodes"][0];
+    assert!(anchor["id"].as_i64().is_some(), "{graph}");
+    assert_eq!(anchor["domain"], "notes");
+    assert_eq!(anchor["title"], "Beta");
+    assert_eq!(anchor["status"], "stable");
+    assert_eq!(anchor["type"], "engram");
+
+    // The edges keep their direction, so a client can tell a backlink from an
+    // outbound reference without asking again.
+    let edges = graph["edges"].as_array().unwrap();
+    assert_eq!(edges.len(), 2, "one edge per hop: {graph}");
+    let by_id = |permalink: &str| -> i64 {
+        graph["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|n| n["permalink"] == permalink)
+            .unwrap_or_else(|| panic!("{permalink} is in the slice: {graph}"))["id"]
+            .as_i64()
+            .unwrap()
+    };
+    let (alpha, beta, gamma) = (by_id("alpha"), by_id("beta"), by_id("gamma"));
+    assert!(
+        edges
+            .iter()
+            .any(|e| e["from"] == alpha && e["to"] == beta && e["rel_type"] == "supersedes"),
+        "the inbound edge, pointing at the anchor: {graph}"
+    );
+    assert!(
+        edges
+            .iter()
+            .any(|e| e["from"] == beta && e["to"] == gamma && e["rel_type"] == "relates_to"),
+        "the outbound edge, pointing away: {graph}"
+    );
+}
+
+/// The depth is the server's to decide: below one it is one, above two it is
+/// two, so a hand-written URL can neither ask for nothing nor walk the whole
+/// index.
+#[tokio::test]
+async fn the_depth_is_clamped_to_one_hop_or_two() {
+    let engine = chain().await;
+
+    let count = async |depth: u8| -> usize {
+        engine
+            .graph_neighborhood("crystalline://notes/beta", depth, 100)
+            .await
+            .unwrap()["nodes"]
+            .as_array()
+            .unwrap()
+            .len()
+    };
+
+    assert_eq!(count(1).await, 3, "alpha, beta, gamma");
+    assert_eq!(count(0).await, 3, "zero hops is one hop");
+    assert_eq!(count(2).await, 4, "delta joins on the second hop");
+    assert_eq!(count(5).await, 4, "five hops is two: epsilon stays out");
+}
+
+/// The node cap is honest about itself: it cuts to the cap and says it cut, and
+/// an edge whose other end was cut goes with it rather than dangling.
+#[tokio::test]
+async fn the_node_cap_cuts_and_reports_it() {
+    let engine = chain().await;
+
+    let capped = engine
+        .graph_neighborhood("crystalline://notes/beta", 2, 1)
+        .await
+        .unwrap();
+    assert_eq!(
+        permalinks(&capped),
+        vec!["beta".to_string()],
+        "the anchor survives a cap of one: {capped}"
+    );
+    assert_eq!(
+        capped["truncated"], true,
+        "and the cut is reported: {capped}"
+    );
+    assert!(
+        capped["edges"].as_array().unwrap().is_empty(),
+        "an edge to a node that was cut is cut too: {capped}"
+    );
+
+    let whole = engine
+        .graph_neighborhood("crystalline://notes/beta", 2, 100)
+        .await
+        .unwrap();
+    assert_eq!(
+        whole["truncated"], false,
+        "a cap nothing reaches cuts nothing: {whole}"
+    );
+}
+
+/// The cap has a server-side ceiling, so a client asking for the whole index in
+/// one response is answered with a bounded slice that says it is one.
+#[tokio::test]
+async fn the_cap_has_a_server_side_ceiling() {
+    let engine = engine().await;
+    write(&engine, "Hub", "stable", "The center of the star.\n").await;
+    for n in 0..200 {
+        write(
+            &engine,
+            &format!("Spoke {n:03}"),
+            "stable",
+            "A spoke.\n\n- relates_to [[Hub]]\n",
+        )
+        .await;
+    }
+
+    let graph = engine
+        .graph_neighborhood("crystalline://notes/hub", 1, 100_000)
+        .await
+        .unwrap();
+    assert_eq!(
+        graph["nodes"].as_array().unwrap().len(),
+        150,
+        "the ceiling holds whatever was asked for: {}",
+        graph["nodes"]
+    );
+    assert_eq!(graph["truncated"], true);
+}
+
+/// Retired knowledge is part of the graph: the API reports it with its status,
+/// and the client decides how to show it.
+#[tokio::test]
+async fn a_retired_neighbor_is_included_with_its_status() {
+    let engine = chain().await;
+
+    let graph = engine
+        .graph_neighborhood("crystalline://notes/beta", 1, 100)
+        .await
+        .unwrap();
+    let alpha = graph["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|n| n["permalink"] == "alpha")
+        .expect("the retired neighbor is in the slice");
+    assert_eq!(
+        alpha["status"], "superseded",
+        "reported as retired rather than dropped: {graph}"
+    );
+}
+
+/// One connection is one edge: an engram that both declares a `links_to`
+/// relation and writes the wikilink in its prose relates to the target once, and
+/// the picture says so once.
+#[tokio::test]
+async fn a_relation_and_its_prose_link_are_one_edge() {
+    let engine = engine().await;
+    write(&engine, "Target", "stable", "The target.\n").await;
+    write(
+        &engine,
+        "Source",
+        "stable",
+        "Prose pointing at [[Target]].\n\n- links_to [[Target]]\n",
+    )
+    .await;
+
+    let graph = engine
+        .graph_neighborhood("crystalline://notes/target", 1, 100)
+        .await
+        .unwrap();
+    let edges = graph["edges"].as_array().unwrap();
+    assert_eq!(edges.len(), 1, "drawn once, not twice: {graph}");
+    assert_eq!(edges[0]["rel_type"], "links_to");
+}
+
+/// The two ways an anchor can be wrong are two different errors, so the HTTP
+/// surface above can map them apart.
+#[tokio::test]
+async fn a_bad_anchor_is_refused_by_kind() {
+    let engine = chain().await;
+
+    let malformed = engine
+        .graph_neighborhood("beta", 1, 100)
+        .await
+        .expect_err("an anchor that is not a URL is refused");
+    assert!(
+        matches!(malformed, EngineError::Invalid(ref m) if m.contains("crystalline://")),
+        "{malformed:?}"
+    );
+
+    let unknown = engine
+        .graph_neighborhood("crystalline://notes/ghost", 1, 100)
+        .await
+        .expect_err("an anchor pointing at nothing is refused");
+    assert!(
+        matches!(unknown, EngineError::NotFound(ref m) if m.contains("ghost")),
+        "{unknown:?}"
+    );
+}

--- a/crates/service/tests/openapi_snapshot.rs
+++ b/crates/service/tests/openapi_snapshot.rs
@@ -1,0 +1,120 @@
+//! The OpenAPI document is a committed artifact, not a runtime detail.
+//!
+//! `fluid/` generates its client types from `crates/service/openapi/fluid-v1.json`
+//! at build time rather than from a running server, so the file in the tree is
+//! the contract the UI is compiled against. These tests are what keeps it equal
+//! to the document the code actually produces: the snapshot check fails on any
+//! drift and says how to regenerate, and the coverage check pins the path list
+//! itself so a route can neither be added without being documented nor be
+//! documented without being served.
+
+use std::collections::BTreeSet;
+
+/// Every operation the `/api/v1` router mounts, as `METHOD path`, spelled the
+/// way the OpenAPI document spells it (the engram wildcard becomes an ordinary
+/// `{permalink}` template, which is the only notation OpenAPI has for it).
+///
+/// This list is the contract rather than a convenience: it is hand-maintained
+/// against `rest::router`, and `the_document_covers_every_mounted_path` compares
+/// it against the document in *both* directions, so a new route that nobody
+/// annotated and an annotation for a route nobody mounted each fail here. The
+/// method is part of it because a documented method the router does not serve
+/// would generate a client function that compiles and then answers 405.
+const MOUNTED_OPERATIONS: &[&str] = &[
+    "GET /api/v1/openapi.json",
+    "POST /api/v1/auth/login",
+    "POST /api/v1/auth/logout",
+    "GET /api/v1/auth/me",
+    "GET /api/v1/domains",
+    "GET /api/v1/domains/{domain}/tree",
+    "GET /api/v1/domains/{domain}/manifest",
+    "GET /api/v1/domains/{domain}/engrams",
+    "GET /api/v1/domains/{domain}/engrams/{permalink}",
+    "GET /api/v1/search",
+    "GET /api/v1/vocabulary",
+    "GET /api/v1/context",
+    "GET /api/v1/activity",
+    "GET /api/v1/graph",
+    "GET /api/v1/users",
+    "POST /api/v1/users",
+    "PATCH /api/v1/users/{name}",
+    "DELETE /api/v1/users/{name}",
+];
+
+/// Where the committed snapshot lives, as an absolute path, for the writer.
+const SNAPSHOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/openapi/fluid-v1.json");
+
+/// How the document is serialized, in exactly one place: the snapshot test, the
+/// regenerator and the served route must all agree byte for byte or the check
+/// would fail on formatting rather than on content.
+fn generated() -> String {
+    let mut json = serde_json::to_string_pretty(&crystalline_service::rest::openapi_document())
+        .expect("the OpenAPI document serializes");
+    json.push('\n');
+    json
+}
+
+/// The committed document equals the generated one.
+///
+/// Compared as text rather than as parsed JSON on purpose: the file is read by
+/// a code generator and by humans in review, so its formatting is part of what
+/// is being pinned.
+#[test]
+fn openapi_snapshot_is_current() {
+    let committed = include_str!("../openapi/fluid-v1.json");
+    assert_eq!(
+        generated().trim(),
+        committed.trim(),
+        "the OpenAPI document has drifted from crates/service/openapi/fluid-v1.json. \
+         Regenerate it with: cargo nextest run -p crystalline-service --run-ignored all \
+         regenerate_openapi"
+    );
+}
+
+/// The document describes exactly the operations the router mounts.
+///
+/// Both directions matter. An operation missing from the document is a route
+/// the UI cannot be generated a client for; one in the document that nothing
+/// mounts is worse, because a generated client would compile and then fail at
+/// runtime.
+#[test]
+fn the_document_covers_every_mounted_path() {
+    // Read the serialized form rather than the typed tree: this is the shape a
+    // client generator consumes, so it is the shape worth asserting on.
+    let doc = serde_json::to_value(crystalline_service::rest::openapi_document()).unwrap();
+    let documented: BTreeSet<String> = doc["paths"]
+        .as_object()
+        .expect("the document has a paths object")
+        .iter()
+        .flat_map(|(path, item)| {
+            item.as_object()
+                .expect("a path item is an object")
+                .keys()
+                .map(move |method| format!("{} {path}", method.to_uppercase()))
+        })
+        .collect();
+    let mounted: BTreeSet<String> = MOUNTED_OPERATIONS.iter().map(|s| s.to_string()).collect();
+
+    let missing: Vec<&String> = mounted.difference(&documented).collect();
+    assert!(
+        missing.is_empty(),
+        "these mounted operations carry no #[utoipa::path] annotation: {missing:?}"
+    );
+    let phantom: Vec<&String> = documented.difference(&mounted).collect();
+    assert!(
+        phantom.is_empty(),
+        "these operations are documented but nothing mounts them: {phantom:?}"
+    );
+}
+
+/// Rewrite the committed snapshot from the code. Ignored by default: it is a
+/// tool rather than a check, and a test that silently fixed its own subject
+/// would make `openapi_snapshot_is_current` unable to fail in CI.
+///
+/// Run it with:
+/// `cargo nextest run -p crystalline-service --run-ignored all regenerate_openapi`
+#[test]
+#[ignore = "regenerates the committed OpenAPI snapshot; run it explicitly"]
+fn regenerate_openapi() {
+    std::fs::write(SNAPSHOT, generated()).expect("the snapshot directory exists and is writable");
+}

--- a/crates/service/tests/rest_api.rs
+++ b/crates/service/tests/rest_api.rs
@@ -2245,3 +2245,133 @@ async fn user_request_failures_are_classified() {
         "the detail names what it takes: {body}"
     );
 }
+
+/// An admin resetting an account's password signs that account out. A session
+/// never presents a password again, so a reset that left the old cookie live
+/// would evict nobody - which is the whole point of resetting one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_password_reset_revokes_the_targets_sessions() {
+    let (fixture, token, csrf) = serve_as_admin(AuthOptions::default()).await;
+    let addr = fixture.addr;
+    fixture
+        .auth
+        .add_user("ada", "Ada", None, Role::Viewer, "s3cret")
+        .await
+        .unwrap();
+    let (ada, _) = login(addr, "ada", "s3cret").await;
+    let signed_in = client()
+        .get(format!("http://{addr}/api/v1/domains"))
+        .header("cookie", format!("fluid_session={ada}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(signed_in.status(), 200, "the session works to begin with");
+
+    let reset = as_session(
+        addr,
+        reqwest::Method::PATCH,
+        "/api/v1/users/ada",
+        &token,
+        &csrf,
+    )
+    .json(&serde_json::json!({"password": "corrected horse"}))
+    .send()
+    .await
+    .unwrap();
+    assert_eq!(reset.status(), 200);
+
+    let after = client()
+        .get(format!("http://{addr}/api/v1/domains"))
+        .header("cookie", format!("fluid_session={ada}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        after.status(),
+        401,
+        "the cookie from before the reset is dead"
+    );
+    // And the account is usable again with the password the admin set.
+    login(addr, "ada", "corrected horse").await;
+}
+
+/// Disabling revokes rather than hides: re-enabling the account must not hand
+/// back the cookies it held, or disabling a compromised account and enabling it
+/// again would restore the intruder's session.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn disabling_and_re_enabling_does_not_restore_the_old_sessions() {
+    let (fixture, token, csrf) = serve_as_admin(AuthOptions::default()).await;
+    let addr = fixture.addr;
+    fixture
+        .auth
+        .add_user("ada", "Ada", None, Role::Viewer, "s3cret")
+        .await
+        .unwrap();
+    let (ada, _) = login(addr, "ada", "s3cret").await;
+
+    for disabled in [true, false] {
+        let resp = as_session(
+            addr,
+            reqwest::Method::PATCH,
+            "/api/v1/users/ada",
+            &token,
+            &csrf,
+        )
+        .json(&serde_json::json!({ "disabled": disabled }))
+        .send()
+        .await
+        .unwrap();
+        assert_eq!(resp.status(), 200, "setting disabled={disabled}");
+    }
+
+    let after = client()
+        .get(format!("http://{addr}/api/v1/domains"))
+        .header("cookie", format!("fluid_session={ada}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        after.status(),
+        401,
+        "the session was deleted, not hidden while the flag was set"
+    );
+    // The account is enabled again, so a fresh login works.
+    login(addr, "ada", "s3cret").await;
+}
+
+/// Creating accounts is argon2 work like logging in, and it goes through the
+/// same limiter. Asserted as liveness rather than as timing: every concurrent
+/// request is answered and every account exists afterwards, which is what a
+/// limiter that queues (rather than drops or deadlocks) looks like from
+/// outside. The bound itself is asserted on the mechanism in
+/// `rest::tests::the_login_limiter_caps_every_caller_that_hashes`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_account_creations_all_answer() {
+    let (fixture, token, csrf) = serve_as_admin(AuthOptions::default()).await;
+    let addr = fixture.addr;
+
+    let mut tasks = Vec::new();
+    for n in 0..12 {
+        let (token, csrf) = (token.clone(), csrf.clone());
+        tasks.push(tokio::spawn(async move {
+            as_session(addr, reqwest::Method::POST, "/api/v1/users", &token, &csrf)
+                .json(&serde_json::json!({
+                    "name": format!("user{n}"),
+                    "role": "viewer",
+                    "password": "hunter2",
+                }))
+                .send()
+                .await
+                .unwrap()
+                .status()
+        }));
+    }
+    for task in tasks {
+        assert_eq!(task.await.unwrap(), 201, "every creation is answered");
+    }
+    assert_eq!(
+        fixture.auth.list_users().await.unwrap().len(),
+        13,
+        "twelve new accounts beside the admin"
+    );
+}

--- a/crates/service/tests/rest_api.rs
+++ b/crates/service/tests/rest_api.rs
@@ -302,8 +302,8 @@ fn hit_permalinks(page: &serde_json::Value) -> Vec<String> {
         .collect()
 }
 
-/// The `permalink` of every node a context response returned, in the order it
-/// returned them: the seeds first, then the neighborhood by rank.
+/// The `permalink` of every node a context or graph response returned, in the
+/// order it returned them: the anchors first, then the neighborhood by rank.
 fn node_permalinks(context: &serde_json::Value) -> Vec<String> {
     context["nodes"]
         .as_array()
@@ -509,6 +509,7 @@ async fn data_routes_401_without_identity_when_not_anonymous() {
         "/api/v1/vocabulary",
         "/api/v1/context",
         "/api/v1/activity",
+        "/api/v1/graph",
     ] {
         let resp = get(fixture.addr, path).await;
         assert_eq!(resp.status(), 401, "{path} must be guarded");
@@ -1592,4 +1593,111 @@ async fn activity_respects_the_timeframe_and_its_filters() {
         default["timeframe"], "7d",
         "the engine's own default, not a second one here: {default}"
     );
+}
+
+/// The graph endpoint answers the same neighborhood `/context` walks, in the
+/// shape a renderer draws: nodes carrying what labels and styles them, edges
+/// carrying their direction and relation type, and a flag saying whether the
+/// node cap cut anything.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graph_returns_the_nodes_and_typed_edges_around_an_anchor() {
+    let fixture = serve_anonymous().await;
+
+    let resp = get(fixture.addr, "/api/v1/graph?anchor=crystalline://eng/alpha").await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let permalinks = node_permalinks(&body);
+    assert_eq!(permalinks[0], "alpha", "the anchor leads: {body}");
+    assert!(
+        permalinks.contains(&"notes/beta".to_string()),
+        "the engram relating to it comes with: {body}"
+    );
+    assert_eq!(body["truncated"], false, "nothing was cut: {body}");
+
+    // What a client draws a node with, all of it in the node itself.
+    let anchor = &body["nodes"][0];
+    assert_eq!(anchor["domain"], "eng");
+    assert_eq!(anchor["title"], "Alpha");
+    assert_eq!(anchor["status"], "current");
+    assert_eq!(anchor["type"], "engram");
+    let anchor_id = anchor["id"].as_i64().expect("a node carries its id");
+
+    // The edge points from Beta, which declared the relation, at the anchor.
+    let edges = body["edges"].as_array().unwrap();
+    assert_eq!(edges.len(), 1, "the one relation the fixture holds: {body}");
+    assert_eq!(edges[0]["rel_type"], "relates_to");
+    assert_eq!(edges[0]["to"], anchor_id, "and it points at Alpha: {body}");
+
+    // The node cap is a real bound, and a cut slice says it was cut.
+    let capped: serde_json::Value = get(
+        fixture.addr,
+        "/api/v1/graph?anchor=crystalline://eng/alpha&max_nodes=1",
+    )
+    .await
+    .json()
+    .await
+    .unwrap();
+    assert_eq!(
+        node_permalinks(&capped),
+        vec!["alpha".to_string()],
+        "the anchor alone: {capped}"
+    );
+    assert_eq!(capped["truncated"], true, "{capped}");
+    assert!(
+        capped["edges"].as_array().unwrap().is_empty(),
+        "an edge whose other end was cut is cut too: {capped}"
+    );
+
+    // A second hop is served rather than refused, clamped or not.
+    let deep = get(
+        fixture.addr,
+        "/api/v1/graph?anchor=crystalline://eng/alpha&depth=9",
+    )
+    .await;
+    assert_eq!(
+        deep.status(),
+        200,
+        "an over-deep request is clamped, not refused"
+    );
+}
+
+/// The three ways an anchor can be wrong, answered here exactly as `/context`
+/// answers them: a rejected request, one the server understood and refused, and
+/// one pointing at nothing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_bad_graph_anchor_is_a_problem_detail() {
+    let fixture = serve_anonymous().await;
+
+    let missing = get(fixture.addr, "/api/v1/graph").await;
+    assert_eq!(missing.status(), 400, "the anchor is required");
+    assert_eq!(
+        missing.headers()["content-type"],
+        "application/problem+json"
+    );
+    let body: serde_json::Value = missing.json().await.unwrap();
+    assert!(
+        body["detail"].as_str().unwrap().contains("anchor"),
+        "the detail names the parameter: {body}"
+    );
+
+    let malformed = get(fixture.addr, "/api/v1/graph?anchor=alpha").await;
+    assert_eq!(malformed.status(), 422);
+    let body: serde_json::Value = malformed.json().await.unwrap();
+    assert!(
+        body["detail"]
+            .as_str()
+            .unwrap()
+            .contains("not a crystalline:// URL"),
+        "the engine's own message: {body}"
+    );
+
+    let unknown = get(fixture.addr, "/api/v1/graph?anchor=crystalline://eng/ghost").await;
+    assert_eq!(unknown.status(), 404);
+    assert_eq!(
+        unknown.headers()["content-type"],
+        "application/problem+json"
+    );
+    let body: serde_json::Value = unknown.json().await.unwrap();
+    assert_eq!(body["title"], "not found");
+    assert!(body["detail"].as_str().unwrap().contains("ghost"), "{body}");
 }

--- a/crates/service/tests/rest_api.rs
+++ b/crates/service/tests/rest_api.rs
@@ -230,6 +230,20 @@ async fn serve_with_ada(opts: AuthOptions) -> Fixture {
     fixture
 }
 
+/// The same fixture with one admin account, `root` / `rootpw`, already added
+/// and logged in. Returns the fixture beside that session's cookie and CSRF
+/// token, which every admin-route request needs.
+async fn serve_as_admin(opts: AuthOptions) -> (Fixture, String, String) {
+    let fixture = serve_with_auth(opts).await;
+    fixture
+        .auth
+        .add_user("root", "Root", None, Role::Admin, "rootpw")
+        .await
+        .unwrap();
+    let (token, csrf) = login(fixture.addr, "root", "rootpw").await;
+    (fixture, token, csrf)
+}
+
 /// A client with proxy discovery disabled: the target is loopback, where a
 /// system proxy must never be consulted anyway, and reqwest's platform proxy
 /// lookup can block for a minute on a machine with a managed network
@@ -245,6 +259,45 @@ async fn get(addr: std::net::SocketAddr, path: &str) -> reqwest::Response {
         .send()
         .await
         .unwrap()
+}
+
+/// A request carrying a session's cookie and its CSRF token, the shape every
+/// mutating request from the browser client has. The caller adds a body and
+/// sends it.
+fn as_session(
+    addr: std::net::SocketAddr,
+    method: reqwest::Method,
+    path: &str,
+    token: &str,
+    csrf: &str,
+) -> reqwest::RequestBuilder {
+    client()
+        .request(method, format!("http://{addr}{path}"))
+        .header("cookie", format!("fluid_session={token}"))
+        .header("x-csrf-token", csrf)
+}
+
+/// The field names one user object carries, which is the whole contract: the
+/// five columns the CLI's `users list --json` prints and nothing else.
+fn user_fields(user: &serde_json::Value) -> Vec<String> {
+    let mut keys: Vec<String> = user
+        .as_object()
+        .expect("a user is an object")
+        .keys()
+        .cloned()
+        .collect();
+    keys.sort();
+    keys
+}
+
+/// The `name` of every account in a `{"users": [...]}` envelope.
+fn user_names(body: &serde_json::Value) -> Vec<String> {
+    body["users"]
+        .as_array()
+        .expect("the listing carries a users array")
+        .iter()
+        .map(|u| u["name"].as_str().unwrap().to_string())
+        .collect()
 }
 
 /// Log in as `name`, returning the session cookie value and the CSRF token.
@@ -510,6 +563,8 @@ async fn data_routes_401_without_identity_when_not_anonymous() {
         "/api/v1/context",
         "/api/v1/activity",
         "/api/v1/graph",
+        "/api/v1/users",
+        "/api/v1/users/ada",
     ] {
         let resp = get(fixture.addr, path).await;
         assert_eq!(resp.status(), 401, "{path} must be guarded");
@@ -1700,4 +1755,493 @@ async fn a_bad_graph_anchor_is_a_problem_detail() {
     let body: serde_json::Value = unknown.json().await.unwrap();
     assert_eq!(body["title"], "not found");
     assert!(body["detail"].as_str().unwrap().contains("ghost"), "{body}");
+}
+
+/// Every user route is admin-only, and the refusal is about the role rather
+/// than about the CSRF token: each request below carries a valid one, so a
+/// viewer and an editor are refused on what they are, not on what they sent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_routes_are_refused_to_a_viewer_and_an_editor() {
+    for role in [Role::Viewer, Role::Editor] {
+        let fixture = serve_with_auth(AuthOptions::default()).await;
+        fixture
+            .auth
+            .add_user("ada", "Ada", None, role, "s3cret")
+            .await
+            .unwrap();
+        let (token, csrf) = login(fixture.addr, "ada", "s3cret").await;
+        let cases = [
+            (reqwest::Method::GET, "/api/v1/users", None),
+            (
+                reqwest::Method::POST,
+                "/api/v1/users",
+                Some(serde_json::json!({"name": "bob", "role": "viewer", "password": "hunter2"})),
+            ),
+            (
+                reqwest::Method::PATCH,
+                "/api/v1/users/ada",
+                Some(serde_json::json!({"role": "admin"})),
+            ),
+            (reqwest::Method::DELETE, "/api/v1/users/ada", None),
+        ];
+        for (method, path, body) in cases {
+            let mut request = as_session(fixture.addr, method.clone(), path, &token, &csrf);
+            if let Some(body) = &body {
+                request = request.json(body);
+            }
+            let resp = request.send().await.unwrap();
+            assert_eq!(
+                resp.status(),
+                403,
+                "a {role} must not reach {method} {path}"
+            );
+            assert_eq!(resp.headers()["content-type"], "application/problem+json");
+            let detail: serde_json::Value = resp.json().await.unwrap();
+            assert_eq!(detail["status"], 403);
+        }
+        let users = fixture.auth.list_users().await.unwrap();
+        assert_eq!(users.len(), 1, "nothing a {role} sent changed anything");
+        assert_eq!(users[0].role, role, "including its own row");
+    }
+}
+
+/// The admin round trip: create an account, see it in the listing, edit it,
+/// and remove it again. The response carries the account as stored - the name
+/// folded, no password material - and the listing is the `{"users": [...]}`
+/// envelope the CLI's `users list --json` already prints.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_admin_creates_lists_edits_and_removes_an_account() {
+    let (fixture, token, csrf) = serve_as_admin(AuthOptions::default()).await;
+    let addr = fixture.addr;
+
+    let created = as_session(addr, reqwest::Method::POST, "/api/v1/users", &token, &csrf)
+        .json(&serde_json::json!({
+            "name": "  BoB ",
+            "display": "Bob",
+            "email": "bob@example.com",
+            "role": "editor",
+            "password": "hunter2",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), 201);
+    let body: serde_json::Value = created.json().await.unwrap();
+    assert_eq!(
+        body["user"]["name"], "bob",
+        "the store folds the name: {body}"
+    );
+    assert_eq!(body["user"]["display"], "Bob");
+    assert_eq!(body["user"]["email"], "bob@example.com");
+    assert_eq!(body["user"]["role"], "editor");
+    assert_eq!(body["user"]["disabled"], false);
+    assert_eq!(
+        user_fields(&body["user"]),
+        vec!["disabled", "display", "email", "name", "role"],
+        "no password material may reach the client: {body}"
+    );
+
+    let listed = as_session(addr, reqwest::Method::GET, "/api/v1/users", &token, &csrf)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(listed.status(), 200);
+    let body: serde_json::Value = listed.json().await.unwrap();
+    assert_eq!(
+        user_names(&body),
+        vec!["bob".to_string(), "root".to_string()],
+        "every account, by name: {body}"
+    );
+    assert_eq!(
+        user_fields(&body["users"][0]),
+        vec!["disabled", "display", "email", "name", "role"],
+        "the listing carries no hashes either: {body}"
+    );
+
+    let patched = as_session(
+        addr,
+        reqwest::Method::PATCH,
+        "/api/v1/users/bob",
+        &token,
+        &csrf,
+    )
+    .json(&serde_json::json!({"role": "viewer", "disabled": true}))
+    .send()
+    .await
+    .unwrap();
+    assert_eq!(patched.status(), 200);
+    let body: serde_json::Value = patched.json().await.unwrap();
+    assert_eq!(body["user"]["role"], "viewer", "{body}");
+    assert_eq!(body["user"]["disabled"], true, "{body}");
+
+    // A password change lands too, which the store only proves by accepting it
+    // at login - so the account is re-enabled and asked to log in with it.
+    let repaired = as_session(
+        addr,
+        reqwest::Method::PATCH,
+        "/api/v1/users/bob",
+        &token,
+        &csrf,
+    )
+    .json(&serde_json::json!({"disabled": false, "password": "corrected horse"}))
+    .send()
+    .await
+    .unwrap();
+    assert_eq!(repaired.status(), 200);
+    let (bob_token, _) = login(addr, "bob", "corrected horse").await;
+    let me: serde_json::Value = client()
+        .get(format!("http://{addr}/api/v1/auth/me"))
+        .header("cookie", format!("fluid_session={bob_token}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(me["user"]["name"], "bob", "the new password works: {me}");
+
+    let removed = as_session(
+        addr,
+        reqwest::Method::DELETE,
+        "/api/v1/users/bob",
+        &token,
+        &csrf,
+    )
+    .send()
+    .await
+    .unwrap();
+    assert_eq!(removed.status(), 204);
+    assert!(
+        removed.bytes().await.unwrap().is_empty(),
+        "204 carries no body"
+    );
+
+    let body: serde_json::Value =
+        as_session(addr, reqwest::Method::GET, "/api/v1/users", &token, &csrf)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+    assert_eq!(user_names(&body), vec!["root".to_string()], "{body}");
+}
+
+/// An admin cannot lock itself out by hand: deleting or disabling its own
+/// account is refused as a conflict, and the refusal reads differently from the
+/// last-admin one - here another admin exists, so the installation is in no
+/// danger and only the caller's own session is being protected.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_admin_cannot_delete_or_disable_itself() {
+    let (fixture, token, csrf) = serve_as_admin(AuthOptions::default()).await;
+    let addr = fixture.addr;
+    fixture
+        .auth
+        .add_user("ada", "Ada", None, Role::Admin, "s3cret")
+        .await
+        .unwrap();
+
+    for (method, path, body) in [
+        (reqwest::Method::DELETE, "/api/v1/users/root", None),
+        (
+            reqwest::Method::PATCH,
+            "/api/v1/users/root",
+            Some(serde_json::json!({"disabled": true})),
+        ),
+        // The same account by another spelling: the comparison folds, so a
+        // capitalized path is not a way around the check.
+        (reqwest::Method::DELETE, "/api/v1/users/ROOT", None),
+    ] {
+        let mut request = as_session(addr, method.clone(), path, &token, &csrf);
+        if let Some(body) = &body {
+            request = request.json(body);
+        }
+        let resp = request.send().await.unwrap();
+        assert_eq!(resp.status(), 409, "{method} {path} must be refused");
+        assert_eq!(resp.headers()["content-type"], "application/problem+json");
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["title"], "conflict");
+        let detail = body["detail"].as_str().unwrap();
+        assert!(
+            detail.contains("your own account"),
+            "the refusal says whose account it is: {body}"
+        );
+        assert!(
+            !detail.contains("last admin"),
+            "and it is not the last-admin refusal: {body}"
+        );
+    }
+
+    let users = fixture.auth.list_users().await.unwrap();
+    let root = users.iter().find(|u| u.name == "root").unwrap();
+    assert!(!root.disabled, "the account is untouched and still enabled");
+    assert_eq!(root.role, Role::Admin);
+}
+
+/// The store's last-admin guard reaches the wire as a 409 carrying its own
+/// message. There is deliberately no escape hatch: an installation must never
+/// be lockable out of its own user management over HTTP, and the CLI is the
+/// recovery path. Self-demotion is the way to ask for it, since any other admin
+/// caller would itself be a remaining admin.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn demoting_the_last_admin_is_refused_with_the_stores_message() {
+    let (fixture, token, csrf) = serve_as_admin(AuthOptions::default()).await;
+    let addr = fixture.addr;
+
+    let refused = as_session(
+        addr,
+        reqwest::Method::PATCH,
+        "/api/v1/users/root",
+        &token,
+        &csrf,
+    )
+    .json(&serde_json::json!({"role": "viewer"}))
+    .send()
+    .await
+    .unwrap();
+    assert_eq!(refused.status(), 409);
+    assert_eq!(
+        refused.headers()["content-type"],
+        "application/problem+json"
+    );
+    let body: serde_json::Value = refused.json().await.unwrap();
+    assert_eq!(body["title"], "conflict");
+    let detail = body["detail"].as_str().unwrap();
+    assert!(
+        detail.contains("last admin"),
+        "the store's own words: {body}"
+    );
+    assert!(
+        detail.contains("add or enable another admin first"),
+        "including what to do about it: {body}"
+    );
+
+    let users = fixture.auth.list_users().await.unwrap();
+    assert_eq!(users[0].role, Role::Admin, "the demotion did not land");
+
+    // With a second admin in place the same request goes through, so what
+    // refused it was the guard and not the route.
+    fixture
+        .auth
+        .add_user("ada", "Ada", None, Role::Admin, "s3cret")
+        .await
+        .unwrap();
+    let ok = as_session(
+        addr,
+        reqwest::Method::PATCH,
+        "/api/v1/users/root",
+        &token,
+        &csrf,
+    )
+    .json(&serde_json::json!({"role": "viewer"}))
+    .send()
+    .await
+    .unwrap();
+    assert_eq!(ok.status(), 200);
+    let body: serde_json::Value = ok.json().await.unwrap();
+    assert_eq!(body["user"]["role"], "viewer", "{body}");
+}
+
+/// A mutating admin request from a cookie session carries the CSRF token like
+/// every other one: without it the middleware refuses before the handler runs,
+/// and no account is created.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn creating_an_account_needs_the_csrf_token() {
+    let (fixture, token, csrf) = serve_as_admin(AuthOptions::default()).await;
+    let addr = fixture.addr;
+    let body = serde_json::json!({"name": "bob", "role": "viewer", "password": "hunter2"});
+
+    let refused = client()
+        .post(format!("http://{addr}/api/v1/users"))
+        .header("cookie", format!("fluid_session={token}"))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), 403);
+    assert_eq!(
+        refused.headers()["content-type"],
+        "application/problem+json"
+    );
+    assert_eq!(
+        fixture.auth.list_users().await.unwrap().len(),
+        1,
+        "the refused request created nothing"
+    );
+
+    let ok = as_session(addr, reqwest::Method::POST, "/api/v1/users", &token, &csrf)
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ok.status(), 201, "with the token it goes through");
+}
+
+/// The invariant the trusted-header path leans on, asserted rather than
+/// assumed: that identity carries no CSRF token, so what keeps a cross-site
+/// form off these routes is the JSON content type this API demands. A form or
+/// text body - all a cross-site form can send without a CORS preflight, and no
+/// CORS layer exists on this surface - is refused by the extractor.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_cross_site_shaped_body_is_refused_on_the_trusted_header_path() {
+    let fixture = serve_with_auth(AuthOptions {
+        trusted_header: Some("remote-user"),
+        ..AuthOptions::default()
+    })
+    .await;
+    let addr = fixture.addr;
+    fixture
+        .auth
+        .ensure_user("proxy", Role::Viewer)
+        .await
+        .unwrap();
+    fixture.auth.set_role("proxy", Role::Admin).await.unwrap();
+    let url = format!("http://{addr}/api/v1/users");
+
+    for content_type in ["application/x-www-form-urlencoded", "text/plain"] {
+        let resp = client()
+            .post(&url)
+            .header("remote-user", "proxy")
+            .header("content-type", content_type)
+            .body(r#"{"name":"bob","role":"admin","password":"hunter2"}"#)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            415,
+            "a {content_type} body must not be acted on"
+        );
+        assert_eq!(resp.headers()["content-type"], "application/problem+json");
+    }
+    let names: Vec<String> = fixture
+        .auth
+        .list_users()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|u| u.name)
+        .collect();
+    assert_eq!(names, vec!["proxy".to_string()], "nothing was created");
+
+    let ok = client()
+        .post(&url)
+        .header("remote-user", "proxy")
+        .json(&serde_json::json!({"name": "bob", "role": "viewer", "password": "hunter2"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ok.status(), 201, "the JSON request is served");
+}
+
+/// The anonymous viewer never reaches these routes, which is what keeps the
+/// CSRF-less anonymous identity off every mutating admin path: it has no
+/// account, so it is told to authenticate rather than being served.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn the_anonymous_viewer_cannot_reach_the_user_routes() {
+    let fixture = serve_anonymous().await;
+    let addr = fixture.addr;
+
+    let listed = get(addr, "/api/v1/users").await;
+    assert_eq!(listed.status(), 401);
+    assert_eq!(listed.headers()["content-type"], "application/problem+json");
+
+    let created = client()
+        .post(format!("http://{addr}/api/v1/users"))
+        .json(&serde_json::json!({"name": "bob", "role": "admin", "password": "hunter2"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status(), 401);
+    assert!(
+        fixture.auth.list_users().await.unwrap().is_empty(),
+        "nothing was created"
+    );
+}
+
+/// The ways a user request can be wrong, each answered with the status a client
+/// can branch on: a name already taken is a conflict, an account nobody created
+/// is a 404, and a request the server understood but cannot act on is a 422.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_request_failures_are_classified() {
+    let (fixture, token, csrf) = serve_as_admin(AuthOptions::default()).await;
+    let addr = fixture.addr;
+
+    let duplicate = as_session(addr, reqwest::Method::POST, "/api/v1/users", &token, &csrf)
+        .json(&serde_json::json!({"name": "Root", "role": "admin", "password": "hunter2"}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(duplicate.status(), 409, "the name is taken");
+    let body: serde_json::Value = duplicate.json().await.unwrap();
+    assert!(
+        body["detail"].as_str().unwrap().contains("root"),
+        "the refusal names the account: {body}"
+    );
+    assert!(
+        !body["detail"].as_str().unwrap().contains("UNIQUE"),
+        "in product copy rather than in the database's words: {body}"
+    );
+
+    for (path, body, expected) in [
+        (
+            "/api/v1/users",
+            serde_json::json!({"name": "  ", "role": "viewer", "password": "hunter2"}),
+            422,
+        ),
+        (
+            "/api/v1/users",
+            serde_json::json!({"name": "bob", "role": "viewer", "password": ""}),
+            422,
+        ),
+        (
+            "/api/v1/users",
+            serde_json::json!({"name": "bob", "role": "wizard", "password": "hunter2"}),
+            422,
+        ),
+    ] {
+        let resp = as_session(addr, reqwest::Method::POST, path, &token, &csrf)
+            .json(&body)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), expected, "POST {body} must be refused");
+        assert_eq!(resp.headers()["content-type"], "application/problem+json");
+    }
+
+    for (method, body) in [
+        (
+            reqwest::Method::PATCH,
+            Some(serde_json::json!({"role": "viewer"})),
+        ),
+        (reqwest::Method::DELETE, None),
+    ] {
+        let mut request = as_session(addr, method.clone(), "/api/v1/users/ghost", &token, &csrf);
+        if let Some(body) = &body {
+            request = request.json(body);
+        }
+        let resp = request.send().await.unwrap();
+        assert_eq!(resp.status(), 404, "{method} on an unknown account");
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["title"], "not found");
+        assert!(body["detail"].as_str().unwrap().contains("ghost"), "{body}");
+    }
+
+    let nothing = as_session(
+        addr,
+        reqwest::Method::PATCH,
+        "/api/v1/users/root",
+        &token,
+        &csrf,
+    )
+    .json(&serde_json::json!({}))
+    .send()
+    .await
+    .unwrap();
+    assert_eq!(nothing.status(), 422, "a patch that changes nothing");
+    let body: serde_json::Value = nothing.json().await.unwrap();
+    assert!(
+        body["detail"].as_str().unwrap().contains("role"),
+        "the detail names what it takes: {body}"
+    );
 }

--- a/crates/service/tests/rest_api.rs
+++ b/crates/service/tests/rest_api.rs
@@ -47,6 +47,17 @@ async fn build_engine(opts: AuthOptions) -> (tempfile::TempDir, Arc<Engine>) {
         "---\ntype: manifest\ntitle: eng\npermalink: manifest\ntags:\n  - manifest\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# eng\n\n## Scope\n\n- Everything about eng\n\n## When to Use\n\n- Route here for eng questions\n",
     )
     .unwrap();
+    // A handful of engrams, so the listing and tree endpoints have real
+    // structure to report: one at the root, one a folder down, one two down.
+    for (rel, title) in [
+        ("alpha.md", "Alpha"),
+        ("notes/beta.md", "Beta"),
+        ("notes/deep/gamma.md", "Gamma"),
+    ] {
+        let path = dir.join(rel);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, engram_markdown(title)).unwrap();
+    }
     cfg.domains
         .insert("eng".to_string(), DomainEntry::file(dir));
     cfg.service = Some(ServiceConfig {
@@ -64,6 +75,16 @@ async fn build_engine(opts: AuthOptions) -> (tempfile::TempDir, Arc<Engine>) {
     ));
     engine.sync(None).await.unwrap();
     (tmp, engine)
+}
+
+/// One engram's markdown, in the shape a sync indexes: the frontmatter the
+/// format layer requires plus a body, so the fixture domain holds real rows
+/// rather than empty files.
+fn engram_markdown(title: &str) -> String {
+    let slug = title.to_ascii_lowercase();
+    format!(
+        "---\ntype: engram\ntitle: {title}\npermalink: {slug}\ntags:\n  - eng\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# {title}\n\nA rule about {slug}.\n"
+    )
 }
 
 /// Bind `http_router` on an ephemeral loopback port and serve it on a
@@ -111,6 +132,16 @@ async fn serve_with_auth(opts: AuthOptions) -> Fixture {
         auth,
         _tmp: tmp,
     }
+}
+
+/// The fixture with `auth.anonymous` on: the shortest way to reach a data
+/// route with an identity the guard accepts.
+async fn serve_anonymous() -> Fixture {
+    serve_with_auth(AuthOptions {
+        anonymous: true,
+        ..AuthOptions::default()
+    })
+    .await
 }
 
 /// The same fixture with one viewer account, `ada` / `s3cret`, already added.
@@ -172,6 +203,17 @@ fn set_cookie(resp: &reqwest::Response) -> Option<String> {
         .filter_map(|v| v.to_str().ok())
         .find(|v| v.starts_with("fluid_session="))
         .map(str::to_string)
+}
+
+/// The `path` of every engram a tree response lists, in the order it listed
+/// them.
+fn engram_paths(tree: &serde_json::Value) -> Vec<String> {
+    tree["engrams"]
+        .as_array()
+        .expect("a tree response carries an engrams array")
+        .iter()
+        .map(|e| e["path"].as_str().unwrap().to_string())
+        .collect()
 }
 
 /// The capability probe answers without an identity, which is what lets the UI
@@ -330,19 +372,27 @@ async fn a_failed_login_is_an_indistinguishable_401() {
 }
 
 /// The guard runs ahead of routing, so an unauthenticated caller is told to
-/// authenticate rather than being told which paths exist.
+/// authenticate rather than being told which paths exist. Every data route is
+/// checked, not just one: a route registered below the guard layer instead of
+/// above it would serve its payload to anybody, and only asking it would say so.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn data_routes_401_without_identity_when_not_anonymous() {
     let fixture = serve_with_auth(AuthOptions::default()).await;
-    let resp = get(fixture.addr, "/api/v1/domains").await;
-    assert_eq!(resp.status(), 401);
-    assert_eq!(resp.headers()["content-type"], "application/problem+json");
-    let body: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(body["status"], 401);
+    for path in [
+        "/api/v1/domains",
+        "/api/v1/domains/eng/tree",
+        "/api/v1/domains/eng/manifest",
+    ] {
+        let resp = get(fixture.addr, path).await;
+        assert_eq!(resp.status(), 401, "{path} must be guarded");
+        assert_eq!(resp.headers()["content-type"], "application/problem+json");
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["status"], 401);
+    }
 }
 
-/// A logged-in caller passes the guard: the request reaches routing, where this
-/// path is simply unknown until the data routes land.
+/// A logged-in caller passes the guard and is served the data itself: the
+/// session cookie alone is enough to read the domain listing.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn data_routes_pass_the_guard_with_a_session() {
     let fixture = serve_with_ada(AuthOptions::default()).await;
@@ -353,20 +403,20 @@ async fn data_routes_pass_the_guard_with_a_session() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status(), 404, "past the guard, into routing");
+    assert_eq!(resp.status(), 200, "past the guard, into the handler");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["domains"][0]["name"], "eng");
 }
 
 /// With `auth.anonymous` on, an unidentified caller is served as a viewer, so
-/// the guard lets the request through to routing.
+/// the guard lets the request through to the data itself.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn anonymous_access_passes_the_guard() {
-    let fixture = serve_with_auth(AuthOptions {
-        anonymous: true,
-        ..AuthOptions::default()
-    })
-    .await;
+    let fixture = serve_anonymous().await;
     let resp = get(fixture.addr, "/api/v1/domains").await;
-    assert_eq!(resp.status(), 404, "past the guard, into routing");
+    assert_eq!(resp.status(), 200, "past the guard, into the handler");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["domains"][0]["name"], "eng");
 }
 
 /// The trusted-header path: the proxy has already authenticated the caller, so
@@ -395,14 +445,16 @@ async fn trusted_header_maps_identity() {
     assert_eq!(users.len(), 1, "the account was provisioned once");
     assert_eq!(users[0].name, "bob");
 
-    // A data route is reachable with the header alone: no cookie, no login.
+    // A data route is served with the header alone: no cookie, no login.
     let resp = client()
         .get(format!("http://{}/api/v1/domains", fixture.addr))
         .header("remote-user", "bob")
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status(), 404, "past the guard, into routing");
+    assert_eq!(resp.status(), 200, "past the guard, into the handler");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["domains"][0]["name"], "eng");
 }
 
 /// The header is only believed when it is configured: an instance that has not
@@ -616,4 +668,217 @@ async fn logging_in_retires_the_session_that_was_presented() {
         .await
         .unwrap();
     assert_eq!(still["user"]["name"], "ada");
+}
+
+/// The domain listing is the engine's own value, verbatim: every registered
+/// domain with its counts, plus the routing block a client needs to know what
+/// each domain is for. `include_routing` is always on, so `behavior` and
+/// `when_to_use` are part of the contract rather than an option a caller has to
+/// ask for.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn domains_lists_every_domain_with_its_routing_bullets() {
+    let fixture = serve_anonymous().await;
+    let resp = get(fixture.addr, "/api/v1/domains").await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        body["behavior"].as_array().is_some_and(|b| !b.is_empty()),
+        "the listing carries the behavior rules: {body}"
+    );
+    let domains = body["domains"].as_array().unwrap();
+    assert_eq!(domains.len(), 1, "one registered domain: {body}");
+    assert_eq!(domains[0]["name"], "eng");
+    assert_eq!(domains[0]["kind"], "file");
+    assert_eq!(
+        domains[0]["engrams"], 4,
+        "the MANIFEST and the three seeded engrams: {body}"
+    );
+    assert!(
+        domains[0]["when_to_use"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|b| b.as_str().unwrap().contains("Route here for eng")),
+        "the routing bullets come from the MANIFEST: {body}"
+    );
+}
+
+/// The tree endpoint is `browse_domain` behind a query string: the defaults
+/// list the root one level deep, `path` descends, `depth` widens and `glob`
+/// filters.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn domain_tree_walks_folders_and_filters_by_glob() {
+    let fixture = serve_anonymous().await;
+
+    let root: serde_json::Value = get(fixture.addr, "/api/v1/domains/eng/tree")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(root["domain"], "eng");
+    assert_eq!(root["path"], "/");
+    assert_eq!(root["folders"].as_array().unwrap(), &["notes"]);
+    let paths = engram_paths(&root);
+    assert!(paths.contains(&"alpha.md".to_string()), "{paths:?}");
+    assert!(paths.contains(&"MANIFEST.md".to_string()), "{paths:?}");
+    assert!(
+        !paths.contains(&"notes/beta.md".to_string()),
+        "one level deep by default: {paths:?}"
+    );
+
+    let notes: serde_json::Value = get(fixture.addr, "/api/v1/domains/eng/tree?path=notes&depth=2")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(notes["path"], "notes");
+    assert_eq!(notes["folders"].as_array().unwrap(), &["deep"]);
+    let paths = engram_paths(&notes);
+    assert!(paths.contains(&"notes/beta.md".to_string()), "{paths:?}");
+    assert!(
+        paths.contains(&"notes/deep/gamma.md".to_string()),
+        "depth 2 reaches the nested folder: {paths:?}"
+    );
+
+    let globbed: serde_json::Value = get(
+        fixture.addr,
+        "/api/v1/domains/eng/tree?depth=3&glob=notes/**",
+    )
+    .await
+    .json()
+    .await
+    .unwrap();
+    let paths = engram_paths(&globbed);
+    assert_eq!(
+        paths,
+        vec![
+            "notes/beta.md".to_string(),
+            "notes/deep/gamma.md".to_string()
+        ],
+        "the glob filters the whole walk"
+    );
+}
+
+/// The manifest endpoint hands back the domain's MANIFEST markdown as written,
+/// so a client can render or edit the source rather than a reduction of it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn domain_manifest_returns_the_markdown_source() {
+    let fixture = serve_anonymous().await;
+    let resp = get(fixture.addr, "/api/v1/domains/eng/manifest").await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["domain"], "eng");
+    let markdown = body["markdown"].as_str().expect("markdown is a string");
+    assert!(
+        markdown.starts_with("---\n"),
+        "the frontmatter is part of the source: {markdown}"
+    );
+    assert!(markdown.contains("## When to Use"), "{markdown}");
+    assert!(
+        markdown.contains("Route here for eng questions"),
+        "{markdown}"
+    );
+}
+
+/// A domain nobody registered is a 404 problem detail that names the domains
+/// that do exist, the same answer the engine's other verbs give.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unknown_domain_is_a_404_problem_detail() {
+    let fixture = serve_anonymous().await;
+    for path in [
+        "/api/v1/domains/ghost/tree",
+        "/api/v1/domains/ghost/manifest",
+    ] {
+        let resp = get(fixture.addr, path).await;
+        assert_eq!(resp.status(), 404, "{path} must be a 404");
+        assert_eq!(resp.headers()["content-type"], "application/problem+json");
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["status"], 404);
+        assert_eq!(body["title"], "not found");
+        let detail = body["detail"].as_str().unwrap();
+        assert!(detail.contains("ghost"), "{detail}");
+        assert!(detail.contains("eng"), "the valid set is named: {detail}");
+    }
+}
+
+/// axum's own extractor rejections are rendered in the same problem+json
+/// contract as everything else, so a client never has to parse a plain-text
+/// body it was not expecting: a query parameter of the wrong type is a 400
+/// problem detail rather than `Failed to deserialize query string` in text.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_malformed_query_parameter_is_a_problem_detail() {
+    let fixture = serve_anonymous().await;
+    let resp = get(fixture.addr, "/api/v1/domains/eng/tree?depth=deep").await;
+    assert_eq!(resp.status(), 400);
+    assert_eq!(resp.headers()["content-type"], "application/problem+json");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], 400);
+    assert_eq!(body["title"], "invalid request");
+    assert!(
+        body["detail"].as_str().unwrap().contains("query"),
+        "the detail says what was wrong: {body}"
+    );
+}
+
+/// A method a route does not serve is a 405 problem detail rather than axum's
+/// empty default, and it still carries the `Allow` header the HTTP spec asks
+/// for.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_wrong_method_is_a_405_problem_detail() {
+    let fixture = serve_anonymous().await;
+    let resp = client()
+        .post(format!("http://{}/api/v1/domains", fixture.addr))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 405);
+    assert_eq!(resp.headers()["content-type"], "application/problem+json");
+    assert!(
+        resp.headers()
+            .get("allow")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| v.contains("GET")),
+        "a 405 names the methods that do work: {:?}",
+        resp.headers()
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], 405);
+    assert_eq!(body["title"], "method not allowed");
+}
+
+/// The same contract on the way in: a login body axum cannot deserialize is a
+/// problem detail, whether it is unparseable, the wrong shape or sent without a
+/// JSON content type.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_malformed_request_body_is_a_problem_detail() {
+    let fixture = serve_with_ada(AuthOptions::default()).await;
+    let url = format!("http://{}/api/v1/auth/login", fixture.addr);
+    let cases = [
+        // Unparseable JSON.
+        (
+            client()
+                .post(&url)
+                .header("content-type", "application/json")
+                .body("{"),
+            400,
+        ),
+        // Parseable, but not the shape the handler takes.
+        (
+            client().post(&url).json(&serde_json::json!({"name": 7})),
+            422,
+        ),
+        // No JSON content type at all.
+        (client().post(&url).body("name=ada"), 415),
+    ];
+    for (request, expected) in cases {
+        let resp = request.send().await.unwrap();
+        assert_eq!(resp.status(), expected);
+        assert_eq!(resp.headers()["content-type"], "application/problem+json");
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["status"], expected);
+        assert!(
+            !body["detail"].as_str().unwrap().is_empty(),
+            "the detail says what was wrong: {body}"
+        );
+    }
 }

--- a/crates/service/tests/rest_api.rs
+++ b/crates/service/tests/rest_api.rs
@@ -56,6 +56,13 @@ async fn build_engine(opts: AuthOptions) -> (tempfile::TempDir, Arc<Engine>) {
     }
     cfg.domains
         .insert("eng".to_string(), DomainEntry::file(dir));
+    // A registered domain that holds nothing, so "this domain does not exist"
+    // and "this domain is empty" are both reachable and visibly different. It
+    // is virtual because a file domain always has its MANIFEST indexed and so
+    // is never truly empty. Registered after `eng`, and the config keeps
+    // insertion order, so the listing's first domain is still `eng`.
+    cfg.domains
+        .insert("void".to_string(), DomainEntry::virtual_domain());
     cfg.service = Some(ServiceConfig {
         response_format: Some(ResponseFormat::Json),
         ..ServiceConfig::default()
@@ -771,7 +778,11 @@ async fn domains_lists_every_domain_with_its_routing_bullets() {
         "the listing carries the behavior rules: {body}"
     );
     let domains = body["domains"].as_array().unwrap();
-    assert_eq!(domains.len(), 1, "one registered domain: {body}");
+    assert_eq!(
+        domains.len(),
+        2,
+        "the seeded domain and the empty one: {body}"
+    );
     assert_eq!(domains[0]["name"], "eng");
     assert_eq!(domains[0]["kind"], "file");
     assert_eq!(
@@ -938,6 +949,45 @@ async fn engram_list_filters_and_carries_the_page_envelope() {
     assert_eq!(unique.len(), 4, "the pages do not overlap: {paged:?}");
 }
 
+/// The two states a client must be able to tell apart, which is why the
+/// listing resolves the domain in its path rather than passing it to the
+/// search filter and reporting whatever comes back: a domain nobody
+/// registered is missing, and a registered domain that holds nothing is
+/// empty. A filter that selects nothing is the empty case too - the path
+/// segment names a resource, the query only narrows it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_empty_domain_lists_empty_and_an_unknown_one_is_a_404() {
+    let fixture = serve_anonymous().await;
+
+    let empty = get(fixture.addr, "/api/v1/domains/void/engrams").await;
+    assert_eq!(empty.status(), 200, "a registered domain answers");
+    let body: serde_json::Value = empty.json().await.unwrap();
+    assert_eq!(body["total"], 0, "and holds nothing: {body}");
+    assert!(hit_permalinks(&body).is_empty(), "{body}");
+
+    let filtered: serde_json::Value = get(fixture.addr, "/api/v1/domains/eng/engrams?tags=nothing")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        filtered["total"], 0,
+        "a filter that selects nothing is empty, not missing: {filtered}"
+    );
+
+    let unknown = get(fixture.addr, "/api/v1/domains/ghost/engrams").await;
+    assert_eq!(unknown.status(), 404, "an unregistered domain is missing");
+    assert_eq!(
+        unknown.headers()["content-type"],
+        "application/problem+json"
+    );
+    let body: serde_json::Value = unknown.json().await.unwrap();
+    assert_eq!(body["title"], "not found");
+    let detail = body["detail"].as_str().unwrap();
+    assert!(detail.contains("ghost"), "{detail}");
+    assert!(detail.contains("eng"), "the valid set is named: {detail}");
+}
+
 /// The detail route answers with the engram itself - its frontmatter, its
 /// markdown and the graph the engine resolves around it - plus an `ETag` a
 /// later conditional write can present. The validator is the SHA-256 of the
@@ -1032,6 +1082,7 @@ async fn an_unknown_domain_is_a_404_problem_detail() {
     for path in [
         "/api/v1/domains/ghost/tree",
         "/api/v1/domains/ghost/manifest",
+        "/api/v1/domains/ghost/engrams",
     ] {
         let resp = get(fixture.addr, path).await;
         assert_eq!(resp.status(), 404, "{path} must be a 404");

--- a/crates/service/tests/rest_api.rs
+++ b/crates/service/tests/rest_api.rs
@@ -552,6 +552,13 @@ async fn a_failed_login_is_an_indistinguishable_401() {
 async fn data_routes_401_without_identity_when_not_anonymous() {
     let fixture = serve_with_auth(AuthOptions::default()).await;
     for path in [
+        // The document describing this API is guarded like the data it
+        // describes: it is deliberately not in `PUBLIC_PATHS`, because handing
+        // an unauthenticated caller every path and parameter would undo what
+        // answering 401 ahead of routing is for. Tooling reads the committed
+        // `crates/service/openapi/fluid-v1.json` instead, so nothing needs it
+        // open.
+        "/api/v1/openapi.json",
         "/api/v1/domains",
         "/api/v1/domains/eng/tree",
         "/api/v1/domains/eng/manifest",
@@ -572,6 +579,29 @@ async fn data_routes_401_without_identity_when_not_anonymous() {
         let body: serde_json::Value = resp.json().await.unwrap();
         assert_eq!(body["status"], 401);
     }
+}
+
+/// The served document is the same one the snapshot pins, so a client that does
+/// reach the route reads exactly what the committed artifact says.
+///
+/// Asserted over the wire rather than only in `openapi_snapshot.rs`, because
+/// that test never mounts a router: this is what says the route is wired to
+/// `openapi_document` and not to some second, drifting construction.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn openapi_route_serves_the_document_the_snapshot_pins() {
+    let fixture = serve_with_ada(AuthOptions::default()).await;
+    let (token, _) = login(fixture.addr, "ada", "s3cret").await;
+    let resp = client()
+        .get(format!("http://{}/api/v1/openapi.json", fixture.addr))
+        .header("cookie", format!("fluid_session={token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let served: serde_json::Value = resp.json().await.unwrap();
+    let generated = serde_json::to_value(crystalline_service::rest::openapi_document()).unwrap();
+    assert_eq!(served, generated, "the route serves the document verbatim");
+    assert_eq!(served["info"]["version"], "v1");
 }
 
 /// A logged-in caller passes the guard and is served the data itself: the

--- a/crates/service/tests/rest_api.rs
+++ b/crates/service/tests/rest_api.rs
@@ -94,6 +94,9 @@ struct FixtureEngram {
     engram_type: &'static str,
     /// The tag it carries beside the shared `eng` one.
     tag: &'static str,
+    /// The title this engram declares a `relates_to` relation onto, if any, so
+    /// the fixture domain holds a real edge for the context endpoint to walk.
+    relates_to: Option<&'static str>,
 }
 
 impl FixtureEngram {
@@ -106,11 +109,15 @@ impl FixtureEngram {
             permalink,
             engram_type,
             tag,
+            relates_to,
             ..
         } = *self;
         let slug = title.to_ascii_lowercase();
+        let relation = relates_to
+            .map(|target| format!("\n- relates_to [[{target}]]\n"))
+            .unwrap_or_default();
         format!(
-            "---\ntype: {engram_type}\ntitle: {title}\npermalink: {permalink}\ntags:\n  - eng\n  - {tag}\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# {title}\n\nA rule about {slug}.\n"
+            "---\ntype: {engram_type}\ntitle: {title}\npermalink: {permalink}\ntags:\n  - eng\n  - {tag}\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# {title}\n\nA rule about {slug}.\n{relation}"
         )
     }
 }
@@ -118,7 +125,8 @@ impl FixtureEngram {
 /// The seeded engrams: one at the root, one a folder down, one two down. The
 /// nested two carry folder-shaped permalinks, so the detail route is exercised
 /// on a permalink with slashes in it, and the types and tags differ so a
-/// filtered listing has something to select on.
+/// filtered listing has something to select on. Beta relates to Alpha, so the
+/// domain holds one edge and the context endpoint has a neighborhood to return.
 const FIXTURE_ENGRAMS: [FixtureEngram; 3] = [
     FixtureEngram {
         path: "alpha.md",
@@ -126,6 +134,7 @@ const FIXTURE_ENGRAMS: [FixtureEngram; 3] = [
         permalink: "alpha",
         engram_type: "engram",
         tag: "root",
+        relates_to: None,
     },
     FixtureEngram {
         path: "notes/beta.md",
@@ -133,6 +142,7 @@ const FIXTURE_ENGRAMS: [FixtureEngram; 3] = [
         permalink: "notes/beta",
         engram_type: "guide",
         tag: "nested",
+        relates_to: Some("Alpha"),
     },
     FixtureEngram {
         path: "notes/deep/gamma.md",
@@ -140,6 +150,7 @@ const FIXTURE_ENGRAMS: [FixtureEngram; 3] = [
         permalink: "notes/deep/gamma",
         engram_type: "engram",
         tag: "nested",
+        relates_to: None,
     },
 ];
 
@@ -288,6 +299,26 @@ fn hit_permalinks(page: &serde_json::Value) -> Vec<String> {
         .expect("a listing carries a hits array")
         .iter()
         .map(|h| h["permalink"].as_str().unwrap().to_string())
+        .collect()
+}
+
+/// The `permalink` of every node a context response returned, in the order it
+/// returned them: the seeds first, then the neighborhood by rank.
+fn node_permalinks(context: &serde_json::Value) -> Vec<String> {
+    context["nodes"]
+        .as_array()
+        .expect("a context response carries a nodes array")
+        .iter()
+        .map(|n| n["permalink"].as_str().unwrap().to_string())
+        .collect()
+}
+
+/// The `name` of every entry in one of a vocabulary response's count lists.
+fn names(list: &serde_json::Value) -> Vec<String> {
+    list.as_array()
+        .expect("a vocabulary list is an array")
+        .iter()
+        .map(|t| t["name"].as_str().unwrap().to_string())
         .collect()
 }
 
@@ -474,6 +505,10 @@ async fn data_routes_401_without_identity_when_not_anonymous() {
         "/api/v1/domains/eng/engrams",
         "/api/v1/domains/eng/engrams/alpha",
         "/api/v1/domains/eng/engrams/notes/deep/gamma",
+        "/api/v1/search",
+        "/api/v1/vocabulary",
+        "/api/v1/context",
+        "/api/v1/activity",
     ] {
         let resp = get(fixture.addr, path).await;
         assert_eq!(resp.status(), 401, "{path} must be guarded");
@@ -1176,4 +1211,385 @@ async fn a_malformed_request_body_is_a_problem_detail() {
             "the detail says what was wrong: {body}"
         );
     }
+}
+
+/// Search is `search_engrams` behind a query string: the text selects on the
+/// body rather than on a title, every filter narrows the same way the MCP tool's
+/// does, and the engine's page envelope comes through unchanged.
+///
+/// The word searched for lives only in the fixture bodies, so a hit proves the
+/// content was matched rather than the permalink the URL already carries. The
+/// fixture has no embeddings and the test engine no provider, so hybrid resolves
+/// to its text fallback and the response says so in `mode`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn search_finds_engrams_by_their_content() {
+    let fixture = serve_anonymous().await;
+
+    let resp = get(fixture.addr, "/api/v1/search?q=rule").await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["mode"], "text",
+        "hybrid falls back to text with no embeddings to search: {body}"
+    );
+    assert_eq!(body["page"], 1, "the page envelope is the engine's: {body}");
+    assert_eq!(body["limit"], 10, "{body}");
+    assert_eq!(
+        body["total"], 3,
+        "the three bodies, not the MANIFEST: {body}"
+    );
+    let mut found = hit_permalinks(&body);
+    found.sort();
+    assert_eq!(
+        found,
+        vec![
+            "alpha".to_string(),
+            "notes/beta".to_string(),
+            "notes/deep/gamma".to_string()
+        ],
+        "{body}"
+    );
+
+    // Every filter, mapped one for one onto the search parameters.
+    let typed: serde_json::Value = get(fixture.addr, "/api/v1/search?q=rule&type=guide")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(hit_permalinks(&typed), vec!["notes/beta".to_string()]);
+
+    let tagged: serde_json::Value = get(fixture.addr, "/api/v1/search?q=rule&tags=eng,nested")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        tagged["total"], 2,
+        "a comma list is split and every tag must match: {tagged}"
+    );
+
+    let statused: serde_json::Value = get(fixture.addr, "/api/v1/search?q=rule&status=draft")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(statused["total"], 0, "nothing is a draft here: {statused}");
+
+    let recent: serde_json::Value = get(fixture.addr, "/api/v1/search?q=rule&after=2026-06-01")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        recent["total"], 0,
+        "everything was recorded before that: {recent}"
+    );
+
+    let titled: serde_json::Value = get(fixture.addr, "/api/v1/search?q=Alpha&search_type=title")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        titled["mode"], "title",
+        "the mode asked for is used: {titled}"
+    );
+    assert_eq!(hit_permalinks(&titled), vec!["alpha".to_string()]);
+
+    let bounded: serde_json::Value = get(
+        fixture.addr,
+        "/api/v1/search?q=rule&search_type=text&min_similarity=0.5&limit=2&page=2",
+    )
+    .await
+    .json()
+    .await
+    .unwrap();
+    assert_eq!(bounded["page"], 2, "{bounded}");
+    assert_eq!(bounded["limit"], 2, "{bounded}");
+    assert_eq!(bounded["total"], 3, "the total spans the pages: {bounded}");
+    assert_eq!(bounded["count"], 1, "the tail of three: {bounded}");
+}
+
+/// A domain in the query string is a filter, not a resource: it narrows what is
+/// searched and an unmatched name narrows it to nothing. That is what separates
+/// it from a domain in a path segment, which names a resource and 404s when
+/// nobody registered it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_domain_filter_narrows_rather_than_404s() {
+    let fixture = serve_anonymous().await;
+
+    let scoped: serde_json::Value = get(fixture.addr, "/api/v1/search?q=rule&domains=eng")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(scoped["total"], 3, "{scoped}");
+
+    let elsewhere: serde_json::Value = get(fixture.addr, "/api/v1/search?q=rule&domains=void")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        elsewhere["total"], 0,
+        "the other registered domain holds nothing: {elsewhere}"
+    );
+
+    let unknown = get(fixture.addr, "/api/v1/search?q=rule&domains=ghost").await;
+    assert_eq!(
+        unknown.status(),
+        200,
+        "an unregistered name in a filter selects nothing, it does not 404"
+    );
+    let body: serde_json::Value = unknown.json().await.unwrap();
+    assert_eq!(body["total"], 0, "{body}");
+
+    // The list is split on commas, so both names are asked for at once.
+    let both: serde_json::Value = get(fixture.addr, "/api/v1/search?q=rule&domains=eng,void")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(both["total"], 3, "{both}");
+
+    let activity: serde_json::Value = get(fixture.addr, "/api/v1/activity?domains=ghost")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        activity["count"], 0,
+        "the same rule on activity: {activity}"
+    );
+
+    let vocab = get(fixture.addr, "/api/v1/vocabulary?domain=ghost").await;
+    assert_eq!(vocab.status(), 200, "and on the vocabulary");
+    let body: serde_json::Value = vocab.json().await.unwrap();
+    assert!(body["tags"].as_array().unwrap().is_empty(), "{body}");
+}
+
+/// A value the engine refuses is a 422 problem detail carrying the engine's own
+/// message, so the caller is told which values do work rather than being handed
+/// a bare status.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unknown_search_type_is_a_422_carrying_the_engines_message() {
+    let fixture = serve_anonymous().await;
+    let resp = get(fixture.addr, "/api/v1/search?q=rule&search_type=nope").await;
+    assert_eq!(resp.status(), 422);
+    assert_eq!(resp.headers()["content-type"], "application/problem+json");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], 422);
+    assert_eq!(body["title"], "invalid request");
+    let detail = body["detail"].as_str().unwrap();
+    assert!(
+        detail.contains("unknown search_type 'nope'"),
+        "the engine's own message arrives verbatim: {detail}"
+    );
+    assert!(
+        detail.contains("hybrid, text, semantic, title or permalink"),
+        "and it names what does work: {detail}"
+    );
+}
+
+/// The vocabulary endpoint hands back what the domains are written in: the tags
+/// in use with their counts, the observation categories and the relation types.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn vocabulary_lists_the_tags_and_relation_types_in_use() {
+    let fixture = serve_anonymous().await;
+
+    let resp = get(fixture.addr, "/api/v1/vocabulary").await;
+    assert_eq!(resp.status(), 200);
+    let all: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        all["domain"].is_null(),
+        "no domain was asked for, so none is echoed: {all}"
+    );
+    let tags = names(&all["tags"]);
+    for tag in ["eng", "root", "nested", "manifest"] {
+        assert!(tags.contains(&tag.to_string()), "{tag} missing from {all}");
+    }
+    let eng = all["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["name"] == "eng")
+        .expect("the shared tag is listed");
+    assert_eq!(eng["engrams"], 3, "it tags the three seeded engrams: {all}");
+    assert!(
+        names(&all["relation_types"]).contains(&"relates_to".to_string()),
+        "the one relation the fixture declares: {all}"
+    );
+
+    let scoped: serde_json::Value = get(fixture.addr, "/api/v1/vocabulary?domain=void")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(scoped["domain"], "void", "the scope is echoed: {scoped}");
+    assert!(
+        scoped["tags"].as_array().unwrap().is_empty(),
+        "the empty domain is written in nothing yet: {scoped}"
+    );
+}
+
+/// Context walks the graph out from a `crystalline://` anchor: the anchor comes
+/// back as a seed node, its neighbors come back beside it, and the edges between
+/// them say how they are related.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn context_returns_the_anchor_and_its_neighborhood() {
+    let fixture = serve_anonymous().await;
+
+    let resp = get(
+        fixture.addr,
+        "/api/v1/context?anchor=crystalline://eng/alpha",
+    )
+    .await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["anchor"], "crystalline://eng/alpha");
+    assert_eq!(body["depth"], 1, "one hop by default: {body}");
+    let nodes = body["nodes"].as_array().unwrap();
+    assert_eq!(nodes[0]["permalink"], "alpha", "the anchor leads: {body}");
+    assert_eq!(nodes[0]["seed"], true, "and is marked as the seed: {body}");
+    assert!(
+        node_permalinks(&body).contains(&"notes/beta".to_string()),
+        "the engram relating to it comes with: {body}"
+    );
+    let edges = body["edges"].as_array().unwrap();
+    assert!(
+        edges.iter().any(|e| e["rel_type"] == "relates_to"),
+        "the edge says how they are related: {body}"
+    );
+
+    // `max_related` caps the neighborhood, `domains` filters it, and `depth` is
+    // passed through to the traversal.
+    let alone: serde_json::Value = get(
+        fixture.addr,
+        "/api/v1/context?anchor=crystalline://eng/alpha&max_related=0&depth=2",
+    )
+    .await
+    .json()
+    .await
+    .unwrap();
+    assert_eq!(alone["depth"], 2, "{alone}");
+    assert_eq!(
+        node_permalinks(&alone),
+        vec!["alpha".to_string()],
+        "the seed alone: {alone}"
+    );
+
+    let filtered: serde_json::Value = get(
+        fixture.addr,
+        "/api/v1/context?anchor=crystalline://eng/alpha&domains=void",
+    )
+    .await
+    .json()
+    .await
+    .unwrap();
+    assert!(
+        node_permalinks(&filtered).is_empty(),
+        "a domain filter that matches nothing keeps nothing: {filtered}"
+    );
+}
+
+/// The three ways an anchor can be wrong, each answered in the same problem+json
+/// contract: absent is a rejected request, unparseable is one the server
+/// understood and refused, and one pointing at nothing is missing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_bad_context_anchor_is_a_problem_detail() {
+    let fixture = serve_anonymous().await;
+
+    let missing = get(fixture.addr, "/api/v1/context").await;
+    assert_eq!(missing.status(), 400, "the anchor is required");
+    assert_eq!(
+        missing.headers()["content-type"],
+        "application/problem+json"
+    );
+    let body: serde_json::Value = missing.json().await.unwrap();
+    assert!(
+        body["detail"].as_str().unwrap().contains("anchor"),
+        "the detail names the parameter: {body}"
+    );
+
+    let malformed = get(fixture.addr, "/api/v1/context?anchor=alpha").await;
+    assert_eq!(malformed.status(), 422);
+    let body: serde_json::Value = malformed.json().await.unwrap();
+    assert!(
+        body["detail"]
+            .as_str()
+            .unwrap()
+            .contains("not a crystalline:// URL"),
+        "the engine's own message: {body}"
+    );
+
+    let unknown = get(
+        fixture.addr,
+        "/api/v1/context?anchor=crystalline://eng/ghost",
+    )
+    .await;
+    assert_eq!(unknown.status(), 404);
+    let body: serde_json::Value = unknown.json().await.unwrap();
+    assert_eq!(body["title"], "not found");
+    assert!(body["detail"].as_str().unwrap().contains("ghost"), "{body}");
+}
+
+/// Activity is the recency window behind a query string: the timeframe decides
+/// what is recent enough to report, and the type and domain filters narrow it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn activity_respects_the_timeframe_and_its_filters() {
+    let fixture = serve_anonymous().await;
+
+    // The fixture was recorded on a fixed past date, so a one-day window reaches
+    // nothing and a wide one reaches everything: the window is what changes the
+    // answer.
+    let today = get(fixture.addr, "/api/v1/activity?timeframe=1d").await;
+    assert_eq!(today.status(), 200);
+    let body: serde_json::Value = today.json().await.unwrap();
+    assert_eq!(body["timeframe"], "1d", "the window is echoed: {body}");
+    assert_eq!(body["count"], 0, "nothing was recorded yesterday: {body}");
+
+    let ever: serde_json::Value = get(fixture.addr, "/api/v1/activity?timeframe=20y")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        ever["count"], 4,
+        "the MANIFEST and the three seeded engrams: {ever}"
+    );
+    let permalinks: Vec<&str> = ever["engrams"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|e| e["permalink"].as_str().unwrap())
+        .collect();
+    assert!(permalinks.contains(&"alpha"), "{ever}");
+
+    let typed: serde_json::Value = get(fixture.addr, "/api/v1/activity?timeframe=20y&types=guide")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(typed["count"], 1, "only the guide: {typed}");
+    assert_eq!(typed["engrams"][0]["permalink"], "notes/beta");
+
+    let multi: serde_json::Value = get(
+        fixture.addr,
+        "/api/v1/activity?timeframe=20y&types=guide,manifest&domains=eng",
+    )
+    .await
+    .json()
+    .await
+    .unwrap();
+    assert_eq!(multi["count"], 2, "a comma list is split: {multi}");
+
+    let default: serde_json::Value = get(fixture.addr, "/api/v1/activity")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        default["timeframe"], "7d",
+        "the engine's own default, not a second one here: {default}"
+    );
 }

--- a/crates/service/tests/rest_api.rs
+++ b/crates/service/tests/rest_api.rs
@@ -49,14 +49,10 @@ async fn build_engine(opts: AuthOptions) -> (tempfile::TempDir, Arc<Engine>) {
     .unwrap();
     // A handful of engrams, so the listing and tree endpoints have real
     // structure to report: one at the root, one a folder down, one two down.
-    for (rel, title) in [
-        ("alpha.md", "Alpha"),
-        ("notes/beta.md", "Beta"),
-        ("notes/deep/gamma.md", "Gamma"),
-    ] {
-        let path = dir.join(rel);
+    for engram in FIXTURE_ENGRAMS {
+        let path = dir.join(engram.path);
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
-        std::fs::write(&path, engram_markdown(title)).unwrap();
+        std::fs::write(&path, engram.markdown()).unwrap();
     }
     cfg.domains
         .insert("eng".to_string(), DomainEntry::file(dir));
@@ -77,15 +73,68 @@ async fn build_engine(opts: AuthOptions) -> (tempfile::TempDir, Arc<Engine>) {
     (tmp, engine)
 }
 
-/// One engram's markdown, in the shape a sync indexes: the frontmatter the
-/// format layer requires plus a body, so the fixture domain holds real rows
-/// rather than empty files.
-fn engram_markdown(title: &str) -> String {
-    let slug = title.to_ascii_lowercase();
-    format!(
-        "---\ntype: engram\ntitle: {title}\npermalink: {slug}\ntags:\n  - eng\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# {title}\n\nA rule about {slug}.\n"
-    )
+/// One fixture engram: where it lives, what it is called, and the frontmatter
+/// that lets a filtered listing tell it apart from its siblings.
+struct FixtureEngram {
+    /// The domain-relative path the file is written at.
+    path: &'static str,
+    /// The engram title.
+    title: &'static str,
+    /// The permalink it carries, folder-shaped for the nested ones the way a
+    /// real domain writes them.
+    permalink: &'static str,
+    /// The engram `type`.
+    engram_type: &'static str,
+    /// The tag it carries beside the shared `eng` one.
+    tag: &'static str,
 }
+
+impl FixtureEngram {
+    /// This engram's markdown, in the shape a sync indexes: the frontmatter the
+    /// format layer requires plus a body, so the fixture domain holds real rows
+    /// rather than empty files.
+    fn markdown(&self) -> String {
+        let FixtureEngram {
+            title,
+            permalink,
+            engram_type,
+            tag,
+            ..
+        } = *self;
+        let slug = title.to_ascii_lowercase();
+        format!(
+            "---\ntype: {engram_type}\ntitle: {title}\npermalink: {permalink}\ntags:\n  - eng\n  - {tag}\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# {title}\n\nA rule about {slug}.\n"
+        )
+    }
+}
+
+/// The seeded engrams: one at the root, one a folder down, one two down. The
+/// nested two carry folder-shaped permalinks, so the detail route is exercised
+/// on a permalink with slashes in it, and the types and tags differ so a
+/// filtered listing has something to select on.
+const FIXTURE_ENGRAMS: [FixtureEngram; 3] = [
+    FixtureEngram {
+        path: "alpha.md",
+        title: "Alpha",
+        permalink: "alpha",
+        engram_type: "engram",
+        tag: "root",
+    },
+    FixtureEngram {
+        path: "notes/beta.md",
+        title: "Beta",
+        permalink: "notes/beta",
+        engram_type: "guide",
+        tag: "nested",
+    },
+    FixtureEngram {
+        path: "notes/deep/gamma.md",
+        title: "Gamma",
+        permalink: "notes/deep/gamma",
+        engram_type: "engram",
+        tag: "nested",
+    },
+];
 
 /// Bind `http_router` on an ephemeral loopback port and serve it on a
 /// background task for the duration of the test.
@@ -108,6 +157,14 @@ struct Fixture {
     addr: std::net::SocketAddr,
     auth: Arc<AuthStore>,
     _tmp: tempfile::TempDir,
+}
+
+impl Fixture {
+    /// The bytes of one seeded engram as they sit on disk, the source of truth
+    /// a response is checked against.
+    fn engram_bytes(&self, path: &str) -> Vec<u8> {
+        std::fs::read(self._tmp.path().join("eng").join(path)).unwrap()
+    }
 }
 
 /// Serve the production router over a fixture engine. The returned guard owns
@@ -213,6 +270,31 @@ fn engram_paths(tree: &serde_json::Value) -> Vec<String> {
         .expect("a tree response carries an engrams array")
         .iter()
         .map(|e| e["path"].as_str().unwrap().to_string())
+        .collect()
+}
+
+/// The `permalink` of every hit a listing returned, in the order it returned
+/// them.
+fn hit_permalinks(page: &serde_json::Value) -> Vec<String> {
+    page["hits"]
+        .as_array()
+        .expect("a listing carries a hits array")
+        .iter()
+        .map(|h| h["permalink"].as_str().unwrap().to_string())
+        .collect()
+}
+
+/// The lowercase hex SHA-256 digest of `bytes`, computed here rather than
+/// asked of the server: the point of the ETag assertions is that the validator
+/// the API sends is the digest of the markdown, independently arrived at.
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
         .collect()
 }
 
@@ -382,6 +464,9 @@ async fn data_routes_401_without_identity_when_not_anonymous() {
         "/api/v1/domains",
         "/api/v1/domains/eng/tree",
         "/api/v1/domains/eng/manifest",
+        "/api/v1/domains/eng/engrams",
+        "/api/v1/domains/eng/engrams/alpha",
+        "/api/v1/domains/eng/engrams/notes/deep/gamma",
     ] {
         let resp = get(fixture.addr, path).await;
         assert_eq!(resp.status(), 401, "{path} must be guarded");
@@ -778,6 +863,165 @@ async fn domain_manifest_returns_the_markdown_source() {
         markdown.contains("Route here for eng questions"),
         "{markdown}"
     );
+}
+
+/// The listing is `search_engrams` with no query behind a query string: the
+/// filters select, and the page envelope the engine already writes comes
+/// through unchanged so a client can page without a second shape to learn.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn engram_list_filters_and_carries_the_page_envelope() {
+    let fixture = serve_anonymous().await;
+
+    let all: serde_json::Value = get(fixture.addr, "/api/v1/domains/eng/engrams")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        all["total"], 4,
+        "the MANIFEST and the three seeded engrams: {all}"
+    );
+    assert_eq!(all["page"], 1, "the envelope names the page: {all}");
+    assert_eq!(all["limit"], 10, "and the page size: {all}");
+    assert_eq!(all["count"], 4, "and what this page holds: {all}");
+
+    // A comma-separated tag list is split, and every tag has to match: `eng` is
+    // on all three, `nested` on two, so the intersection is the nested pair.
+    let tagged: serde_json::Value =
+        get(fixture.addr, "/api/v1/domains/eng/engrams?tags=eng,nested")
+            .await
+            .json()
+            .await
+            .unwrap();
+    assert_eq!(tagged["total"], 2, "only the tagged pair: {tagged}");
+    assert_eq!(
+        hit_permalinks(&tagged),
+        vec!["notes/beta".to_string(), "notes/deep/gamma".to_string()],
+        "{tagged}"
+    );
+
+    let typed: serde_json::Value = get(fixture.addr, "/api/v1/domains/eng/engrams?type=guide")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(hit_permalinks(&typed), vec!["notes/beta".to_string()]);
+
+    let statused: serde_json::Value = get(fixture.addr, "/api/v1/domains/eng/engrams?status=draft")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(statused["total"], 0, "nothing is a draft here: {statused}");
+
+    // Paging: two pages of two over the same filtered set, disjoint and
+    // covering it.
+    let first: serde_json::Value = get(fixture.addr, "/api/v1/domains/eng/engrams?limit=2&page=1")
+        .await
+        .json()
+        .await
+        .unwrap();
+    let second: serde_json::Value = get(fixture.addr, "/api/v1/domains/eng/engrams?limit=2&page=2")
+        .await
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(second["page"], 2);
+    assert_eq!(second["limit"], 2);
+    assert_eq!(second["total"], 4, "the total spans the pages: {second}");
+    let mut paged = hit_permalinks(&first);
+    paged.extend(hit_permalinks(&second));
+    assert_eq!(paged.len(), 4, "two pages of two: {first} {second}");
+    let mut unique = paged.clone();
+    unique.sort();
+    unique.dedup();
+    assert_eq!(unique.len(), 4, "the pages do not overlap: {paged:?}");
+}
+
+/// The detail route answers with the engram itself - its frontmatter, its
+/// markdown and the graph the engine resolves around it - plus an `ETag` a
+/// later conditional write can present. The validator is the SHA-256 of the
+/// markdown, quoted as RFC 9110 requires of a strong one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn engram_detail_carries_the_source_and_a_strong_etag() {
+    let fixture = serve_anonymous().await;
+    let resp = get(fixture.addr, "/api/v1/domains/eng/engrams/alpha").await;
+    assert_eq!(resp.status(), 200);
+    let etag = resp
+        .headers()
+        .get("etag")
+        .expect("the detail response carries an ETag")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let body: serde_json::Value = resp.json().await.unwrap();
+
+    assert_eq!(body["domain"], "eng");
+    assert_eq!(body["permalink"], "alpha");
+    assert_eq!(body["title"], "Alpha");
+    assert_eq!(body["url"], "crystalline://eng/alpha");
+    assert_eq!(
+        body["frontmatter"]["title"], "Alpha",
+        "the frontmatter is part of the answer: {body}"
+    );
+    assert_eq!(body["frontmatter"]["permalink"], "alpha");
+
+    let on_disk = fixture.engram_bytes("alpha.md");
+    assert_eq!(
+        body["content"].as_str().unwrap().as_bytes(),
+        on_disk.as_slice(),
+        "the content is the markdown as written: {body}"
+    );
+    assert_eq!(
+        etag,
+        format!("\"{}\"", sha256_hex(&on_disk)),
+        "the ETag is the quoted SHA-256 of that markdown"
+    );
+    assert!(
+        etag.starts_with('"') && etag.ends_with('"') && !etag.starts_with("W/"),
+        "a strong validator, quoted: {etag}"
+    );
+}
+
+/// A permalink is a path, not a segment: the route captures the rest of the URL
+/// so an engram two folders down is reachable by the permalink it carries.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn engram_detail_resolves_a_permalink_with_folders() {
+    let fixture = serve_anonymous().await;
+    let resp = get(fixture.addr, "/api/v1/domains/eng/engrams/notes/deep/gamma").await;
+    assert_eq!(resp.status(), 200, "a nested permalink resolves");
+    let etag = resp.headers()["etag"].to_str().unwrap().to_string();
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["permalink"], "notes/deep/gamma");
+    assert_eq!(body["path"], "notes/deep/gamma.md");
+    assert_eq!(
+        etag,
+        format!(
+            "\"{}\"",
+            sha256_hex(&fixture.engram_bytes("notes/deep/gamma.md"))
+        )
+    );
+}
+
+/// An engram nobody wrote is a 404 problem detail, the same shape every other
+/// failure on this surface has, and the engine's own message says what was
+/// looked for.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn an_unknown_permalink_is_a_404_problem_detail() {
+    let fixture = serve_anonymous().await;
+    let resp = get(fixture.addr, "/api/v1/domains/eng/engrams/notes/ghost").await;
+    assert_eq!(resp.status(), 404);
+    assert_eq!(resp.headers()["content-type"], "application/problem+json");
+    assert!(
+        resp.headers().get("etag").is_none(),
+        "a failure carries no validator"
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["status"], 404);
+    assert_eq!(body["title"], "not found");
+    let detail = body["detail"].as_str().unwrap();
+    assert!(detail.contains("notes/ghost"), "{detail}");
+    assert!(detail.contains("eng"), "{detail}");
 }
 
 /// A domain nobody registered is a 404 problem detail that names the domains

--- a/crates/service/tests/rest_api.rs
+++ b/crates/service/tests/rest_api.rs
@@ -420,6 +420,61 @@ async fn me_reports_anonymous_access_when_it_is_enabled() {
         .unwrap();
     assert!(body["user"].is_null());
     assert_eq!(body["anonymous"], true);
+    assert!(
+        body["csrf"].is_null(),
+        "the anonymous viewer has no session and so no token: {body}"
+    );
+}
+
+/// The probe reissues the session's CSRF token, and it is the same one login
+/// minted.
+///
+/// This is what makes a reload survivable. The session cookie is `HttpOnly`, so
+/// a refreshed page still holds a live session but has lost the token login
+/// handed it in a response body; without this it could neither log out nor
+/// write, and its only way back would be logging in again.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn me_reissues_the_sessions_csrf_token() {
+    let fixture = serve_with_ada(AuthOptions::default()).await;
+    let (token, csrf) = login(fixture.addr, "ada", "s3cret").await;
+    let body: serde_json::Value = client()
+        .get(format!("http://{}/api/v1/auth/me", fixture.addr))
+        .header("cookie", format!("fluid_session={token}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(body["user"]["name"], "ada");
+    assert_eq!(
+        body["csrf"], csrf,
+        "the probe hands back the token login minted: {body}"
+    );
+
+    // And the reissued token is usable, which is the whole point: a browser
+    // that only ever saw this response can still send a mutating request.
+    let resp = client()
+        .post(format!("http://{}/api/v1/auth/logout", fixture.addr))
+        .header("cookie", format!("fluid_session={token}"))
+        .header("x-csrf-token", body["csrf"].as_str().unwrap())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "the reissued token passes the CSRF check"
+    );
+}
+
+/// A request carrying no session gets no token, so a client cannot mistake an
+/// unauthenticated probe for a usable one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn me_carries_no_csrf_token_without_a_session() {
+    let (addr, _guard) = serve_test_router_with_fixture().await;
+    let body: serde_json::Value = get(addr, "/api/v1/auth/me").await.json().await.unwrap();
+    assert!(body["csrf"].is_null(), "{body}");
 }
 
 /// An unknown path under the mount answers in problem+json rather than falling
@@ -559,6 +614,12 @@ async fn data_routes_401_without_identity_when_not_anonymous() {
         // `crates/service/openapi/fluid-v1.json` instead, so nothing needs it
         // open.
         "/api/v1/openapi.json",
+        // A path nothing mounts, which must answer 401 rather than 404. The
+        // published document claims an unauthenticated caller never learns
+        // which paths exist, and that claim rests on the fallback being
+        // registered above the guard layer: without this line, moving it below
+        // would start mapping the API out for anybody and no test would say so.
+        "/api/v1/nope",
         "/api/v1/domains",
         "/api/v1/domains/eng/tree",
         "/api/v1/domains/eng/manifest",
@@ -653,6 +714,12 @@ async fn trusted_header_maps_identity() {
     assert_eq!(me["user"]["name"], "bob", "the name is folded by the store");
     assert_eq!(me["user"]["display"], "Bob");
     assert_eq!(me["user"]["role"], "viewer");
+    assert!(
+        me["csrf"].is_null(),
+        "a trusted-header identity carries no session and so no token; what \
+         keeps its mutating requests off another origin is the shape they are \
+         allowed to have. See `check_csrf`. Body: {me}"
+    );
 
     let users = fixture.auth.list_users().await.unwrap();
     assert_eq!(users.len(), 1, "the account was provisioned once");

--- a/crates/service/tests/virtual_domains.rs
+++ b/crates/service/tests/virtual_domains.rs
@@ -974,3 +974,49 @@ async fn retag_rejects_a_non_canonical_name() {
         .await;
     assert!(matches!(bad, Err(EngineError::Invalid(_))));
 }
+
+// --- manifest source ---------------------------------------------------------
+
+/// `manifest_markdown` reads a virtual domain's MANIFEST out of the database,
+/// the way a file domain's is read off disk. Three answers matter to the caller
+/// serving it: the source once one exists, a `NotFound` while it does not, and
+/// an `UnknownDomain` naming the registered set for a domain nobody added.
+async fn virtual_manifest_markdown(store: Arc<Mutex<dyn Store>>) {
+    let engine = virtual_engine(store);
+
+    let missing = engine.manifest_markdown("notes").await;
+    assert!(
+        matches!(missing, Err(EngineError::NotFound(_))),
+        "a domain with no MANIFEST yet is a NotFound, got {missing:?}"
+    );
+
+    engine
+        .scaffold_virtual_manifest(
+            "notes",
+            "---\ntype: manifest\ntitle: Notes\npermalink: manifest\ntags:\n  - manifest\nstatus: current\nrecorded_at: 2026-01-01\n---\n\n# Notes\n\n## Scope\n\n- notes\n\n## When to Use\n\n- Route here for notes\n",
+        )
+        .await
+        .unwrap();
+
+    let markdown = engine.manifest_markdown("notes").await.unwrap();
+    assert!(
+        markdown.starts_with("---\n"),
+        "the frontmatter is part of the source: {markdown}"
+    );
+    assert!(markdown.contains("## When to Use"), "{markdown}");
+    assert!(markdown.contains("- Route here for notes"), "{markdown}");
+
+    let unknown = engine.manifest_markdown("ghost").await.unwrap_err();
+    assert!(
+        matches!(unknown, EngineError::UnknownDomain { .. }),
+        "got {unknown:?}"
+    );
+    assert!(
+        unknown.to_string().contains("notes"),
+        "the valid set is named: {unknown}"
+    );
+}
+both_backends!(
+    virtual_manifest_markdown_reads_the_database,
+    virtual_manifest_markdown
+);


### PR DESCRIPTION
Second of four PRs for Fluid, the web UI. PR #45 laid the auth foundation; this one adds every read endpoint the UI needs, the admin user management API, and the OpenAPI contract that pins it all.

## What's here

- **Domains**: listing with routing lines, folder tree, and rendered-MANIFEST source (file domains from disk, virtual from the store, via a new engine helper).
- **Engrams**: filtered, paged listing and a detail endpoint whose strong ETag is the engram's own checksum - the exact value slice 3's If-Match editing will compare against.
- **Discovery**: hybrid/text/semantic/title search, vocabulary, build_context neighborhoods, and recent activity, all as thin JSON projections of the existing engine verbs.
- **Graph**: a new graph_neighborhood engine verb (nodes, typed edges, truncation flag; retired engrams included, faded by the UI, never hidden) reusing the sweep's chunked neighbors machinery.
- **Admin users API**: CRUD with per-handler admin gating, self-target and last-admin refusals as distinct 409s, and session revocation on password change and disable - the CLI inherits the same semantics.
- **OpenAPI**: 18 operations documented, generated from the handlers, with a committed snapshot that fails CI on drift and a coverage test pinning METHOD+path pairs against the mounted router in both directions.
- **Error contract**: axum extractor rejections (bad query, wrong method, non-JSON content type) now render as problem+json like every other failure, so a client sees one error shape everywhere.

## Semantics settled here

A domain named in a path segment must exist (404 with the valid set); a domain in a query filter filters to nothing. Unsafe methods on admin routes are CSRF-checked for cookie sessions, and for trusted-header identities the protecting invariant (JSON content type forces a CORS preflight that nothing answers, and no CORS layer exists) is stated in code, tested, and marked as revisit-on-CORS.

## Review loop highlights

The per-task adversarial reviews caught and closed: an empty-vs-404 ambiguity the UI could not have distinguished, a remote password reset that left the target's stolen sessions alive, admin hashing paths bypassing the argon2 memory cap, and a name-injection path that could steer error classification. The sweep refactor backing the graph verb was proven behavior-identical for the evolve feature at its call site.

MCP and stdio surfaces are untouched; tool counts unchanged.