### PR TITLE
fix: auth database multiprocess mode and /data volume ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,32 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 
 USER nonroot
 
+# Ship /data owned by the runtime user (65532:65532), so a fresh named volume
+# mounted there is writable from the first start.
+#
+# Docker copies the image's content *and* its ownership into a named volume
+# the first time that volume is used, but a volume mounted over a path the
+# image does not have is created root-owned instead - and this image runs as
+# uid 65532 with no way to chown anything, since distroless has no shell.
+# Without this the daemon cannot create its state directory under /data and
+# restart-loops until an operator chowns the volume by hand.
+#
+# The VOLUME line above is not enough on its own: it declares the mount point
+# and nothing more, and leaves no /data in the image filesystem (verified by
+# exporting the built image, before and after).
+#
+# WORKDIR is what creates the directory: it creates missing directories owned
+# by the current USER, which is why it sits after the USER line above rather
+# than beside the ENV block. The second WORKDIR puts the working directory
+# back to / - only the first one's side effect is wanted, not a container that
+# starts in /data.
+#
+# A *bind* mount cannot inherit any of this: the host directory keeps its own
+# ownership, so a bind-mounted state directory has to be writable by uid 65532
+# on the host (see docs/deployment.md#run-in-a-container).
+WORKDIR /data
+WORKDIR /
+
 ENTRYPOINT ["/usr/local/bin/crystalline"]
 CMD ["serve", "--http", "0.0.0.0:7411"]
 

