### PR TITLE
chore: Windows test isolation sweep and fluid TS strictness flags

### DIFF
--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -3,7 +3,43 @@
 
 use std::path::{Path, PathBuf};
 
+use assert_cmd::Command;
+
 /// The repo-root `tests/fixtures` directory, shared across milestones.
 pub fn fixtures_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures")
+}
+
+/// The seven base-directory variables that redirect every child this crate
+/// can spawn into an isolated `home`, so its accounts, config, index and
+/// state never land in the developer's own directories.
+///
+/// Both families are needed, because base-directory resolution (via
+/// etcetera's `choose_base_strategy`) is a different strategy per platform:
+/// the XDG one on unix and macOS, which reads `HOME` and `XDG_*_HOME`, and
+/// the Windows one, which reads `USERPROFILE`, `APPDATA` and `LOCALAPPDATA`
+/// and ignores the XDG variables entirely. On Windows it also has no state
+/// directory of its own, so `state_dir` falls back to the data directory,
+/// `APPDATA`. Setting only the XDG variables would leave a Windows run
+/// resolving one real `%APPDATA%\crystalline` and colliding with every other
+/// test doing the same (Windows byte-range locks are mandatory). Setting the
+/// Windows names on unix as well is harmless there, so one array covers both
+/// platforms without a `cfg`.
+pub fn isolation_env(home: &Path) -> [(&'static str, PathBuf); 7] {
+    [
+        ("HOME", home.to_path_buf()),
+        ("XDG_CONFIG_HOME", home.join("config")),
+        ("XDG_STATE_HOME", home.join("state")),
+        ("XDG_CACHE_HOME", home.join("cache")),
+        ("USERPROFILE", home.to_path_buf()),
+        ("APPDATA", home.join("roaming")),
+        ("LOCALAPPDATA", home.join("local")),
+    ]
+}
+
+/// Apply [`isolation_env`] to a child `Command`.
+pub fn isolate(cmd: &mut Command, home: &Path) {
+    for (name, value) in isolation_env(home) {
+        cmd.env(name, value);
+    }
 }

--- a/crates/cli/tests/configure.rs
+++ b/crates/cli/tests/configure.rs
@@ -6,21 +6,19 @@
 
 use assert_cmd::Command;
 
+mod common;
+use common::isolate;
+
 fn bin() -> Command {
     Command::cargo_bin("crystalline").unwrap()
 }
 
-/// Redirect `HOME` and the XDG base directories into `home` so a child that
-/// reads the environment never reaches a real daemon socket or the developer's
-/// own config, and the default config path stays inside the tempdir. The
-/// environment-driven tests below combine this with a per-child `.env` for the
-/// `CRYSTALLINE_*` variable under test, never a process-global `set_var`.
-fn isolate(cmd: &mut Command, home: &std::path::Path) {
-    cmd.env("HOME", home)
-        .env("XDG_CONFIG_HOME", home.join("config"))
-        .env("XDG_STATE_HOME", home.join("state"))
-        .env("XDG_CACHE_HOME", home.join("cache"));
-}
+// `isolate` (from `common`) redirects every base directory a child can
+// resolve into `home`, so a child that reads the environment never reaches a
+// real daemon socket or the developer's own config, and the default config
+// path stays inside the tempdir. The environment-driven tests below combine
+// this with a per-child `.env` for the `CRYSTALLINE_*` variable under test,
+// never a process-global `set_var`.
 
 #[test]
 fn config_show_set_unset_round_trip_against_a_temp_config() {

--- a/crates/cli/tests/doctor.rs
+++ b/crates/cli/tests/doctor.rs
@@ -6,6 +6,8 @@
 //! directory, so that scenario isolates `HOME`/`XDG_*` the same way the
 //! service integration tests do.
 
+mod common;
+
 use std::path::{Path, PathBuf};
 
 use assert_cmd::Command;
@@ -35,25 +37,24 @@ fn engram(title: &str, permalink: &str) -> String {
     )
 }
 
+/// Point a doctor invocation's `HOME`/`XDG_*`/Windows base-directory
+/// variables at a fresh scratch directory so its exit-code assertions never
+/// couple to the developer's real machine-wide state (harness configs under
+/// `~/.claude` and `~/.codex`, service lock and socket). Returns the
+/// directory as a guard: keep it bound in the caller for the duration of the
+/// `Command` call, since dropping it removes the directory.
+fn shield_ambient_home(cmd: &mut Command) -> tempfile::TempDir {
+    let home = tempfile::tempdir().unwrap();
+    for (name, value) in common::isolation_env(home.path()) {
+        cmd.env(name, value);
+    }
+    home
+}
+
 /// Scaffold and register a fresh domain, returning its root path. `domain add`
 /// now indexes on registration, so it needs the same `--db` the test's own
 /// later sync/doctor calls use (`work/index.db`), rather than the machine's
 /// default state directory.
-/// Point a doctor invocation's `HOME`/`XDG_*` at a scratch directory so its
-/// exit-code assertions never couple to the developer's real machine-wide
-/// state (harness configs under `~/.claude` and `~/.codex`, service lock and
-/// socket). A no-op on Windows, where the base-directory strategy does not
-/// honor these variables; Windows CI runs on a fresh profile, so the ambient
-/// state is empty there anyway.
-#[allow(unused_variables)]
-fn shield_ambient_home(cmd: &mut Command, tag: &str) {
-    #[cfg(unix)]
-    {
-        let (home, _state) = isolated_home(tag);
-        apply_home(cmd, &home);
-    }
-}
-
 fn setup_domain(work: &Path, name: &str, config: &Path) -> PathBuf {
     let domain_dir = work.join(format!("kb-{name}"));
     bin()
@@ -91,7 +92,7 @@ fn reports_clean_when_nothing_is_wrong() {
         .success();
 
     let mut cmd = bin();
-    shield_ambient_home(&mut cmd, "clean-run");
+    let _home = shield_ambient_home(&mut cmd);
     let out = cmd
         .args(["--json", "doctor", "--config"])
         .arg(&config)
@@ -138,7 +139,7 @@ fn reports_near_duplicate_tag_clusters_without_failing() {
         .success();
 
     let mut cmd = bin();
-    shield_ambient_home(&mut cmd, "tag-clusters");
+    let _home = shield_ambient_home(&mut cmd);
     let out = cmd
         .args(["--json", "doctor", "--config"])
         .arg(&config)
@@ -202,7 +203,7 @@ fn detects_orphan_and_fix_removes_it() {
 
     // --fix removes the orphan row and the report shows zero problems.
     let mut fixed_cmd = bin();
-    shield_ambient_home(&mut fixed_cmd, "orphan-fix");
+    let _home = shield_ambient_home(&mut fixed_cmd);
     let fixed_out = fixed_cmd
         .args(["--json", "doctor", "--fix", "--config"])
         .arg(&config)
@@ -218,7 +219,7 @@ fn detects_orphan_and_fix_removes_it() {
 
     // A clean re-run confirms the row is really gone.
     let mut clean_cmd = bin();
-    shield_ambient_home(&mut clean_cmd, "orphan-clean");
+    let _home = shield_ambient_home(&mut clean_cmd);
     let clean = clean_cmd
         .args(["--json", "doctor", "--config"])
         .arg(&config)
@@ -329,7 +330,7 @@ fn domain_filter_restricts_checks_to_one_domain() {
     setup_domain(work.path(), "product", &config);
 
     let mut cmd = bin();
-    shield_ambient_home(&mut cmd, "domain-filter");
+    let _home = shield_ambient_home(&mut cmd);
     let out = cmd
         .args(["--json", "doctor", "--domain", "eng", "--config"])
         .arg(&config)

--- a/crates/cli/tests/env_domains.rs
+++ b/crates/cli/tests/env_domains.rs
@@ -8,18 +8,16 @@ use std::path::Path;
 
 use assert_cmd::Command;
 
+mod common;
+use common::isolate;
+
 fn bin() -> Command {
     Command::cargo_bin("crystalline").unwrap()
 }
 
-/// Redirect `HOME` and the XDG base directories into `home` so a child never
-/// reaches a real daemon socket, the developer's own config or a real index.
-fn isolate(cmd: &mut Command, home: &Path) {
-    cmd.env("HOME", home)
-        .env("XDG_CONFIG_HOME", home.join("config"))
-        .env("XDG_STATE_HOME", home.join("state"))
-        .env("XDG_CACHE_HOME", home.join("cache"));
-}
+// `isolate` (from `common`) redirects every base directory a child can
+// resolve into `home`, so a child never reaches a real daemon socket, the
+// developer's own config or a real index.
 
 /// A minimal domain directory with a MANIFEST.md so the routing prompt has
 /// something to read.

--- a/crates/cli/tests/env_token.rs
+++ b/crates/cli/tests/env_token.rs
@@ -4,23 +4,18 @@
 //! the variable per-child with `assert_cmd`'s `.env`, never a process-global
 //! `set_var`, and points every path at a tempdir.
 
-use std::path::Path;
-
 use assert_cmd::Command;
+
+mod common;
+use common::isolate;
 
 fn bin() -> Command {
     Command::cargo_bin("crystalline").unwrap()
 }
 
-/// Redirect `HOME` and the XDG base directories into `home` so a child never
-/// reaches a real daemon socket, the developer's own config or a real
-/// credential store.
-fn isolate(cmd: &mut Command, home: &Path) {
-    cmd.env("HOME", home)
-        .env("XDG_CONFIG_HOME", home.join("config"))
-        .env("XDG_STATE_HOME", home.join("state"))
-        .env("XDG_CACHE_HOME", home.join("cache"));
-}
+// `isolate` (from `common`) redirects every base directory a child can
+// resolve into `home`, so a child never reaches a real daemon socket, the
+// developer's own config or a real credential store.
 
 #[test]
 fn connect_github_refuses_when_the_environment_owns_the_token() {

--- a/crates/cli/tests/users.rs
+++ b/crates/cli/tests/users.rs
@@ -5,48 +5,21 @@
 
 use assert_cmd::Command;
 
+mod common;
+use common::{isolate, isolation_env};
+
 fn bin() -> Command {
     Command::cargo_bin("crystalline").unwrap()
 }
 
-/// Redirect every base directory this child can resolve into `home`, so the
-/// auth database at `<state_dir>/web-auth.db` is this test's alone.
-///
-/// Both families are needed, because `state_dir` goes through etcetera's
-/// `choose_base_strategy`, which is a different strategy per platform: the XDG
-/// one on unix and macOS, which reads `HOME` and `XDG_*_HOME`, and the Windows
-/// one, which reads `USERPROFILE`, `APPDATA` and `LOCALAPPDATA` and ignores
-/// the XDG variables entirely. On Windows it also has no state directory of
-/// its own, so `state_dir` falls back to the data directory, `APPDATA`.
-/// Setting only the XDG variables would leave every test in this file
-/// resolving one real `%APPDATA%\crystalline\web-auth.db` and locking each
-/// other out of it (Windows byte-range locks are mandatory). The Windows names
-/// and layout mirror `service_windows.rs`, which isolates the daemon the same
-/// way; setting them on unix as well is harmless there and keeps this helper
-/// free of a `cfg`.
-fn isolate(cmd: &mut Command, home: &std::path::Path) {
-    for (name, value) in isolation_env(home) {
-        cmd.env(name, value);
-    }
-}
-
-/// The variables [`isolate`] sets, as pairs, because one other place needs the
-/// same set and cannot go through [`isolate`]:
-/// `users_add_works_while_another_process_holds_the_auth_db` spawns its holder
-/// with a plain [`std::process::Command`], not an `assert_cmd` one. Both read
-/// this list, so a variable added here reaches both and the two cannot drift
-/// into resolving different `web-auth.db` files.
-fn isolation_env(home: &std::path::Path) -> [(&'static str, std::path::PathBuf); 7] {
-    [
-        ("HOME", home.to_path_buf()),
-        ("XDG_CONFIG_HOME", home.join("config")),
-        ("XDG_STATE_HOME", home.join("state")),
-        ("XDG_CACHE_HOME", home.join("cache")),
-        ("USERPROFILE", home.to_path_buf()),
-        ("APPDATA", home.join("roaming")),
-        ("LOCALAPPDATA", home.join("local")),
-    ]
-}
+// `isolate` and `isolation_env` (both from `common`) redirect every base
+// directory this child can resolve into `home`, so the auth database at
+// `<state_dir>/web-auth.db` is this test's alone. `isolation_env` is used
+// directly (not through `isolate`) by
+// `users_add_works_while_another_process_holds_the_auth_db`, which spawns its
+// holder with a plain `std::process::Command`, not an `assert_cmd` one - both
+// read the same list, so a variable added there reaches both and the two
+// cannot drift into resolving different `web-auth.db` files.
 
 /// Run `crystalline users ...` in the isolated home, feeding `stdin` when
 /// given, and return stdout on success.

--- a/fluid/src/api/domain.test.ts
+++ b/fluid/src/api/domain.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, it } from "vitest";
 
 import { readTree } from "./domain";
+import { defined } from "../test/assert";
 
 /** One folder of a domain, in the shape the endpoint answers with. */
 function browsePayload() {
@@ -49,8 +50,9 @@ describe("a browse payload", () => {
     ]);
     // The domain of the request rides along, because a tree row names only
     // itself and a link out of one needs both halves of the address.
-    expect(tree.engrams[0].domain).toBe("eng");
-    expect(tree.engrams[0].type).toBe("engram");
+    const alpha = defined(tree.engrams[0], "the first row");
+    expect(alpha.domain).toBe("eng");
+    expect(alpha.type).toBe("engram");
   });
 
   it("leaves the status null when a row does not say", () => {
@@ -63,7 +65,8 @@ describe("a browse payload", () => {
     // Null rather than a plausible default: a row claiming a state nobody
     // wrote would be a lie a reader cannot see through, and it would fade or
     // fail to fade on that lie.
-    expect(tree.engrams[0].status).toBeNull();
-    expect(tree.engrams[0].title).toBe("a");
+    const row = defined(tree.engrams[0], "the first row");
+    expect(row.status).toBeNull();
+    expect(row.title).toBe("a");
   });
 });

--- a/fluid/src/api/graph.test.ts
+++ b/fluid/src/api/graph.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, expect, it } from "vitest";
 
+import { defined } from "../test/assert";
 import {
   NEIGHBORHOOD_DEPTH,
   backlinksTo,
@@ -68,7 +69,10 @@ describe("backlinks", () => {
   it("groups one source's several relation types into one entry", () => {
     const [beta] = backlinksTo(neighborhood(), "eng", "alpha");
 
-    expect(beta.relTypes).toEqual(["links_to", "supersedes"]);
+    expect(defined(beta, "the grouped backlink").relTypes).toEqual([
+      "links_to",
+      "supersedes",
+    ]);
   });
 
   it("never counts an engram as pointing at itself", () => {

--- a/fluid/src/components/CommandPalette.tsx
+++ b/fluid/src/components/CommandPalette.tsx
@@ -197,11 +197,13 @@ export function CommandPalette() {
   // The top row, in the order they are drawn in. Enter follows the highlight,
   // and the highlight is the top row until somebody moves it off: an answer
   // landing above a highlighted row takes the highlight with it.
+  const firstDomain = domains[0];
+  const firstHit = hits[0];
   const top =
-    domains.length > 0
-      ? domainValue(domains[0].name)
-      : hits.length > 0
-        ? engramValue(hits[0])
+    firstDomain !== undefined
+      ? domainValue(firstDomain.name)
+      : firstHit !== undefined
+        ? engramValue(firstHit)
         : typed === ""
           ? ""
           : searchValue(typed);

--- a/fluid/src/components/EngramList.tsx
+++ b/fluid/src/components/EngramList.tsx
@@ -79,7 +79,7 @@ export function EngramList({
     () => data?.pages.flatMap((page) => page.hits) ?? [],
     [data],
   );
-  const total = data?.pages[data.pages.length - 1].total ?? rows.length;
+  const total = data?.pages[data.pages.length - 1]?.total ?? rows.length;
 
   // The virtualizer hands back functions rather than values, which the React
   // Compiler cannot memoize, so it would skip this component. That is the
@@ -147,14 +147,22 @@ export function EngramList({
           className="relative w-full"
           style={{ height: `${String(virtualizer.getTotalSize())}px` }}
         >
-          {drawn.map((item) => (
-            <Row
-              key={`${rows[item.index].domain}/${rows[item.index].permalink}`}
-              row={rows[item.index]}
-              offset={item.start}
-              highlight={highlight}
-            />
-          ))}
+          {drawn.map((item) => {
+            const row = rows[item.index];
+            // The virtualizer only ever hands back indices within `rows`;
+            // this guards the type honestly rather than trusting that.
+            if (!row) {
+              return null;
+            }
+            return (
+              <Row
+                key={`${row.domain}/${row.permalink}`}
+                row={row}
+                offset={item.start}
+                highlight={highlight}
+              />
+            );
+          })}
         </ul>
       </div>
       {isFetchingNextPage && (
@@ -209,7 +217,7 @@ function Row({
         <span className="flex items-center gap-1.5 overflow-hidden text-xs whitespace-nowrap">
           {row.type !== null && <Badge>{row.type}</Badge>}
           {row.status !== null && (
-            <Badge title={retired ? "A retired status" : undefined}>
+            <Badge {...(retired ? { title: "A retired status" } : {})}>
               {row.status}
             </Badge>
           )}

--- a/fluid/src/components/Layout.test.tsx
+++ b/fluid/src/components/Layout.test.tsx
@@ -9,6 +9,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ApiProblem, api, setCsrfToken } from "../api/client";
+import { defined } from "../test/assert";
 import {
   answersFor,
   domainsResponse,
@@ -280,10 +281,14 @@ describe("the layout", () => {
     const probes = apiMock.mock.calls
       .map((call, index) => ({
         path: call[0],
-        order: apiMock.mock.invocationCallOrder[index],
+        order: defined(
+          apiMock.mock.invocationCallOrder[index],
+          "the call's invocation order",
+        ),
       }))
       .filter((call) => call.path === "/auth/me");
-    expect(droppedAt).toBeLessThan(probes[probes.length - 1].order);
+    const lastProbe = defined(probes[probes.length - 1], "the last probe");
+    expect(droppedAt).toBeLessThan(lastProbe.order);
   });
 });
 

--- a/fluid/src/components/Markdown.test.tsx
+++ b/fluid/src/components/Markdown.test.tsx
@@ -32,7 +32,7 @@ async function renderMarkdown(source: string, wikilinks?: WikilinkResolver) {
   const result = render(
     <MemoryRouter>
       <ThemeProvider>
-        <Markdown source={source} wikilinks={wikilinks} />
+        <Markdown source={source} {...(wikilinks ? { wikilinks } : {})} />
       </ThemeProvider>
     </MemoryRouter>,
   );

--- a/fluid/src/components/Markdown.tsx
+++ b/fluid/src/components/Markdown.tsx
@@ -42,7 +42,7 @@ export function Markdown({ source, wikilinks }: MarkdownProps) {
         </p>
       }
     >
-      <MarkdownBody source={source} wikilinks={wikilinks} />
+      <MarkdownBody source={source} {...(wikilinks ? { wikilinks } : {})} />
     </Suspense>
   );
 }

--- a/fluid/src/components/MarkdownBody.tsx
+++ b/fluid/src/components/MarkdownBody.tsx
@@ -149,7 +149,13 @@ function split(text: string, resolve: WikilinkResolver): HastNode[] {
   const parts: HastNode[] = [];
   let taken = 0;
   for (const match of text.matchAll(WIKILINK)) {
-    const resolution = resolve(match[1]);
+    // WIKILINK's one capture group is not optional, so it is always present
+    // in a match; this only documents that guarantee to the checker.
+    const target = match[1];
+    if (target === undefined) {
+      continue;
+    }
+    const resolution = resolve(target);
     // Bracket text carries no parsed reference of its own, so the payload has
     // nothing to say about it here.
     const state = referenceState(resolution, null);

--- a/fluid/src/components/NeighborhoodGraph.test.tsx
+++ b/fluid/src/components/NeighborhoodGraph.test.tsx
@@ -20,6 +20,7 @@ import { ApiProblem, api } from "../api/client";
 import type { GraphElement, GraphNodeData } from "../graphElements";
 import { isEdgeElement } from "../graphElements";
 import { RETIRED_CLASS } from "../lifecycle";
+import { defined } from "../test/assert";
 import { NeighborhoodGraph } from "./NeighborhoodGraph";
 
 vi.mock("../api/client", async (importOriginal) => {
@@ -159,7 +160,10 @@ describe("the neighborhood graph", () => {
     const list = await screen.findByRole("list", {
       name: /connections in this neighborhood/i,
     });
-    const [connection] = within(list).getAllByRole("listitem");
+    const connection = defined(
+      within(list).getAllByRole("listitem")[0],
+      "the sole connection row",
+    );
     expect(connection).toHaveTextContent("links_to");
     expect(
       within(connection).getByRole("link", { name: /Beta/ }),

--- a/fluid/src/graphElements.test.ts
+++ b/fluid/src/graphElements.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, it } from "vitest";
 
 import { readGraph } from "./api/graph";
+import { defined } from "./test/assert";
 import type { GraphElement, GraphNodeElement } from "./graphElements";
 import {
   ANCHOR_CLASS,
@@ -101,7 +102,7 @@ describe("the graph elements", () => {
       ANCHOR,
     );
 
-    expect(edges(elements)[0].data.label).toBe("");
+    expect(defined(edges(elements)[0], "the sole edge").data.label).toBe("");
   });
 
   it("fades a retired engram and never leaves it out", () => {
@@ -109,23 +110,23 @@ describe("the graph elements", () => {
     const [alpha, beta, gamma] = nodes(elements);
 
     // Retired is part of what the domain holds: it is drawn, and drawn faded.
-    expect(beta.classes).toContain(FADED_CLASS);
-    expect(alpha.classes).not.toContain(FADED_CLASS);
-    expect(gamma.classes).not.toContain(FADED_CLASS);
+    expect(defined(beta, "beta").classes).toContain(FADED_CLASS);
+    expect(defined(alpha, "alpha").classes).not.toContain(FADED_CLASS);
+    expect(defined(gamma, "gamma").classes).not.toContain(FADED_CLASS);
   });
 
   it("marks the engram the neighborhood was drawn around", () => {
     const elements = graphElements(neighborhood(), ANCHOR);
     const [alpha, beta] = nodes(elements);
 
-    expect(alpha.classes).toContain(ANCHOR_CLASS);
-    expect(beta.classes).not.toContain(ANCHOR_CLASS);
+    expect(defined(alpha, "alpha").classes).toContain(ANCHOR_CLASS);
+    expect(defined(beta, "beta").classes).not.toContain(ANCHOR_CLASS);
   });
 
   it("carries each engram's address, which is what a click needs", () => {
     const elements = graphElements(neighborhood(), ANCHOR);
 
-    expect(nodes(elements)[2].data).toMatchObject({
+    expect(defined(nodes(elements)[2], "the third node").data).toMatchObject({
       domain: "ops",
       permalink: "gamma",
     });
@@ -145,7 +146,9 @@ describe("the graph elements", () => {
     );
 
     expect(edges(elements)).toHaveLength(1);
-    expect(edges(elements)[0].data.label).toBe("supersedes");
+    expect(defined(edges(elements)[0], "the surviving edge").data.label).toBe(
+      "supersedes",
+    );
   });
 
   it("draws one element per id however often the payload repeats it", () => {
@@ -194,7 +197,7 @@ describe("the graph connections", () => {
 
     // The status is what fades a retired end, and the address is what the
     // link points at: both come from the node rather than from the edge.
-    expect(first.to).toMatchObject({
+    expect(defined(first, "the sole connection").to).toMatchObject({
       domain: "eng",
       permalink: "notes/beta",
       status: "deprecated",
@@ -209,8 +212,9 @@ describe("the graph connections", () => {
     );
 
     expect(connections).toHaveLength(1);
-    expect(connections[0].from.title).toBe("Beta");
-    expect(connections[0].to.title).toBe("Gamma");
+    const connection = defined(connections[0], "the sole connection");
+    expect(connection.from.title).toBe("Beta");
+    expect(connection.to.title).toBe("Gamma");
   });
 
   it("agrees with the picture about which arrows there are", () => {
@@ -234,6 +238,6 @@ describe("the graph connections", () => {
       neighborhood({ edges: [{ from: 1, to: 2 }] }),
     );
 
-    expect(connections[0].relType).toBeNull();
+    expect(defined(connections[0], "the sole connection").relType).toBeNull();
   });
 });

--- a/fluid/src/screens/Search.tsx
+++ b/fluid/src/screens/Search.tsx
@@ -132,7 +132,8 @@ export default function Search() {
   // that domain's when exactly one is filtered on, and the instance's
   // otherwise. Either way the chips are the real set for what is being
   // searched rather than a guess assembled from a page of results.
-  const scope = request.domains.length === 1 ? request.domains[0] : null;
+  const scope =
+    request.domains.length === 1 ? (request.domains[0] ?? null) : null;
   const tags = useQuery({
     queryKey: vocabularyKey(scope),
     queryFn: () => fetchTags(scope),

--- a/fluid/src/test/assert.ts
+++ b/fluid/src/test/assert.ts
@@ -1,0 +1,13 @@
+/**
+ * A narrowing guard for pulling a value out of a fixture array or object a
+ * test built itself and knows is present, under `noUncheckedIndexedAccess`.
+ * Throwing with a clear message keeps this honest: unlike a non-null
+ * assertion, a fixture that regresses to actually being empty fails the test
+ * with a message pointing at the cause, not a silent type lie.
+ */
+export function defined<T>(value: T | undefined, what = "value"): T {
+  if (value === undefined) {
+    throw new Error(`expected ${what} to be defined`);
+  }
+  return value;
+}

--- a/fluid/src/test/harness.tsx
+++ b/fluid/src/test/harness.tsx
@@ -32,7 +32,10 @@ export function answersFor(routes: Record<string, Answer>) {
   // Async, so an answer that throws an `ApiProblem` rejects the call exactly
   // as the real client would, without the test having to build a promise.
   return async (path: string, init?: RequestInit): Promise<never> => {
-    const route = path.split("?")[0];
+    // `split` on a non-empty separator always yields at least one element;
+    // the fallback to `path` itself only documents that guarantee to the
+    // checker, it never actually triggers.
+    const [route = path] = path.split("?");
     const answer = routes[route];
     if (!answer) {
       throw new ApiProblem(404, "not found", `no stub for ${route}`);

--- a/fluid/tsconfig.app.json
+++ b/fluid/tsconfig.app.json
@@ -24,7 +24,9 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
   },
   "include": ["src"]
 }

--- a/fluid/tsconfig.e2e.json
+++ b/fluid/tsconfig.e2e.json
@@ -22,7 +22,9 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
   },
   "include": ["playwright.config.ts", "e2e"]
 }

--- a/fluid/tsconfig.node.json
+++ b/fluid/tsconfig.node.json
@@ -19,7 +19,9 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
Two hygiene items gating the upcoming editor work.

Windows test isolation: the configure, doctor, env_domains and env_token CLI suites now apply the full seven-variable env isolation (XDG plus USERPROFILE/APPDATA/LOCALAPPDATA) via a shared common module extracted from the users suite, so parallel test processes on Windows stop sharing the real user dirs. No existing isolation weakened.

Fluid strictness: noUncheckedIndexedAccess and exactOptionalPropertyTypes enabled across all three tsconfig projects (app/node/e2e stay in lockstep as their comments document), with fallout fixed by real narrowing, defaults and conditional spreads - no non-null assertions, no masking casts.

Tests: Rust workspace 1694 passed plus doctests, clippy/fmt/style-lint clean; fluid 189 vitest passed, typecheck/lint/build/api-drift clean.