### PR TITLE
feat(fluid): domain-aware sidebar navigation

### DIFF
--- a/crates/service/openapi/fluid-v1.json
+++ b/crates/service/openapi/fluid-v1.json
@@ -866,6 +866,7 @@
                     {
                       "path": "alpha.md",
                       "permalink": "alpha",
+                      "status": "stable",
                       "title": "Alpha",
                       "type": "engram"
                     }

--- a/crates/service/src/engine.rs
+++ b/crates/service/src/engine.rs
@@ -3023,10 +3023,17 @@ impl Engine {
                 folders.insert(segments[0].to_string());
             }
             if segments.len() <= depth {
+                // `status` rides along with the rest of the descriptor, which
+                // already carries it: a browse row is what a navigation tree is
+                // drawn from, and whether an engram is retired is the one thing
+                // such a tree has to say about a row it is not otherwise
+                // describing. Leaving it out meant every client browsing a
+                // domain had to fetch the listing again to learn it.
                 entries.push(json!({
                     "permalink": d.permalink,
                     "title": d.title,
                     "type": d.engram_type,
+                    "status": d.status,
                     "path": d.path,
                 }));
             }

--- a/crates/service/src/rest/domains.rs
+++ b/crates/service/src/rest/domains.rs
@@ -113,6 +113,7 @@ pub struct TreeQuery {
                     "permalink": "alpha",
                     "title": "Alpha",
                     "type": "engram",
+                    "status": "stable",
                     "path": "alpha.md"
                 }]
             }),

--- a/crates/service/tests/mcp_tools.rs
+++ b/crates/service/tests/mcp_tools.rs
@@ -1562,6 +1562,15 @@ async fn recent_list_browse_delete() {
             .iter()
             .any(|f| f == "sub")
     );