--- a/crates/cli/tests/users.rs
+++ b/crates/cli/tests/users.rs
@@ -25,13 +25,27 @@ fn bin() -> Command {
 /// way; setting them on unix as well is harmless there and keeps this helper
 /// free of a `cfg`.
 fn isolate(cmd: &mut Command, home: &std::path::Path) {
-    cmd.env("HOME", home)
-        .env("XDG_CONFIG_HOME", home.join("config"))
-        .env("XDG_STATE_HOME", home.join("state"))
-        .env("XDG_CACHE_HOME", home.join("cache"))
-        .env("USERPROFILE", home)
-        .env("APPDATA", home.join("roaming"))
-        .env("LOCALAPPDATA", home.join("local"));
+    for (name, value) in isolation_env(home) {
+        cmd.env(name, value);
+    }
+}
+
+/// The variables [`isolate`] sets, as pairs, because one other place needs the
+/// same set and cannot go through [`isolate`]:
+/// `users_add_works_while_another_process_holds_the_auth_db` spawns its holder
+/// with a plain [`std::process::Command`], not an `assert_cmd` one. Both read
+/// this list, so a variable added here reaches both and the two cannot drift
+/// into resolving different `web-auth.db` files.
+fn isolation_env(home: &std::path::Path) -> [(&'static str, std::path::PathBuf); 7] {
+    [
+        ("HOME", home.to_path_buf()),
+        ("XDG_CONFIG_HOME", home.join("config")),
+        ("XDG_STATE_HOME", home.join("state")),
+        ("XDG_CACHE_HOME", home.join("cache")),
+        ("USERPROFILE", home.to_path_buf()),
+        ("APPDATA", home.join("roaming")),
+        ("LOCALAPPDATA", home.join("local")),
+    ]
 }
 
 /// Run `crystalline users ...` in the isolated home, feeding `stdin` when
@@ -220,4 +234,150 @@ fn a_password_is_required_and_a_non_terminal_run_must_pass_password_stdin() {
     // An empty password is refused too.
     let err = users_err(home.path(), &["add", "ada", "--password-stdin"], Some("\n"));
     assert!(err.contains("password"), "{err}");
+}
+
+/// Names the auth database this process must hold open, turning this test
+/// binary into the stand-in for a running daemon (see [`holds_the_auth_db`]).
+/// The value is the isolated home, from which the child derives every path.
+const HOLD_ENV: &str = "CRYSTALLINE_TEST_AUTH_HOLD";
+
+/// The child touches this file once its `AuthStore` is open, and exits once
+/// the parent creates [`STOP_FILE`] beside it.
+const READY_FILE: &str = "auth-hold-ready";
+const STOP_FILE: &str = "auth-hold-stop";
+
+/// The daemon stand-in, run as a child process by
+/// [`users_add_works_while_another_process_holds_the_auth_db`] and a no-op in
+/// an ordinary test run.
+///
+/// It has to be a real second process. Two `AuthStore`s in one process prove
+/// nothing about this: turso keeps a process-wide registry of open databases
+/// keyed by file identity, so the second open is handed the first one's
+/// `Database` and never touches the file lock that the CLI trips over. See
+/// `two_stores_on_one_file_interleave_writes` in `crystalline-service`, which
+/// is the same-process test and says so.
+#[test]
+fn holds_the_auth_db() {
+    let Ok(home) = std::env::var(HOLD_ENV) else {
+        return;
+    };
+    let home = std::path::PathBuf::from(home);
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    runtime.block_on(async {
+        let path = crystalline_core::config::web_auth_db_path().unwrap();
+        let store = crystalline_service::rest::AuthStore::open(&path)
+            .await
+            .expect("the holder must be able to open the auth database");
+        std::fs::write(home.join(READY_FILE), "").unwrap();
+
+        // Keep writing while the parent writes, the way a serving daemon
+        // issues sessions while an operator edits accounts. This is what puts
+        // the busy timeout to work across processes, which only has a chance
+        // of mattering once the open no longer locks the whole file.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        while !home.join(STOP_FILE).exists() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "the parent never came"
+            );
+            store
+                .create_session("ada", 3600)
+                .await
+                .expect("the daemon's own writes must not fail while the CLI writes");
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        // Still holding the same open store, the writes the other process made
+        // meanwhile are visible without reopening.
+        let names: Vec<String> = store
+            .list_users()
+            .await
+            .expect("listing must work after the other process wrote")
+            .into_iter()
+            .map(|u| u.name)
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "bob"),
+            "the holder sees the account the CLI added: {names:?}"
+        );
+    });
+}
+
+/// The bug this guards: while `serve` holds `web-auth.db` open, every
+/// `crystalline users` command used to fail at open time, because turso's
+/// default open takes a whole-file exclusive advisory lock for the life of the
+/// handle. Neither the busy timeout nor `BEGIN IMMEDIATE` could help, since
+/// both come after the open. `AuthStore` therefore opens with turso's
+/// multiprocess WAL, and this test is the only one that can tell the
+/// difference: it holds the database open in a second, real process.
+#[test]
+fn users_add_works_while_another_process_holds_the_auth_db() {
+    let home = tempfile::tempdir().unwrap();
+    // Create the database first, so the holder does not race the CLI over
+    // which process gets to create the file.
+    users_ok(
+        home.path(),
+        &["add", "ada", "--role", "admin", "--password-stdin"],
+        Some("s3cret\n"),
+    );
+
+    let mut command = std::process::Command::new(std::env::current_exe().unwrap());
+    command
+        .args(["holds_the_auth_db", "--exact", "--nocapture"])
+        .env(HOLD_ENV, home.path());
+    for (name, value) in isolation_env(home.path()) {
+        command.env(name, value);
+    }
+    let mut holder = Holder(command.spawn().unwrap());
+
+    let ready = home.path().join(READY_FILE);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    while !ready.exists() {
+        if let Some(status) = holder.0.try_wait().unwrap() {
+            panic!("the holder exited before it opened the database: {status}");
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the holder never opened the database"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    // The real thing: a second process writes while the first holds its handle.
+    users_ok(
+        home.path(),
+        &["add", "bob", "--password-stdin"],
+        Some("hunter2\n"),
+    );
+    let out = users_ok(home.path(), &["list"], None);
+    assert!(out.contains("bob"), "the write landed: {out}");
+
+    std::fs::write(home.path().join(STOP_FILE), "").unwrap();
+    let status = holder.0.wait().unwrap();
+    assert!(
+        status.success(),
+        "the holder's own assertions must have passed: {status}"
+    );
+}
+
+/// The spawned holder, killed when this goes out of scope.
+///
+/// Every path between the spawn and the orderly stop can panic - a failing
+/// `users_ok`, the readiness loop timing out, the `bob` assertion - and each
+/// one would otherwise leave the child running for its full 60 second timeout:
+/// holding the inherited stdout pipe, which nextest reports as a leak, and on
+/// Windows holding `web-auth.db` open, so the `TempDir` would fail to delete
+/// its own directory on the way out. Killing on unwind makes every failure
+/// path shut the holder down at once. On the success path the child has
+/// already exited through `STOP_FILE` by the time this runs, and both calls
+/// below are no-ops.
+struct Holder(std::process::Child);
+
+impl Drop for Holder {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
 }

--- a/crates/service/src/rest/auth_store.rs
+++ b/crates/service/src/rest/auth_store.rs
@@ -20,13 +20,20 @@
 //! Concurrency therefore has two independent layers, and both are needed:
 //!
 //! 1. *Across processes*, the CLI and the daemon each have their own
-//!    connection. `PRAGMA busy_timeout` is set on every connection so a writer
-//!    waits instead of failing, no transaction spans more than the two
-//!    statements of [`AuthStore::remove_user`], and the two multi-statement
-//!    operations ([`AuthStore::remove_user`] and [`AuthStore::create_session`])
-//!    take `BEGIN IMMEDIATE` so they serialize against each other rather than
+//!    connection. The file is opened with turso's experimental multiprocess
+//!    WAL, without which the daemon's open holds an exclusive lock on the
+//!    whole file and the CLI cannot open it at all (see [`open_database`],
+//!    which is where the interesting part of this lives). On top of that,
+//!    `PRAGMA busy_timeout` is set on every connection so a writer waits
+//!    instead of failing, no transaction spans more than the two statements of
+//!    [`AuthStore::remove_user`], and the two multi-statement operations
+//!    ([`AuthStore::remove_user`] and [`AuthStore::create_session`]) take
+//!    `BEGIN IMMEDIATE` so they serialize against each other rather than
 //!    interleaving. Covering test:
-//!    `two_stores_on_one_file_interleave_writes`.
+//!    `users_add_works_while_another_process_holds_the_auth_db` in the CLI's
+//!    `tests/users.rs`, which is the only one that spawns a second process.
+//!    `two_stores_on_one_file_interleave_writes` below covers the ordering
+//!    within one process and nothing about the locking.
 //! 2. *Within one process*, every method serializes on `AuthStore::guard`,
 //!    because turso's [`Connection`] refuses concurrent use outright rather
 //!    than queueing. The daemon shares one `AuthStore` across axum handlers, so
@@ -276,6 +283,95 @@ fn last_admin_error(verb: &str, name: &str) -> anyhow::Error {
     )
 }
 
+/// Open the database file itself, in the one mode that lets a second process
+/// open it at the same time.
+///
+/// turso's default open path takes a whole-file, process-scoped, *exclusive*
+/// advisory lock on the database file (`IO::lock_file`, non-blocking, no
+/// retry), so while `serve` holds this file open a second process cannot even
+/// get to a statement: `crystalline users add` fails at open time with a
+/// locking error, and neither the busy timeout nor `BEGIN IMMEDIATE` ever gets
+/// a say, because both act after the open. That is the whole bug this flag
+/// fixes.
+///
+/// `experimental_multiprocess_wal(true)` (turso 0.7.2) replaces that lock with
+/// a shared coordination file beside the database (`web-auth.db-tshm`): the
+/// open adds `OpenFlags::NoLock` instead of locking the file and writers
+/// coordinate through that mapping, so the busy timeout finally does the
+/// waiting it was always meant to do. The rest is read out of the turso 0.7.2
+/// and turso_core 0.7.2 sources (`Database::effective_open_flags_for_path`,
+/// `open_with_flags_async`) and, where noted, checked against a running
+/// daemon:
+///
+/// * The two modes are exclusive per file, but nothing enforces that on the
+///   path this takes. turso rejects a mixed open in both directions
+///   (`reject_live_multiprocess_wal_for_legacy_open` and
+///   `reject_live_legacy_wal_for_multiprocess_open`) only in the *synchronous*
+///   `Database::open_file_with_flags`; `open_with_flags_async`, which is what
+///   `Builder::build` reaches, applies the flags and skips both probes.
+///   Checked, not deduced: with a daemon built without this flag holding the
+///   file and a build carrying it running `users add`, the write goes through
+///   with no complaint, and so does the reverse pairing. This is the only path
+///   that opens `web-auth.db`, so one build never disagrees with itself, and
+///   an upgrade is the one thing that puts two builds on one file. **Restart
+///   the daemon after upgrading the binary, before editing accounts**: two
+///   builds that open this file differently would coordinate through different
+///   indexes (an in-process one against the `-tshm` mapping) on one WAL.
+///   Nothing here can detect that, which is why it is written down here and in
+///   `docs/deployment.md` instead. No shipped Crystalline has ever had a
+///   `web-auth.db`, though, so the only way to be on the wrong side of this is
+///   to run pre-release builds of both halves.
+/// * The flag is a no-op, keeping legacy behavior, where turso_core's
+///   `host_shared_wal` cfg is off, which is every 32-bit target. There the
+///   old failure mode remains.
+/// * It is refused outright, rather than ignored, on a memory-like path and
+///   on network filesystems (NFS, SMB/CIFS, AFS, Ceph, GFS2, Lustre, 9p and
+///   friends). This half *is* on the async path. A state directory on a
+///   network share is unusual but real, and failing to open at all would be a
+///   worse regression than the bug being fixed, so that one case falls back to
+///   a legacy open below.
+async fn open_database(path: &Path) -> Result<Database> {
+    let name = path.to_string_lossy().to_string();
+    let multiprocess = Builder::new_local(&name)
+        .experimental_multiprocess_wal(true)
+        .build()
+        .await;
+    let err = match multiprocess {
+        Ok(db) => return Ok(db),
+        Err(err) if is_multiprocess_unsupported(&err) => err,
+        Err(err) => {
+            return Err(anyhow::Error::new(err))
+                .with_context(|| format!("opening auth database {}", path.display()));
+        }
+    };
+    tracing::warn!(
+        error = %err,
+        path = %path.display(),
+        "this filesystem does not support cross-process access to the auth database; \
+         `crystalline users` will fail while the daemon is running"
+    );
+    Builder::new_local(&name)
+        .build()
+        .await
+        .with_context(|| format!("opening auth database {}", path.display()))
+}
+
+/// Whether this open failed because multiprocess WAL cannot be had here at
+/// all, as opposed to any other reason an open can fail.
+///
+/// Matched on the message because turso flattens `LimboError::InvalidArgument`
+/// into the catch-all `turso::Error::Error(String)` (see `turso_sdk_kit`'s
+/// `From<LimboError> for TursoError`), so the message is the only thing that
+/// survives. The three messages it has to catch all end in "is not supported
+/// ..." and all begin with the same prefix, which is what is matched. A
+/// locking error is deliberately *not* matched: that one means another process
+/// holds the file in the other mode, and retrying without the flag would only
+/// swap a clear message for a bare lock failure.
+fn is_multiprocess_unsupported(err: &turso::Error) -> bool {
+    err.to_string()
+        .contains("experimental multiprocess WAL is not supported")
+}
+
 impl AuthStore {
     /// Open (creating if absent) the auth database at `path`, applying the
     /// schema. The parent directory is created too, so a first run against a
@@ -287,10 +383,7 @@ impl AuthStore {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("creating {}", parent.display()))?;
         }
-        let db = Builder::new_local(&path.to_string_lossy())
-            .build()
-            .await
-            .with_context(|| format!("opening auth database {}", path.display()))?;
+        let db = open_database(path).await?;
         let conn = db.connect().context("connecting to the auth database")?;
         // The CLI and the daemon write the same file. Wait rather than fail;
         // every transaction here is a single short statement.
@@ -1272,12 +1365,21 @@ mod tests {
         assert_eq!(store.list_users().await.unwrap().len(), 1);
     }
 
-    /// The brief's central concurrency requirement: the `crystalline users`
-    /// CLI edits this file while the daemon serves from it. That is two
-    /// processes on one database, which is the case `crystalline_index`'s
-    /// turso store explicitly does not exercise (see this module's docs), so
-    /// it gets a test of its own. Two `AuthStore` instances stand in for the
-    /// two processes; each has its own `Database` and `Connection`.
+    /// Two `AuthStore` handles on one file see each other's writes as they
+    /// happen, in the order the `crystalline users` CLI and the daemon do it.
+    ///
+    /// **Same process only, and deliberately so.** These two handles are not
+    /// two processes and cannot stand in for them: turso keeps a process-wide
+    /// registry of open databases keyed by file identity
+    /// (`Database::lookup_in_registry`), so the second `open` here is handed
+    /// the first one's `Database` back and never opens the file a second time.
+    /// That makes this a test of statement ordering and visibility through one
+    /// engine, which is worth having, and no evidence at all about the file
+    /// locking between processes that [`open_database`] exists to solve. The
+    /// test that does spawn a second process is
+    /// `users_add_works_while_another_process_holds_the_auth_db` in the CLI's
+    /// `tests/users.rs`, and it is the one that fails if the multiprocess WAL
+    /// flag is dropped.
     #[tokio::test]
     async fn two_stores_on_one_file_interleave_writes() {
         let dir = tempfile::tempdir().unwrap();
@@ -1315,6 +1417,70 @@ mod tests {
         cli.remove_user("ada").await.unwrap();
         assert!(daemon.session_user(&second.token).await.unwrap().is_none());
         assert!(daemon.list_users().await.unwrap().is_empty());
+    }
+
+    /// The upgrade path: a `web-auth.db` written by a build that opened
+    /// without the multiprocess WAL flag must open, and keep its accounts,
+    /// under a build that opens with it.
+    ///
+    /// The two modes are exclusive only while a database is *live* in the
+    /// other mode (turso probes both directions on open). Nothing about the
+    /// file itself is mode-specific: the coordination file is a separate
+    /// `-tshm` sibling created on demand, so an existing state directory needs
+    /// no migration. This writes the file exactly as the previous build did,
+    /// closes it and reopens it the way [`open_database`] now does.
+    #[tokio::test]
+    async fn a_database_written_without_the_multiprocess_flag_still_opens() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("web-auth.db");
+        {
+            let legacy = Builder::new_local(&path.to_string_lossy())
+                .build()
+                .await
+                .unwrap();
+            let conn = legacy.connect().unwrap();
+            conn.execute_batch(SCHEMA).await.unwrap();
+            conn.execute(
+                "INSERT INTO users (name, display, email, role, pass_hash, disabled, created_at)
+                 VALUES ('ada', 'Ada', NULL, 'admin', 'x', 0, '2026-01-01T00:00:00Z')",
+                (),
+            )
+            .await
+            .unwrap();
+        }
+
+        let store = AuthStore::open(&path)
+            .await
+            .expect("an existing legacy-mode database must open in multiprocess mode");
+        let users = store.list_users().await.unwrap();
+        assert_eq!(users.len(), 1, "the accounts survived the mode change");
+        assert_eq!(users[0].name, "ada");
+        // The account is still editable, so the reopen is a real read-write
+        // open and not a degraded one.
+        store.set_role("ada", Role::Admin).await.unwrap();
+        assert!(
+            path.with_file_name("web-auth.db-tshm").exists(),
+            "multiprocess mode is what actually opened the file"
+        );
+    }
+
+    /// The fallback in [`open_database`] hinges on recognizing turso's own
+    /// "not supported" wording, which reaches us as a string rather than a
+    /// typed error. A memory-like path is the one way to provoke that message
+    /// without a network filesystem to hand, so it is what pins it: if a turso
+    /// upgrade rewords it, this fails here, rather than the fallback silently
+    /// going missing on the NFS or SMB state directory it exists for.
+    #[tokio::test]
+    async fn turso_still_words_an_unsupported_multiprocess_open_the_way_we_match() {
+        let err = Builder::new_local(":memory:")
+            .experimental_multiprocess_wal(true)
+            .build()
+            .await
+            .expect_err("multiprocess WAL cannot be had on an in-memory path");
+        assert!(
+            is_multiprocess_unsupported(&err),
+            "the fallback no longer recognizes turso's message: {err}"
+        );
     }
 
     /// Two simultaneous logins in the daemon are two concurrent

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -73,6 +73,8 @@ printf '%s' 'the-password' | docker compose -f deploy/fluid/docker-compose.yml \
   exec -T crystalline crystalline users add ada --role admin --password-stdin
 ```
 
+Restart the daemon after upgrading the binary, before editing accounts, so both sides open the accounts database the same way. A container upgrade recreates the container and has this covered already; a native install upgraded underneath a daemon that keeps running does not.
+
 `-T` because `--password-stdin` reads a pipe and compose would otherwise allocate a terminal there is nothing to read from. Everyone else is `--role viewer` or `--role editor`. Two other identity modes need no accounts at all: `CRYSTALLINE_AUTH_ANONYMOUS=true` serves an identityless request at viewer level, which together with `--read-only` is a published archive anyone who can reach it may browse, and `CRYSTALLINE_AUTH_TRUSTED_HEADER=remote-user` takes the already-authenticated user from a header an SSO proxy sets, creating that account at viewer role the first time it is seen. The trusted header is only safe when the proxy sets it itself and strips whatever a client sent, which means that proxy has to sit in front of Fluid rather than behind it: nginx forwards client headers untouched.
 
 Serve it over TLS anywhere but localhost. The session cookie is marked `Secure` for any browser `Host` that is not loopback, and for any request a proxy in front reports as `https`, so a browser on a plain `http://team.lan` is handed a cookie it refuses to store and signing in never sticks. Put a TLS terminator in front of the Fluid container and the same deployment works unchanged: Fluid passes an existing `X-Forwarded-Proto` through rather than overwriting it with its own hop.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -201,6 +201,15 @@ What persists where:
 - `./knowledge` (bind mount) holds the engrams of every file domain, one subfolder per domain - the durable state for file-backed knowledge, exactly the same markdown-plus-frontmatter files the native binary reads.
 - `crystalline-data` (named volume, mounted at `/data`) holds the search index and the embedding model cache. For file domains those two are fully rebuildable: losing them costs a `crystalline reindex --full` and a model re-download (skipped entirely on `with-model`, since its model lives outside `/data` and is never affected by the volume), never knowledge. Two things on this volume are not rebuildable, though. If you run virtual domains, their engrams are the source of truth and live here, so back this volume up or `crystalline domain export` them to the bind mount to keep a file copy. And `web-auth.db` holds the JSON API's accounts and sessions, which are data rather than derived state: losing it means creating every user again with `crystalline users add`.
 
+The image runs as the non-root user `65532:65532` and ships `/data` owned by it, so an empty named volume mounted there is writable from the first start: Docker copies the image directory's ownership into the volume when it initializes it. A bind mount never inherits that - the host directory keeps its own ownership - so a host folder mounted at `/data` instead of a named volume has to be made writable by that uid first, or the daemon cannot create its state directory and the container restarts in a loop:
+
+```sh
+mkdir -p ./crystalline-data
+sudo chown 65532:65532 ./crystalline-data
+```
+
+The same applies to the bind-mounted knowledge folder whenever the daemon writes into it (an agent's `write_engram`, or the generated `index.md` files), which includes the case where `docker run` creates a missing bind-mount source itself: Docker creates it root-owned. A knowledge folder mounted read-only, as in `compose.git-sync.yaml`, needs nothing.
+
 The `with-model` variant sets `CRYSTALLINE_MODELS_DIR` (also settable directly, on any install, to relocate the model cache anywhere else) to a path outside `/data` so the baked model is never shadowed by the `/data` volume mount. The bundled model is [BAAI/bge-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5), MIT licensed.
 
 Both variants ship a built-in Docker `HEALTHCHECK` that probes `GET /health` with no shell involved (the image is distroless), so `docker ps` reports health directly and a Compose service can gate on `condition: service_healthy`. External monitors (a Kubernetes `httpGet` probe, an uptime checker such as Gatus, a load balancer) can probe the same `/health` endpoint directly rather than going through Docker's own health state.

--- a/fluid/Dockerfile
+++ b/fluid/Dockerfile
@@ -27,10 +27,12 @@ WORKDIR /app
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN npm install --global corepack@0.35.0 && corepack enable pnpm
 
-# The manifest and the lockfile on their own first, so the install layer is
-# rebuilt only when the dependencies actually change and not on every edit to
-# a source file.
-COPY package.json pnpm-lock.yaml ./
+# The manifest, the lockfile and the workspace file (pnpm reads overrides
+# from it, and a frozen install fails if the lockfile records overrides the
+# visible config does not declare) on their own first, so the install layer
+# is rebuilt only when the dependencies actually change and not on every
+# edit to a source file.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 COPY . .


### PR DESCRIPTION
Two deployment bugs found by the first real compose run.

users add while the daemon runs: turso takes a whole-file exclusive lock at open time and the daemon holds its accounts-database handle for its entire life, so any second process failed at open before busy_timeout could matter. The store now opens with multiprocess WAL on the single shared path both the daemon and the CLI use, with a fallback to the old single-process open only where turso refuses the mode (network filesystems), pinned by a test provoking the real refusal error. A genuine cross-process test (spawned child process holding the store while the real binary writes) reproduces the original bug with the flag off and passes with it on, plus an end-to-end container verification. Existing databases need no migration; no released version carries the old mode.

/data volume ownership: the runtime image now ships /data owned by 65532:65532, so fresh named volumes inherit the ownership on first use and the daemon starts instead of restart-looping on a root-owned volume. Verified against real docker named-volume initialization. docs/deployment.md documents the chown requirement that remains for bind mounts.

Tests: full workspace suite 1694 passed, doctests, clippy, fmt, style-lint all green; new cross-process, upgrade-path and error-wording tests included.