### PR TITLE
Keep the smoke's scratch environment off the test runner

### DIFF
--- a/fluid/.prettierignore
+++ b/fluid/.prettierignore
@@ -8,3 +8,9 @@ src/api/types.ts
 # among other things). Prettier reformats that frontmatter, which would leave
 # the fixture looking unlike every engram the product itself produces.
 e2e/fixtures
+
+# What a browser smoke leaves behind: Playwright's own run record, traces and
+# screenshots. Not ours to format, and a local smoke run would otherwise make
+# the next format check fail on a file nobody wrote.
+test-results
+playwright-report

--- a/fluid/e2e/run-smoke.sh
+++ b/fluid/e2e/run-smoke.sh
@@ -79,24 +79,40 @@ trap finish EXIT
 # Every path the daemon resolves, pointed inside the scratch directory. The
 # config, state and cache directories all come from these (see
 # crates/core/src/config.rs), so this is the whole of the isolation.
-export XDG_CONFIG_HOME="$run_dir/config"
-export XDG_STATE_HOME="$run_dir/state"
-export XDG_CACHE_HOME="$run_dir/cache"
-export XDG_DATA_HOME="$run_dir/data"
-mkdir -p "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME"
+#
+# Handed to the Crystalline commands one at a time rather than exported into
+# this shell, and that is load bearing. XDG_CACHE_HOME is not Crystalline's
+# variable: on Linux it is where Playwright keeps its browsers
+# (`XDG_CACHE_HOME || ~/.cache` then `ms-playwright`, in playwright-core's
+# registry), so exporting it pointed `playwright test` at a scratch directory
+# holding nothing but an embedding model, and every test failed with a browser
+# it had just installed into the real cache moments earlier. macOS never showed
+# it: Playwright reads ~/Library/Caches there and ignores XDG entirely. Scoping
+# the isolation to the process it belongs to is what makes that impossible
+# rather than merely fixed, for pnpm's store and anything else reading XDG too.
+isolated=(
+    env
+    "XDG_CONFIG_HOME=$run_dir/config"
+    "XDG_STATE_HOME=$run_dir/state"
+    "XDG_CACHE_HOME=$run_dir/cache"
+    "XDG_DATA_HOME=$run_dir/data"
+)
+mkdir -p "$run_dir/config" "$run_dir/state" "$run_dir/cache" "$run_dir/data"
 
 domain_root="$run_dir/domain"
 cp -R "$here/fixtures/domain" "$domain_root"
 
 echo "smoke: registering the fixture domain"
-"$bin" domain add "$FLUID_E2E_DOMAIN" "$domain_root"
+"${isolated[@]}" "$bin" domain add "$FLUID_E2E_DOMAIN" "$domain_root"
 
 echo "smoke: seeding the account"
 printf '%s' "$FLUID_E2E_PASSWORD" \
-    | "$bin" users add "$FLUID_E2E_USER" --role admin --password-stdin
+    | "${isolated[@]}" "$bin" users add "$FLUID_E2E_USER" --role admin --password-stdin
 
+# `env` execs, so the pid recorded here is the daemon's own and the trap above
+# signals the daemon rather than a wrapper around it.
 echo "smoke: starting the daemon on $DAEMON_ADDR"
-"$bin" serve --http "$DAEMON_ADDR" > "$run_dir/daemon.log" 2>&1 &
+"${isolated[@]}" "$bin" serve --http "$DAEMON_ADDR" > "$run_dir/daemon.log" 2>&1 &
 daemon_pid=$!
 
 # The same probe an external monitor makes, so a daemon that answers here is a
@@ -107,7 +123,7 @@ for _ in $(seq 1 60); do
         echo "smoke: the daemon exited before it was ready" >&2
         exit 1
     fi
-    if "$bin" healthcheck "$DAEMON_ADDR" > /dev/null 2>&1; then
+    if "${isolated[@]}" "$bin" healthcheck "$DAEMON_ADDR" > /dev/null 2>&1; then
         ready=1
         break
     fi
@@ -124,6 +140,13 @@ cd "$fluid_dir"
 # whatever is in dist/, and a stale one would be a green run of last week's app.
 echo "smoke: building the bundle"
 pnpm build
+
+# Where this run expects to find a browser, said out loud before it needs one.
+# A missing browser otherwise reports only that an executable is not at a path,
+# and the useful half of that story is which path was resolved and why.
+browsers=$(pnpm exec playwright install --dry-run chromium 2>/dev/null \
+    | awk '/Install location/ { print $3; exit }')
+echo "smoke: playwright browsers at ${browsers:-an unknown location}"
 
 echo "smoke: running playwright"
 pnpm exec playwright test "$@"


### PR DESCRIPTION
Fixes the fluid-smoke CI failure from #48's first run. The smoke script exported XDG_CACHE_HOME to isolate the daemon's scratch state, but playwright-core resolves its Linux browser registry through that same variable, so the test step searched the scratch directory for browsers that were installed in the runner's real cache. macOS resolves caches through ~/Library/Caches, which is why the leak could not reproduce locally.

The isolation now rides as an env prefix on the crystalline invocations only; nothing is exported, so the install and exec steps share one environment and cannot disagree. The script also prints the resolved browser location before it needs one, so a future divergence is visible in the log instead of a banner. No workflow file changed.

Verified: smoke green locally (6/6), daemon isolation still holds, shellcheck and all gates clean. The runner run on this PR is the real proof.