+    // And the row carries the engram's status, so an agent browsing a domain
+    // can tell a retired engram from a live one without reading it.
+    let fresh = browse["engrams"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["permalink"] == "sub/fresh")
+        .unwrap_or_else(|| panic!("the browse lists the engram just written: {browse}"));
+    assert_eq!(fresh["status"], "stable", "{fresh}");
 
     // delete removes the file and index row.
     let del = call(

--- a/crates/service/tests/rest_api.rs
+++ b/crates/service/tests/rest_api.rs
@@ -1002,6 +1002,17 @@ async fn domain_tree_walks_folders_and_filters_by_glob() {
     assert_eq!(root["domain"], "eng");
     assert_eq!(root["path"], "/");
     assert_eq!(root["folders"].as_array().unwrap(), &["notes"]);
+    // A row says what state its engram is in, not only where it lives: a tree
+    // is what a navigation sidebar is drawn from, and fading a retired engram
+    // there would otherwise cost a second request per folder.
+    let alpha = root["engrams"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["path"] == "alpha.md")
+        .unwrap_or_else(|| panic!("the root holds alpha: {root}"));
+    assert_eq!(alpha["status"], "current", "{alpha}");
+    assert_eq!(alpha["type"], "engram", "{alpha}");
     let paths = engram_paths(&root);
     assert!(paths.contains(&"alpha.md".to_string()), "{paths:?}");
     assert!(paths.contains(&"MANIFEST.md".to_string()), "{paths:?}");

--- a/fluid/e2e/smoke.spec.ts
+++ b/fluid/e2e/smoke.spec.ts
@@ -105,7 +105,14 @@ test("a multi-segment permalink loads from the address bar", async ({
   await page.goto(`/d/${DOMAIN}/e/${DEEP_PERMALINK}`);
 
   await expect(engramTitle(page)).toHaveText("Deep Gamma Note");
-  await expect(page.getByText(DEEP_PERMALINK, { exact: true })).toBeVisible();
+  // Scoped to the page's own header, which is where the permalink the address
+  // bar carried is echoed. Unscoped this is a race rather than an assertion:
+  // the body of this fixture quotes its own permalink in a code span, so once
+  // the markdown chunk has landed there are two matches and strict mode is
+  // right to refuse them.
+  await expect(
+    page.locator("main header").getByText(DEEP_PERMALINK, { exact: true }),
+  ).toBeVisible();
 });
 
 test("a search finds an engram by what is in it", async ({ page }) => {

--- a/fluid/src/api/domain.test.ts
+++ b/fluid/src/api/domain.test.ts
@@ -1,0 +1,69 @@
+/**
+ * What a browse row is allowed to carry, read the way every list in this app
+ * reads a row.
+ *
+ * The tree is the one source whose rows are navigation rather than description,
+ * and the one field navigation cannot do without is `status`: it is what fades
+ * a retired engram in a sidebar. The endpoint answers with it, so this pins
+ * that it survives the read, and that a row without one still reads as a row
+ * rather than throwing three components deep.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { readTree } from "./domain";
+
+/** One folder of a domain, in the shape the endpoint answers with. */
+function browsePayload() {
+  return {
+    domain: "eng",
+    path: "/",
+    folders: ["notes"],
+    engrams: [
+      {
+        permalink: "alpha",
+        title: "Alpha",
+        type: "engram",
+        status: "stable",
+        path: "alpha.md",
+      },
+      {
+        permalink: "old",
+        title: "Old Way",
+        type: "decision",
+        status: "deprecated",
+        path: "old.md",
+      },
+    ],
+  };
+}
+
+describe("a browse payload", () => {
+  it("carries each engram's status into the row", () => {
+    const tree = readTree(browsePayload(), "eng", "");
+
+    expect(tree.folders).toEqual(["notes"]);
+    expect(tree.engrams.map((row) => row.status)).toEqual([
+      "stable",
+      "deprecated",
+    ]);
+    // The domain of the request rides along, because a tree row names only
+    // itself and a link out of one needs both halves of the address.
+    expect(tree.engrams[0].domain).toBe("eng");
+    expect(tree.engrams[0].type).toBe("engram");
+  });
+
+  it("leaves the status null when a row does not say", () => {
+    const tree = readTree(
+      { domain: "eng", path: "/", folders: [], engrams: [{ permalink: "a" }] },
+      "eng",
+      "",
+    );
+
+    // Null rather than a plausible default: a row claiming a state nobody
+    // wrote would be a lie a reader cannot see through, and it would fade or
+    // fail to fade on that lie.
+    expect(tree.engrams[0].status).toBeNull();
+    expect(tree.engrams[0].title).toBe("a");
+  });
+});

--- a/fluid/src/api/types.ts
+++ b/fluid/src/api/types.ts
@@ -1308,6 +1308,7 @@ export interface operations {
                      *         {
                      *           "path": "alpha.md",
                      *           "permalink": "alpha",
+                     *           "status": "stable",
                      *           "title": "Alpha",
                      *           "type": "engram"
                      *         }

--- a/fluid/src/components/DomainNav.tsx
+++ b/fluid/src/components/DomainNav.tsx
@@ -1,0 +1,296 @@
+/**
+ * The sidebar once a domain is open: which domain you are in, and what is in
+ * it.
+ *
+ * A domain is a place somebody works in rather than an entry they picked once,
+ * so while they are inside one the sidebar stops being a list of everything and
+ * becomes the way around this one thing. Two controls make that true: a
+ * switcher that names the current domain and moves across to another, and the
+ * folder tree below it, which is the domain's own shape rather than a flat
+ * listing of it. The way back out to every domain stays on screen beside them,
+ * because a place you cannot leave is a trap.
+ *
+ * The tree is walked rather than downloaded. `GET /domains/{d}/tree` answers
+ * one folder at a time - its subfolder names and the engrams directly in it -
+ * and this asks for a folder only when somebody opens it. A deep fetch would
+ * mean pulling every engram of a domain into the frame around every screen,
+ * and the folder structure below the first level would still have to be
+ * inferred from engram paths. Each folder is cached under the same key the
+ * domain screen uses (`treeKey`), so the root costs nothing when a reader is
+ * already looking at it and an expanded folder stays expanded for free.
+ *
+ * The folders on the way to the engram being read start open, because a mark
+ * on a row nobody can see marks nothing.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { DropdownMenu } from "radix-ui";
+import { useState } from "react";
+import { Link, useNavigate } from "react-router";
+
+import { problemDetail } from "../api/client";
+import { fetchTree, treeKey } from "../api/domain";
+import type { DomainSummary } from "../api/domains";
+import type { EngramRow } from "../api/engrams";
+import { RETIRED_CLASS, isRetired } from "../lifecycle";
+import { domainRoute, engramRoute } from "../paths";
+import { ITEM_CLASSES, MENU_CLASSES } from "./menu";
+
+export interface DomainNavProps {
+  /** The domain the route is inside. */
+  domain: string;
+  /** The permalink being read, or the empty string when none is. */
+  permalink: string;
+  /** Every registered domain, for the switcher. */
+  domains: DomainSummary[];
+}
+
+export function DomainNav({ domain, permalink, domains }: DomainNavProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <Link
+        to="/"
+        className="px-2 text-xs text-slate-500 underline underline-offset-2 hover:no-underline focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:outline-none dark:text-slate-400"
+      >
+        All domains
+      </Link>
+
+      <DomainSwitcher domain={domain} domains={domains} />
+
+      <div>
+        <h2 className="px-2 pb-2 text-xs font-semibold tracking-wide text-slate-500 uppercase dark:text-slate-400">
+          Engrams
+        </h2>
+        <TreeBranch domain={domain} path="" permalink={permalink} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Which domain this is, and the way across to another.
+ *
+ * Each entry carries what that domain holds, which is what makes choosing
+ * between them a choice rather than a guess. A domain the listing does not
+ * name - a wrong address, or one this identity may not list - still shows on
+ * the trigger, so the switcher says where the reader actually is.
+ */
+function DomainSwitcher({
+  domain,
+  domains,
+}: {
+  domain: string;
+  domains: DomainSummary[];
+}) {
+  const navigate = useNavigate();
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger
+        aria-label={`Domain: ${domain}`}
+        className="flex w-full items-center gap-2 rounded border border-slate-300 px-2 py-1.5 text-sm hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:outline-none dark:border-slate-700 dark:hover:bg-slate-800"
+      >
+        <span className="truncate font-medium">{domain}</span>
+        <span aria-hidden="true" className="ml-auto text-xs text-slate-500">
+          ▾
+        </span>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="start"
+          sideOffset={6}
+          className={MENU_CLASSES}
+        >
+          <DropdownMenu.RadioGroup
+            value={domain}
+            onValueChange={(value) => {
+              if (value !== domain) {
+                void navigate(domainRoute(value));
+              }
+            }}
+          >
+            {domains.map((entry) => (
+              <DropdownMenu.RadioItem
+                key={entry.name}
+                value={entry.name}
+                className={ITEM_CLASSES}
+              >
+                <DropdownMenu.ItemIndicator>
+                  <span aria-hidden="true">*</span>
+                </DropdownMenu.ItemIndicator>
+                <span className="truncate">{entry.name}</span>
+                {entry.engrams !== null && (
+                  <span className="ml-auto text-xs text-slate-500 tabular-nums dark:text-slate-400">
+                    {entry.engrams}
+                  </span>
+                )}
+              </DropdownMenu.RadioItem>
+            ))}
+          </DropdownMenu.RadioGroup>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  );
+}
+
+/**
+ * One folder: its subfolders, then its engrams.
+ *
+ * Folders first because they are the shape of the domain and the engrams are
+ * what is in it, and a reader scanning for either finds the two in the same
+ * place at every level.
+ */
+function TreeBranch({
+  domain,
+  path,
+  permalink,
+}: {
+  domain: string;
+  path: string;
+  permalink: string;
+}) {
+  const tree = useQuery({
+    queryKey: treeKey(domain, path),
+    queryFn: () => fetchTree(domain, path),
+  });
+
+  if (tree.isPending) {
+    return (
+      <p className="px-2 py-1 text-sm text-slate-500 dark:text-slate-400">
+        Loading engrams
+      </p>
+    );
+  }
+  if (tree.error) {
+    return (
+      <p
+        role="alert"
+        className="rounded bg-red-50 px-2 py-1.5 text-sm text-red-800 dark:bg-red-950 dark:text-red-200"
+      >
+        {problemDetail(tree.error)}
+      </p>
+    );
+  }
+
+  const folders = tree.data?.folders ?? [];
+  const engrams = tree.data?.engrams ?? [];
+  if (folders.length === 0 && engrams.length === 0) {
+    return (
+      <p className="px-2 py-1 text-sm text-slate-500 dark:text-slate-400">
+        {path === "" ? "This domain has no engrams yet." : "Nothing in here."}
+      </p>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-0.5">
+      {folders.map((name) => (
+        <li key={`folder:${name}`}>
+          <Folder
+            domain={domain}
+            path={childPath(path, name)}
+            name={name}
+            permalink={permalink}
+          />
+        </li>
+      ))}
+      {engrams.map((row) => (
+        <li key={row.permalink}>
+          <EngramLink row={row} current={row.permalink === permalink} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * A folder, open or shut.
+ *
+ * A disclosure button rather than a link: opening a folder is a look inside
+ * the sidebar, and the screen beside it stays where the reader left it. What
+ * is inside is mounted only while it is open, which is what makes the fetch
+ * lazy.
+ *
+ * A folder opens itself when the engram being read moves into it, whether that
+ * happened on arrival or by a link somewhere else on the screen. It never
+ * closes itself: a reader who folded this branch away meant it, and the state
+ * they set is theirs until they leave the folder again.
+ */
+function Folder({
+  domain,
+  path,
+  name,
+  permalink,
+}: {
+  domain: string;
+  path: string;
+  name: string;
+  permalink: string;
+}) {
+  const holdsCurrent = permalink.startsWith(`${path}/`);
+  const [open, setOpen] = useState(holdsCurrent);
+  // Adjusted while rendering rather than in an effect, which is what React
+  // asks for when state has to follow a prop: the branch opens in the same
+  // pass that noticed the reader moved into it, with no flash of a shut
+  // folder in between.
+  const [held, setHeld] = useState(holdsCurrent);
+  if (held !== holdsCurrent) {
+    setHeld(holdsCurrent);
+    if (holdsCurrent) {
+      setOpen(true);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => {
+          setOpen((wasOpen) => !wasOpen);
+        }}
+        className="flex w-full items-center gap-1 rounded px-2 py-1 text-left text-sm hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:outline-none dark:hover:bg-slate-800"
+      >
+        <span
+          aria-hidden="true"
+          className="w-3 text-xs text-slate-500 dark:text-slate-400"
+        >
+          {open ? "▾" : "▸"}
+        </span>
+        <span className="truncate">{name}</span>
+      </button>
+      {open && (
+        <div className="ml-3 border-l border-slate-200 pl-1 dark:border-slate-800">
+          <TreeBranch domain={domain} path={path} permalink={permalink} />
+        </div>
+      )}
+    </>
+  );
+}
+
+/**
+ * One engram in the tree.
+ *
+ * Named by its title alone: this is navigation, and the row that says what an
+ * engram is made of is the list on the screen beside it. A retired one is
+ * faded and still there, which is the rule everywhere else in this app.
+ */
+function EngramLink({ row, current }: { row: EngramRow; current: boolean }) {
+  const retired = isRetired(row.status);
+  return (
+    <Link
+      to={engramRoute(row.domain, row.permalink)}
+      aria-current={current ? "page" : undefined}
+      className={`block truncate rounded px-2 py-1 text-sm hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:outline-none dark:hover:bg-slate-800 ${
+        current ? "bg-slate-100 font-medium dark:bg-slate-800" : ""
+      } ${retired ? RETIRED_CLASS : ""}`}
+    >
+      {row.title}
+    </Link>
+  );
+}
+
+/** The path of a subfolder, from the folder it sits in. */
+function childPath(path: string, name: string): string {
+  return path === "" ? name : `${path}/${name}`;
+}

--- a/fluid/src/components/Layout.test.tsx
+++ b/fluid/src/components/Layout.test.tsx
@@ -1,6 +1,7 @@
 /**
  * The frame's own behavior: the domain list it fetches, where the search box
- * sends you, what the theme control writes, and what logging out does.
+ * sends you, what the theme control writes, what logging out does, and what
+ * the sidebar becomes once a domain is open.
  */
 
 import { screen, waitFor, within } from "@testing-library/react";
@@ -24,12 +25,12 @@ vi.mock("../api/client", async (importOriginal) => {
 const apiMock = vi.mocked(api);
 const setCsrfTokenMock = vi.mocked(setCsrfToken);
 
-function serve(routes: Record<string, () => unknown>) {
+function serve(routes: Record<string, (path: string) => unknown>) {
   apiMock.mockImplementation(answersFor(routes));
 }
 
 /** Signed in, with one domain to list and a quiet activity feed. */
-function serveSignedIn(extra: Record<string, () => unknown> = {}) {
+function serveSignedIn(extra: Record<string, (path: string) => unknown> = {}) {
   serve({
     "/auth/me": () => meResponse({ user: userFixture() }),
     "/domains": domainsResponse,
@@ -38,6 +39,116 @@ function serveSignedIn(extra: Record<string, () => unknown> = {}) {
     "/activity": () => ({ timeframe: "7d", count: 0, engrams: [] }),
     ...extra,
   });
+}
+
+/** Two domains, so the switcher has somewhere to switch to. */
+function twoDomainsResponse() {
+  return {
+    behavior: ["Search before answering from memory."],
+    domains: [
+      {
+        name: "eng",
+        kind: "file",
+        engrams: 4,
+        when_to_use: ["Route here for eng questions."],
+      },
+      { name: "ops", kind: "file", engrams: 2, when_to_use: [] },
+    ],
+  };
+}
+
+/**
+ * The browse payload, answering with the folder that was asked for.
+ *
+ * The retired row carries a `status`, which the live browse payload does not
+ * send today. The shared row reader takes one when a source has it, so this
+ * pins the fade rule the sidebar applies rather than inventing a field: the
+ * day the payload carries a status, the fade is already right.
+ */
+function treeResponse(path: string) {
+  if (path.includes("path=notes")) {
+    return {
+      domain: "eng",
+      path: "notes",
+      folders: [],
+      engrams: [
+        {
+          permalink: "notes/beta",
+          title: "Beta",
+          type: "engram",
+          path: "notes/beta.md",
+        },
+      ],
+    };
+  }
+  return {
+    domain: "eng",
+    path: "/",
+    folders: ["notes"],
+    engrams: [
+      { permalink: "alpha", title: "Alpha", type: "engram", path: "alpha.md" },
+      {
+        permalink: "old",
+        title: "Old Way",
+        type: "decision",
+        status: "deprecated",
+        path: "old.md",
+      },
+    ],
+  };
+}
+
+/** Signed in, inside a domain: the frame's own reads plus the screen's. */
+function serveInDomain(extra: Record<string, (path: string) => unknown> = {}) {
+  serve({
+    "/auth/me": () => meResponse({ user: userFixture() }),
+    "/domains": twoDomainsResponse,
+    "/domains/eng/tree": treeResponse,
+    "/domains/eng/manifest": () => ({ domain: "eng", markdown: "" }),
+    "/domains/eng/engrams": () => ({
+      mode: "text",
+      total: 0,
+      page: 1,
+      limit: 50,
+      count: 0,
+      hits: [],
+    }),
+    "/domains/eng/engrams/alpha": () => ({
+      domain: "eng",
+      permalink: "alpha",
+      title: "Alpha",
+      url: "crystalline://eng/alpha",
+      content: "# Alpha\n",
+      frontmatter: {},
+      observations: [],
+      relations: [],
+      links: [],
+    }),
+    "/domains/eng/engrams/notes/beta": () => ({
+      domain: "eng",
+      permalink: "notes/beta",
+      title: "Beta",
+      url: "crystalline://eng/notes/beta",
+      content: "# Beta\n",
+      frontmatter: {},
+      observations: [],
+      relations: [],
+      links: [],
+    }),
+    "/graph": () => ({ nodes: [], edges: [], truncated: false }),
+    "/vocabulary": () => ({ domain: "eng", tags: [] }),
+    ...extra,
+  });
+}
+
+/** The sidebar, whichever mode it is in. */
+async function sidebar(): Promise<HTMLElement> {
+  return screen.findByRole("navigation", { name: /^Domain/ });
+}
+
+/** Every path the app asked for, in order. */
+function requested(): string[] {
+  return apiMock.mock.calls.map((call) => call[0]);
 }
 
 beforeEach(() => {
@@ -55,6 +166,9 @@ describe("the layout", () => {
     const domains = await screen.findByRole("navigation", { name: "Domains" });
     const link = await within(domains).findByRole("link", { name: /eng/ });
     expect(link).toHaveAttribute("href", "/d/eng");
+    // Outside a domain there is nothing to switch between yet: the flat list
+    // is the whole sidebar, and it stays that way.
+    expect(screen.queryByRole("button", { name: /^Domain:/ })).toBeNull();
   });
 
   it("says what went wrong instead of emptying the sidebar", async () => {
@@ -164,5 +278,181 @@ describe("the layout", () => {
       }))
       .filter((call) => call.path === "/auth/me");
     expect(droppedAt).toBeLessThan(probes[probes.length - 1].order);
+  });
+});
+
+/**
+ * Inside a domain the sidebar stops being a list of everything and becomes the
+ * way around one thing: which domain you are in, and what is in it. A domain
+ * is a place you work in rather than an entry you picked once, so the way out
+ * and the way across stay on screen while you are in it.
+ */
+describe("the sidebar inside a domain", () => {
+  it("switches from the domain list to the domain's own navigation", async () => {
+    serveInDomain();
+
+    renderApp("/d/eng");
+
+    const nav = await screen.findByRole("navigation", { name: "Domain eng" });
+    // The switcher says where you are, and is the control that moves you.
+    expect(
+      await within(nav).findByRole("button", { name: "Domain: eng" }),
+    ).toBeVisible();
+    // The way back to everything stays on screen rather than being a browser
+    // button somebody has to remember.
+    expect(
+      within(nav).getByRole("link", { name: "All domains" }),
+    ).toHaveAttribute("href", "/");
+    // And below it, what this domain holds: its folders and its engrams.
+    expect(
+      await within(nav).findByRole("button", { name: "notes" }),
+    ).toHaveAttribute("aria-expanded", "false");
+    expect(within(nav).getByRole("link", { name: "Alpha" })).toHaveAttribute(
+      "href",
+      "/d/eng/e/alpha",
+    );
+    // The flat list is gone: two lists of domains at once would be two answers
+    // to the same question.
+    expect(within(nav).queryByRole("link", { name: /^ops/ })).toBeNull();
+  });
+
+  it("moves to another domain when the switcher picks one", async () => {
+    serveInDomain({
+      "/domains/ops/tree": () => ({
+        domain: "ops",
+        path: "/",
+        folders: [],
+        engrams: [],
+      }),
+      "/domains/ops/manifest": () => ({ domain: "ops", markdown: "" }),
+      "/domains/ops/engrams": () => ({
+        mode: "text",
+        total: 0,
+        page: 1,
+        limit: 50,
+        count: 0,
+        hits: [],
+      }),
+    });
+
+    renderApp("/d/eng");
+    const user = userEvent.setup();
+    await user.click(
+      await screen.findByRole("button", { name: "Domain: eng" }),
+    );
+
+    // Every domain is offered with what it holds, which is what makes the
+    // choice between them a choice rather than a guess.
+    const other = await screen.findByRole("menuitemradio", { name: /^ops/ });
+    expect(other).toHaveTextContent("2");
+    await user.click(other);
+
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "ops" }),
+    ).toBeVisible();
+    expect(
+      await screen.findByRole("button", { name: "Domain: ops" }),
+    ).toBeVisible();
+  });
+
+  it("asks for a folder only when it is opened", async () => {
+    serveInDomain();
+
+    renderApp("/d/eng");
+    // Scoped to the sidebar: the domain screen beside it browses by folder
+    // too, and this is about the tree in the frame.
+    const folder = await within(await sidebar()).findByRole("button", {
+      name: "notes",
+    });
+    // Nothing below the root was fetched: the tree is walked, not downloaded.
+    expect(requested().some((path) => path.includes("path=notes"))).toBe(false);
+
+    await userEvent.click(folder);
+
+    expect(
+      await within(await sidebar()).findByRole("link", { name: "Beta" }),
+    ).toHaveAttribute("href", "/d/eng/e/notes/beta");
+    expect(folder).toHaveAttribute("aria-expanded", "true");
+    await waitFor(() => {
+      expect(requested().some((path) => path.includes("path=notes"))).toBe(
+        true,
+      );
+    });
+  });
+
+  it("marks the engram being read, and opens the folder holding it", async () => {
+    serveInDomain();
+
+    renderApp("/d/eng/e/notes/beta");
+
+    const nav = await sidebar();
+    // The folder on the way to it is open, because a mark nobody can see is
+    // not a mark at all.
+    expect(
+      await within(nav).findByRole("button", { name: "notes" }),
+    ).toHaveAttribute("aria-expanded", "true");
+    const current = await within(nav).findByRole("link", { name: "Beta" });
+    expect(current).toHaveAttribute("aria-current", "page");
+    expect(
+      within(nav).getByRole("link", { name: "Alpha" }),
+    ).not.toHaveAttribute("aria-current");
+  });
+
+  it("opens the folder when the reader walks into it from the screen", async () => {
+    serveInDomain();
+
+    renderApp("/d/eng");
+    const nav = await sidebar();
+    const folder = await within(nav).findByRole("button", { name: "notes" });
+    expect(folder).toHaveAttribute("aria-expanded", "false");
+
+    // Into the folder the long way round, through the screen's own browse
+    // controls rather than the sidebar: the tree follows where the reader
+    // went, not only where they arrived.
+    const body = await screen.findByRole("main");
+    const user = userEvent.setup();
+    await user.click(within(body).getByRole("button", { name: "notes" }));
+    await user.click(await within(body).findByRole("link", { name: /Beta/ }));
+
+    await waitFor(() => {
+      expect(folder).toHaveAttribute("aria-expanded", "true");
+    });
+    expect(
+      await within(nav).findByRole("link", { name: "Beta" }),
+    ).toHaveAttribute("aria-current", "page");
+  });
+
+  it("fades a retired engram in the tree rather than dropping it", async () => {
+    serveInDomain();
+
+    renderApp("/d/eng");
+
+    const retired = await within(await sidebar()).findByRole("link", {
+      name: "Old Way",
+    });
+    expect(retired).toBeVisible();
+    expect(retired.className).toContain("opacity-60");
+  });
+
+  it("says why a folder is empty instead of showing an empty one", async () => {
+    serveInDomain({
+      "/domains/eng/tree": () => {
+        throw new ApiProblem(
+          403,
+          "forbidden",
+          "this account may not browse eng",
+        );
+      },
+    });
+
+    renderApp("/d/eng");
+
+    const alert = await within(await sidebar()).findByRole("alert");
+    expect(alert).toHaveTextContent("this account may not browse eng");
+    // The switcher survives the failure: one domain refusing to be browsed is
+    // not a reason to strand somebody in it.
+    expect(
+      within(await sidebar()).getByRole("button", { name: "Domain: eng" }),
+    ).toBeVisible();
   });
 });

--- a/fluid/src/components/Layout.test.tsx
+++ b/fluid/src/components/Layout.test.tsx
@@ -60,10 +60,9 @@ function twoDomainsResponse() {
 /**
  * The browse payload, answering with the folder that was asked for.
  *
- * The retired row carries a `status`, which the live browse payload does not
- * send today. The shared row reader takes one when a source has it, so this
- * pins the fade rule the sidebar applies rather than inventing a field: the
- * day the payload carries a status, the fade is already right.
+ * Every row carries a `status`, which is the shape the endpoint answers with:
+ * a browse row is what a tree is drawn from, so it says what state its engram
+ * is in as well as where it lives. That is what the fade below is reading.
  */
 function treeResponse(path: string) {
   if (path.includes("path=notes")) {
@@ -76,6 +75,7 @@ function treeResponse(path: string) {
           permalink: "notes/beta",
           title: "Beta",
           type: "engram",
+          status: "stable",
           path: "notes/beta.md",
         },
       ],
@@ -86,7 +86,13 @@ function treeResponse(path: string) {
     path: "/",
     folders: ["notes"],
     engrams: [
-      { permalink: "alpha", title: "Alpha", type: "engram", path: "alpha.md" },
+      {
+        permalink: "alpha",
+        title: "Alpha",
+        type: "engram",
+        status: "stable",
+        path: "alpha.md",
+      },
       {
         permalink: "old",
         title: "Old Way",

--- a/fluid/src/components/Layout.tsx
+++ b/fluid/src/components/Layout.tsx
@@ -2,9 +2,12 @@
  * The frame every screen inside the app is drawn in: which domains exist down
  * the side, and search, theme and identity across the top.
  *
- * The domain listing is the one thing this fetches. It is what the sidebar is,
- * and it is also the app's answer to "what does this instance know about",
- * which is the question a person arrives with.
+ * The domain listing is the one thing this fetches. It is what the sidebar is
+ * outside a domain, and it is also the app's answer to "what does this
+ * instance know about", which is the question a person arrives with. Inside a
+ * domain the question has changed - they are in one place and want their way
+ * around it - so the sidebar changes with it and hands over to `DomainNav`,
+ * which is the switcher and the folder tree.
  *
  * Down to tablet width the frame is unchanged. Narrower than that the sidebar
  * folds behind a disclosure rather than shrinking into a column too narrow to
@@ -14,7 +17,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 import { DropdownMenu } from "radix-ui";
-import { Link, NavLink, Outlet, useNavigate } from "react-router";
+import { Link, NavLink, Outlet, useMatch, useNavigate } from "react-router";
 
 import { problemDetail } from "../api/client";
 import { DOMAINS_QUERY_KEY, fetchDomains } from "../api/domains";
@@ -24,10 +27,8 @@ import { domainRoute, searchRoute } from "../paths";
 import { useTheme } from "../theme/context";
 import type { ThemePreference } from "../theme/context";
 import { CommandPalette } from "./CommandPalette";
-
-/** The classes every menu surface shares. */
-const MENU_CLASSES =
-  "z-50 min-w-48 rounded border border-slate-200 bg-white p-1 text-sm shadow-lg dark:border-slate-700 dark:bg-slate-900";
+import { DomainNav } from "./DomainNav";
+import { ITEM_CLASSES, MENU_CLASSES } from "./menu";
 
 /**
  * What the command palette's shortcut is called on this keyboard.
@@ -38,10 +39,6 @@ const MENU_CLASSES =
 const PALETTE_HINT = /Mac|iPhone|iPad/.test(navigator.userAgent)
   ? "⌘K"
   : "Ctrl K";
-
-/** The classes every menu row shares. */
-const ITEM_CLASSES =
-  "flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 outline-none select-none data-[highlighted]:bg-slate-100 dark:data-[highlighted]:bg-slate-800";
 
 export function Layout() {
   const [navOpen, setNavOpen] = useState(false);
@@ -265,41 +262,93 @@ function UserMenu() {
   );
 }
 
-/** The domain list, which is what this instance knows about. */
+/**
+ * The sidebar, in whichever of its two modes the address calls for.
+ *
+ * The route is read with `useMatch` rather than `useParams`, which inside a
+ * layout route only sees the params the layout's own pattern declares - none.
+ * `useMatch` matches the whole location, so the frame knows the domain and the
+ * engram the screen inside it is showing.
+ */
 function DomainSidebar({ open }: { open: boolean }) {
   const listing = useQuery({
     queryKey: DOMAINS_QUERY_KEY,
     queryFn: fetchDomains,
   });
 
+  const match = useMatch("/d/:domain/*");
+  const domain = match?.params.domain ?? "";
+  // The splat holds whatever follows the domain: `e/<permalink>` on an engram
+  // screen, the empty string on the domain's own.
+  const rest = match?.params["*"] ?? "";
+  const permalink = rest.startsWith("e/") ? rest.slice(2) : "";
+
   return (
     <nav
       id="domain-sidebar"
-      aria-label="Domains"
+      aria-label={domain === "" ? "Domains" : `Domain ${domain}`}
       className={`${open ? "block" : "hidden"} w-56 shrink-0 md:block`}
     >
+      {domain === "" ? (
+        <DomainList
+          domains={listing.data?.domains}
+          pending={listing.isPending}
+          error={listing.error}
+        />
+      ) : (
+        <>
+          {/*
+            A listing that failed is said here as it is in the flat mode. The
+            switcher is drawn either way: it names the domain the reader is in
+            from the address, so it works even when nothing could be listed to
+            switch to.
+          */}
+          {listing.error && <SidebarProblem error={listing.error} />}
+          <DomainNav
+            domain={domain}
+            permalink={permalink}
+            domains={listing.data?.domains ?? []}
+          />
+        </>
+      )}
+    </nav>
+  );
+}
+
+/** Every domain this instance holds: the sidebar outside any one of them. */
+function DomainList({
+  domains,
+  pending,
+  error,
+}: {
+  domains: DomainSummary[] | undefined;
+  pending: boolean;
+  error: Error | null;
+}) {
+  return (
+    <>
       <h2 className="px-2 pb-2 text-xs font-semibold tracking-wide text-slate-500 uppercase dark:text-slate-400">
         Domains
       </h2>
-      {listing.isPending && (
+      {pending && (
         <p className="px-2 text-sm text-slate-500 dark:text-slate-400">
           Loading domains
         </p>
       )}
-      {listing.error && <SidebarProblem error={listing.error} />}
+      {error && <SidebarProblem error={error} />}
       <ul className="flex flex-col gap-0.5">
-        {listing.data?.domains.map((domain) => (
+        {domains?.map((domain) => (
           <li key={domain.name}>
             <DomainLink domain={domain} />
           </li>
         ))}
       </ul>
-      {listing.data?.domains.length === 0 && (
+      {domains?.length === 0 && (
         <p className="px-2 text-sm text-slate-500 dark:text-slate-400">
           No domains are registered on this instance yet.
         </p>
       )}
-    </nav>
+    </>
   );
 }
 

--- a/fluid/src/components/menu.ts
+++ b/fluid/src/components/menu.ts
@@ -1,0 +1,15 @@
+/**
+ * The classes every dropdown in this app is drawn with.
+ *
+ * One definition rather than one per menu: the theme menu, the account menu
+ * and the domain switcher are the same control in three places, and a reader
+ * who has learned what one looks like should not have to learn the others.
+ */
+
+/** The surface a menu opens onto. */
+export const MENU_CLASSES =
+  "z-50 min-w-48 rounded border border-slate-200 bg-white p-1 text-sm shadow-lg dark:border-slate-700 dark:bg-slate-900";
+
+/** One row inside it. */
+export const ITEM_CLASSES =
+  "flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 outline-none select-none data-[highlighted]:bg-slate-100 dark:data-[highlighted]:bg-slate-800";

--- a/fluid/src/routes.test.tsx
+++ b/fluid/src/routes.test.tsx
@@ -14,7 +14,7 @@
  * same slashes the link did, encoded a segment at a time.
  */
 
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -80,11 +80,18 @@ function requested(): string[] {
   return apiMock.mock.calls.map((call) => call[0]);
 }
 
-/** Open the domain and click the row the list drew for its one engram. */
+/**
+ * Open the domain and click the row the list drew for its one engram.
+ *
+ * Scoped to the screen: inside a domain the frame's sidebar draws the same
+ * engram as a tree entry, so an unscoped query would be asking about two
+ * links at once.
+ */
 async function followRowIn(domain: string, permalink: string) {
   serveDomain(domain, permalink);
   renderApp(`/d/${encodeURIComponent(domain)}`);
-  const row = await screen.findByRole("link", { name: /Gamma/ });
+  const screenBody = await screen.findByRole("main");
+  const row = await within(screenBody).findByRole("link", { name: /Gamma/ });
   await userEvent.click(row);
   return row;
 }

--- a/fluid/src/screens/DomainHome.test.tsx
+++ b/fluid/src/screens/DomainHome.test.tsx
@@ -10,7 +10,7 @@
  * filters. The screen names which one is on screen instead of blending them.
  */
 
-import { screen, waitFor } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -113,6 +113,16 @@ function requested(): string[] {
   return apiMock.mock.calls.map((call) => call[0]);
 }
 
+/**
+ * The screen itself, without the frame around it.
+ *
+ * Inside a domain the sidebar draws the same folders and the same engrams as
+ * navigation, so a query for one of them has to say which of the two it means.
+ */
+async function screenBody(): Promise<HTMLElement> {
+  return screen.findByRole("main");
+}
+
 beforeEach(() => {
   apiMock.mockReset();
 });
@@ -129,7 +139,9 @@ describe("the domain screen", () => {
     expect(
       await screen.findByRole("heading", { name: "When to Use" }),
     ).toBeVisible();
-    const row = await screen.findByRole("link", { name: /Alpha/ });
+    const row = await within(await screenBody()).findByRole("link", {
+      name: /Alpha/,
+    });
     expect(row).toHaveAttribute("href", "/d/eng/e/alpha");
   });
 
@@ -193,21 +205,23 @@ describe("the domain screen", () => {
       screen.queryByRole("heading", { name: "Domain not found" }),
     ).toBeNull();
     // The engrams are still listed: the manifest is one panel, not the screen.
-    expect(await screen.findByRole("link", { name: /Alpha/ })).toBeVisible();
+    expect(
+      await within(await screenBody()).findByRole("link", { name: /Alpha/ }),
+    ).toBeVisible();
   });
 
   it("opens a folder into its own list", async () => {
     serve();
 
     renderApp("/d/eng");
-    await screen.findByRole("link", { name: /Alpha/ });
+    const body = await screenBody();
+    await within(body).findByRole("link", { name: /Alpha/ });
 
-    await userEvent.click(await screen.findByRole("button", { name: "notes" }));
+    await userEvent.click(within(body).getByRole("button", { name: "notes" }));
 
-    expect(await screen.findByRole("link", { name: /Beta/ })).toHaveAttribute(
-      "href",
-      "/d/eng/e/notes/beta",
-    );
+    expect(
+      await within(body).findByRole("link", { name: /Beta/ }),
+    ).toHaveAttribute("href", "/d/eng/e/notes/beta");
     await waitFor(() => {
       expect(requested().some((path) => path.includes("path=notes"))).toBe(
         true,
@@ -219,9 +233,10 @@ describe("the domain screen", () => {
     serve();
 
     renderApp("/d/eng");
-    await screen.findByRole("link", { name: /Alpha/ });
+    const body = await screenBody();
+    await within(body).findByRole("link", { name: /Alpha/ });
 
-    await userEvent.click(await screen.findByRole("button", { name: /#eng/ }));
+    await userEvent.click(within(body).getByRole("button", { name: /#eng/ }));
 
     // The frontmatter view answers, and it is the one that carries status.
     const row = await screen.findByRole("link", { name: /Gamma/ });

--- a/fluid/src/screens/EngramPage.test.tsx
+++ b/fluid/src/screens/EngramPage.test.tsx
@@ -143,6 +143,22 @@ function serve(routes: Record<string, (path: string) => unknown> = {}) {
     answersFor({
       "/auth/me": () => meResponse({ user: userFixture() }),
       "/domains": domainsResponse,
+      // The frame around this screen browses the domain it is in, so the tree
+      // is stubbed here the way the domain listing is: an unstubbed one would
+      // put a failed sidebar beside every assertion below.
+      "/domains/eng/tree": () => ({
+        domain: "eng",
+        path: "/",
+        folders: [],
+        engrams: [
+          {
+            permalink: "alpha",
+            title: "Alpha",
+            type: "decision",
+            path: "alpha.md",
+          },
+        ],
+      }),
       "/domains/eng/engrams/alpha": () => detailResponse(),
       "/graph": () => graphResponse(),
       ...routes,


### PR DESCRIPTION
Once a domain is open, the left sidebar switches from the flat domain list to a domain-scoped view: an All domains link, a labeled domain switcher with engram counts, and a lazily loaded collapsible tree of the domain's engrams (aria-expanded folders, aria-current on the open engram, retired rows faded, errors surfaced verbatim as problem details). Outside a domain the existing flat list is unchanged.

Server side, browse_domain rows now carry the status field (the descriptor already had it), so the retired fade works against the live API. OpenAPI snapshot, generated types, REST and MCP shape tests and the sidebar fixtures are swept to match.

Tests: Rust workspace 1690 passed plus doctests, clippy/fmt/style-lint clean; Fluid 189 vitest passed, typecheck/lint/build clean, generated types reproduce; real-daemon smoke 6/6 on the sidebar work.